### PR TITLE
Resize egl window when software keyboard is shown

### DIFF
--- a/shell/platform/tizen/tizen_embedder_engine.h
+++ b/shell/platform/tizen/tizen_embedder_engine.h
@@ -76,6 +76,7 @@ class TizenEmbedderEngine {
   void SetPluginRegistrarDestructionCallback(
       FlutterDesktopOnPluginRegistrarDestroyed callback);
 
+  void SendWindowMetrics(int32_t width, int32_t height, double pixel_ratio);
   void SetWindowOrientation(int32_t degree);
   void SendLocales();
   void AppIsInactive();
@@ -105,6 +106,9 @@ class TizenEmbedderEngine {
   std::unique_ptr<TextInputChannel> text_input_channel;
   std::unique_ptr<PlatformViewChannel> platform_view_channel;
 
+  const std::string device_profile;
+  const double device_dpi;
+
  private:
   static bool MakeContextCurrent(void* user_data);
   static bool ClearContext(void* user_data);
@@ -117,7 +121,6 @@ class TizenEmbedderEngine {
       const FlutterPlatformMessage* engine_message, void* user_data);
   static void OnVsyncCallback(void* user_data, intptr_t baton);
 
-  void SendWindowMetrics(int32_t width, int32_t height, double pixel_ratio);
   FlutterDesktopMessage ConvertToDesktopMessage(
       const FlutterPlatformMessage& engine_message);
   static bool OnAcquireExternalTexture(void* user_data, int64_t texture_id,

--- a/shell/platform/tizen/tizen_surface.cc
+++ b/shell/platform/tizen/tizen_surface.cc
@@ -9,6 +9,6 @@ TizenSurface::TizenSurface(int32_t x, int32_t y, int32_t width, int32_t height)
 
 TizenSurface::~TizenSurface() {}
 
-uint32_t TizenSurface::GetWidth() { return window_width_; }
+int32_t TizenSurface::GetWidth() { return window_width_; }
 
-uint32_t TizenSurface::GetHeight() { return window_height_; }
+int32_t TizenSurface::GetHeight() { return window_height_; }

--- a/shell/platform/tizen/tizen_surface.h
+++ b/shell/platform/tizen/tizen_surface.h
@@ -18,8 +18,9 @@ class TizenSurface {
   virtual uint32_t OnGetFBO() = 0;
   virtual void* OnProcResolver(const char* name) = 0;
   virtual bool IsValid() = 0;
-  uint32_t GetWidth();
-  uint32_t GetHeight();
+  virtual void SetSize(int32_t width, int32_t height) = 0;
+  int32_t GetWidth();
+  int32_t GetHeight();
 
  protected:
   const int32_t window_width_;

--- a/shell/platform/tizen/tizen_surface_gl.cc
+++ b/shell/platform/tizen/tizen_surface_gl.cc
@@ -3,8 +3,10 @@
 // found in the LICENSE file.
 
 #include "tizen_surface_gl.h"
+
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
+
 #include "flutter/shell/platform/tizen/logger.h"
 
 TizenSurfaceGL::TizenSurfaceGL(int32_t x, int32_t y, int32_t width,
@@ -78,7 +80,7 @@ uint32_t TizenSurfaceGL::OnGetFBO() {
   return 0;  // FBO0
 }
 
-#define GL_FUNC(FunctionName)              \
+#define GL_FUNC(FunctionName)                     \
   else if (strcmp(name, #FunctionName) == 0) {    \
     return reinterpret_cast<void*>(FunctionName); \
   }
@@ -241,6 +243,8 @@ bool TizenSurfaceGL::InitalizeDisplay() {
   // ecore_wl2 SHOW
   ecore_wl2_window_show(wl2_window_);
 
+  ecore_wl2_window_aux_hint_add(wl2_window_, 0, "wm.policy.win.user.geometry",
+                                "1");
   ecore_wl2_window_position_set(wl2_window_, x_, y_);
   ecore_wl2_window_geometry_set(wl2_window_, x_, y_, window_width_,
                                 window_height_);
@@ -365,4 +369,10 @@ void TizenSurfaceGL::Destroy() {
     wl2_display_ = nullptr;
   }
   ecore_wl2_shutdown();
+}
+
+void TizenSurfaceGL::SetSize(int32_t width, int32_t height) {
+  LoggerD("Resize egl window %d %d", width, height);
+  ecore_wl2_egl_window_resize_with_rotation(egl_window_, 0, 0, width, height,
+                                            0);
 }

--- a/shell/platform/tizen/tizen_surface_gl.h
+++ b/shell/platform/tizen/tizen_surface_gl.h
@@ -33,6 +33,7 @@ class TizenSurfaceGL : public TizenSurface {
   bool IsValid();
   bool InitalizeDisplay();
   void Destroy();
+  void SetSize(int32_t width, int32_t height);
   Ecore_Wl2_Window* wl2_window() { return wl2_window_; }
 
  private:


### PR DESCRIPTION
* This only works for mobile. On other devices, needs some improvements.
For examples, wearables have a very small UI area outside the keyboard area.
The TV-emulator has a translucent software keyboard, so window resize is unnecessary.
Lastly, on real TV device, the current way that to handle HW-back key fallback
on text_input_channel is not enough.
We have to take the time and improve it one by one.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>
