### PR TITLE
Exit application method can be replaced by 'ui_app_exit'

### DIFF
--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -63,6 +63,7 @@ source_set("flutter_tizen") {
 
   include_dirs = [
     "//third_party/tizen_tools/sysroot/$target_cpu/usr/include",
+    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/appfw",
     "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/base",
     "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/dlog",
     "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/ecore-1",
@@ -89,6 +90,7 @@ source_set("flutter_tizen") {
 
   libs = [
     "base-utils-i18n",
+    "capi-appfw-application",
     "capi-system-info",
     "capi-system-system-settings",
     "dlog",

--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <app.h>
 #include "platform_channel.h"
 
 #include "flutter/shell/platform/common/cpp/json_method_codec.h"
@@ -28,7 +29,7 @@ void PlatformChannel::HandleMethodCall(
   const auto method = call.method_name();
 
   if (method == "SystemNavigator.pop") {
-    exit(EXIT_SUCCESS);
+    ui_app_exit();
     result->Success();
   } else if (method == "SystemSound.play") {
     result->NotImplemented();

--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <app.h>
 #include "platform_channel.h"
+
+#include <app.h>
 
 #include "flutter/shell/platform/common/cpp/json_method_codec.h"
 #include "flutter/shell/platform/tizen/logger.h"


### PR DESCRIPTION
The function 'exit(EXIT_SUCCESS)' terminaters the calling process
immediately. The better way to exit process is on the main thread,
app can save current status before exit app. if call 'ui_app_exit'
will call terminate callback on main thread, app can save current
status on terminate callback before exit app.