### PR TITLE
Remove tizen_tools dependency and update BUILD.gn

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -107,8 +107,6 @@ allowed_hosts = [
 deps = {
   'src': 'https://github.com/flutter/buildroot.git' + '@' + 'a6c0959d1ac8cdfe6f9ff87892bc4905a73699fe',
 
-  'src/third_party/tizen_tools': 'git@github.com:flutter-tizen/tizen_tools.git',
-
    # Fuchsia compatibility
    #
    # The dependencies in this section should match the layout in the Fuchsia gn

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -62,26 +62,26 @@ source_set("flutter_tizen") {
   ]
 
   include_dirs = [
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/appfw",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/base",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/dlog",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/ecore-1",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/ecore-evas-1",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/ecore-imf-1",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/ecore-imf-evas-1",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/ecore-input-1",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/ecore-wl2-1",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/efl-1",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/eina-1",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/eina-1/eina",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/emile-1",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/eo-1",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/evas-1",
-    "//third_party/tizen_tools/sysroot/$target_cpu/usr/include/system",
+    "$custom_sysroot/usr/include",
+    "$custom_sysroot/usr/include/appfw",
+    "$custom_sysroot/usr/include/base",
+    "$custom_sysroot/usr/include/dlog",
+    "$custom_sysroot/usr/include/ecore-1",
+    "$custom_sysroot/usr/include/ecore-evas-1",
+    "$custom_sysroot/usr/include/ecore-imf-1",
+    "$custom_sysroot/usr/include/ecore-imf-evas-1",
+    "$custom_sysroot/usr/include/ecore-input-1",
+    "$custom_sysroot/usr/include/ecore-wl2-1",
+    "$custom_sysroot/usr/include/efl-1",
+    "$custom_sysroot/usr/include/eina-1",
+    "$custom_sysroot/usr/include/eina-1/eina",
+    "$custom_sysroot/usr/include/emile-1",
+    "$custom_sysroot/usr/include/eo-1",
+    "$custom_sysroot/usr/include/evas-1",
+    "$custom_sysroot/usr/include/system",
   ]
   
-  lib_dirs = [ "//third_party/tizen_tools/sysroot/$target_cpu/usr/lib" ]
+  lib_dirs = [ "$custom_sysroot/usr/lib" ]
 
   cflags_cc = [
     "-Wno-newline-eof",


### PR DESCRIPTION
- It's pointless to define tizen_tools in DEPS file as it's not version controlled and you still have to manually pull newly added dependencies. The new build procedure ([Building the engine](https://github.com/flutter-tizen/engine/wiki/Building-the-engine)) guides you to create a local copy of tizen_tools in `src/tizen_tools`.
- In the CI container image, sysroots are pre-created outside the engine build root. The relative paths to `tizen_tools/sysroot/$arch` were replaced with `$custom_sysroot` to enable such use case. (Note: The build command remains the same.)
