### PR TITLE
Fix a crash during app shutdown

### DIFF
--- a/shell/platform/tizen/tizen_embedder_engine.cc
+++ b/shell/platform/tizen/tizen_embedder_engine.cc
@@ -35,10 +35,10 @@ static double GetDeviceDpi() {
 TizenEmbedderEngine::TizenEmbedderEngine(
     const FlutterWindowProperties& window_properties)
     : device_profile(GetDeviceProfile()), device_dpi(GetDeviceDpi()) {
-  tizen_native_window = std::make_unique<TizenNativeWindow>(
+  tizen_native_window = std::make_shared<TizenNativeWindow>(
       window_properties.x, window_properties.y, window_properties.width,
       window_properties.height);
-  tizen_surface = std::make_unique<TizenSurfaceGL>(tizen_native_window.get());
+  tizen_surface = std::make_unique<TizenSurfaceGL>(tizen_native_window);
 
   // Run flutter task on Tizen main loop.
   // Tizen engine has four threads (GPU thread, UI thread, IO thread, platform
@@ -59,7 +59,11 @@ TizenEmbedderEngine::TizenEmbedderEngine(
   tizen_vsync_waiter_ = std::make_unique<TizenVsyncWaiter>();
 }
 
-TizenEmbedderEngine::~TizenEmbedderEngine() { LoggerD("Destroy"); }
+TizenEmbedderEngine::~TizenEmbedderEngine() {
+  LoggerD("Destroy");
+  tizen_surface = nullptr;
+  tizen_native_window = nullptr;
+}
 
 // Attempts to load AOT data from the given path, which must be absolute and
 // non-empty. Logs and returns nullptr on failure.

--- a/shell/platform/tizen/tizen_embedder_engine.h
+++ b/shell/platform/tizen/tizen_embedder_engine.h
@@ -95,7 +95,7 @@ class TizenEmbedderEngine {
 
   // The interface between the Flutter rasterizer and the platform.
   std::unique_ptr<TizenSurface> tizen_surface;
-  std::unique_ptr<TizenNativeWindow> tizen_native_window;
+  std::shared_ptr<TizenNativeWindow> tizen_native_window;
 
   // The system channels for communicating between Flutter and the platform.
   std::unique_ptr<KeyEventChannel> key_event_channel;

--- a/shell/platform/tizen/tizen_native_window.cc
+++ b/shell/platform/tizen/tizen_native_window.cc
@@ -24,7 +24,7 @@ class TizenWl2Display {
 
   ~TizenWl2Display() {
     if (wl2_display_) {
-      ecore_wl2_display_destroy(wl2_display_);
+      ecore_wl2_display_disconnect(wl2_display_);
       wl2_display_ = nullptr;
     }
     ecore_wl2_shutdown();

--- a/shell/platform/tizen/tizen_native_window.cc
+++ b/shell/platform/tizen/tizen_native_window.cc
@@ -93,11 +93,12 @@ TizenNativeWindow::TizenNativeWindow(int32_t x, int32_t y, int32_t w,
                                 "1");
   ecore_wl2_window_show(wl2_window_);
 
-  tizen_native_egl_window_ = std::make_unique<TizenNativeEGLWindow>(this, w, h);
+  tizen_native_egl_window_ = std::make_shared<TizenNativeEGLWindow>(this, w, h);
   is_valid_ = true;
 }
 
 TizenNativeWindow::~TizenNativeWindow() {
+  tizen_native_egl_window_ = nullptr;
   if (wl2_window_) {
     ecore_wl2_window_free(wl2_window_);
     wl2_window_ = nullptr;

--- a/shell/platform/tizen/tizen_native_window.h
+++ b/shell/platform/tizen/tizen_native_window.h
@@ -39,13 +39,13 @@ class TizenNativeWindow {
   ~TizenNativeWindow();
   bool IsValid() { return is_valid_; }
   Ecore_Wl2_Window* GetWindowHandle() { return wl2_window_; }
-  TizenNativeEGLWindow* GetTizenNativeEGLWindow() {
-    return tizen_native_egl_window_.get();
+  std::shared_ptr<TizenNativeEGLWindow> GetTizenNativeEGLWindow() {
+    return tizen_native_egl_window_;
   };
   TizenNativeWindowGeometry GetGeometry();
 
  private:
-  std::unique_ptr<TizenNativeEGLWindow> tizen_native_egl_window_;
+  std::shared_ptr<TizenNativeEGLWindow> tizen_native_egl_window_;
   Ecore_Wl2_Window* wl2_window_{nullptr};
   bool is_valid_{false};
 };

--- a/shell/platform/tizen/tizen_surface_gl.h
+++ b/shell/platform/tizen/tizen_surface_gl.h
@@ -23,7 +23,7 @@
 
 class TizenEGLSurface {
  public:
-  TizenEGLSurface(TizenNativeEGLWindow* tizen_native_egl_window,
+  TizenEGLSurface(std::shared_ptr<TizenNativeEGLWindow> tizen_native_egl_window,
                   EGLSurface egl_surface)
       : tizen_native_egl_window_(tizen_native_egl_window),
         egl_surface_(egl_surface){};
@@ -32,13 +32,14 @@ class TizenEGLSurface {
   EGLSurface GetEGLSurfaceHandle() { return egl_surface_; };
 
  private:
-  TizenNativeEGLWindow* tizen_native_egl_window_;
+  std::shared_ptr<TizenNativeEGLWindow> tizen_native_egl_window_;
   EGLSurface egl_surface_{EGL_NO_SURFACE};
 };
 
 class TizenEGLContext {
  public:
-  TizenEGLContext(TizenNativeEGLWindow* tizen_native_egl_window);
+  TizenEGLContext(
+      std::shared_ptr<TizenNativeEGLWindow> tizen_native_egl_window);
   ~TizenEGLContext();
   bool IsValid();
   std::unique_ptr<TizenEGLSurface> CreateTizenEGLWindowSurface();
@@ -47,7 +48,7 @@ class TizenEGLContext {
   EGLContext GetEGLResourceContextHandle() { return egl_resource_context_; }
 
  public:
-  TizenNativeEGLWindow* tizen_native_egl_window_;
+  std::shared_ptr<TizenNativeEGLWindow> tizen_native_egl_window_;
   EGLConfig egl_config_{nullptr};
   EGLContext egl_context_{EGL_NO_CONTEXT};
   EGLContext egl_resource_context_{EGL_NO_CONTEXT};
@@ -55,7 +56,7 @@ class TizenEGLContext {
 
 class TizenSurfaceGL : public TizenSurface {
  public:
-  TizenSurfaceGL(TizenNativeWindow* tizen_native_window);
+  TizenSurfaceGL(std::shared_ptr<TizenNativeWindow> tizen_native_window);
   ~TizenSurfaceGL();
   bool OnMakeCurrent() override;
   bool OnClearCurrent() override;
@@ -66,11 +67,9 @@ class TizenSurfaceGL : public TizenSurface {
   bool IsValid() override { return is_valid_; };
   void SetSize(int32_t width, int32_t height) override;
 
-  void Destroy();
-
  private:
   bool is_valid_{false};
-  TizenNativeWindow* tizen_native_window_;
+  std::shared_ptr<TizenNativeWindow> tizen_native_window_;
   std::unique_ptr<TizenEGLContext> tizen_context_gl_;
   std::unique_ptr<TizenEGLSurface> tizen_egl_window_surface_;
   std::unique_ptr<TizenEGLSurface> tizen_egl_pbuffer_surface_;


### PR DESCRIPTION
This PR includes:

* Disconnect Ecore_Wl2_Display instead of destroy
* Correct the order of resource release.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>
