### PR TITLE
Fix a crash when TizenVsyncWaiter is destroyed.

### DIFF
--- a/shell/platform/tizen/tizen_embedder_engine.cc
+++ b/shell/platform/tizen/tizen_embedder_engine.cc
@@ -56,7 +56,7 @@ TizenEmbedderEngine::TizenEmbedderEngine(
   message_dispatcher =
       std::make_unique<flutter::IncomingMessageDispatcher>(messenger.get());
 
-  tizen_vsync_waiter_ = std::make_unique<TizenVsyncWaiter>();
+  tizen_vsync_waiter_ = std::make_unique<TizenVsyncWaiter>(this);
 }
 
 TizenEmbedderEngine::~TizenEmbedderEngine() {
@@ -163,8 +163,6 @@ bool TizenEmbedderEngine::RunEngine(
     LoggerE("FlutterEngineRun Failure! result: %d", result);
     return false;
   }
-
-  tizen_vsync_waiter_->AsyncWaitForRunEngineSuccess(flutter_engine);
 
   std::unique_ptr<FlutterTextureRegistrar> textures =
       std::make_unique<FlutterTextureRegistrar>();
@@ -330,7 +328,11 @@ void TizenEmbedderEngine::OnFlutterPlatformMessage(
 void TizenEmbedderEngine::OnVsyncCallback(void* user_data, intptr_t baton) {
   TizenEmbedderEngine* tizen_embedder_engine =
       reinterpret_cast<TizenEmbedderEngine*>(user_data);
-  tizen_embedder_engine->tizen_vsync_waiter_->AsyncWaitForVsync(baton);
+  if (tizen_embedder_engine->tizen_vsync_waiter_->IsValid()) {
+    tizen_embedder_engine->tizen_vsync_waiter_->AsyncWaitForVsync(baton);
+  } else {
+    LoggerW("TizenVsyncWaiter is not valid");
+  }
 }
 
 // Converts a FlutterPlatformMessage to an equivalent FlutterDesktopMessage.

--- a/shell/platform/tizen/tizen_surface_gl.cc
+++ b/shell/platform/tizen/tizen_surface_gl.cc
@@ -342,7 +342,7 @@ void* TizenSurfaceGL::OnProcResolver(const char* name) {
   GL_FUNC(glVertexAttrib4fv)
   GL_FUNC(glVertexAttribPointer)
   GL_FUNC(glViewport)
-  LoggerW("Could not resolve: %s", name);
+  LoggerD("Could not resolve: %s", name);
   return nullptr;
 }
 #undef GL_FUNC

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -5,41 +5,35 @@
 #ifndef EMBEDDER_TIZEN_VSYNC_WAITER_H_
 #define EMBEDDER_TIZEN_VSYNC_WAITER_H_
 
-#include <Ecore.h>
 #include <tdm_client.h>
 
 #include <thread>
 
 #include "flutter/shell/platform/embedder/embedder.h"
 
+class TizenEmbedderEngine;
+
 class TizenVsyncWaiter {
  public:
-  TizenVsyncWaiter();
+  TizenVsyncWaiter(TizenEmbedderEngine* engine);
   virtual ~TizenVsyncWaiter();
-  bool CreateTDMVblank();
-  bool AsyncWaitForVsync();
   void AsyncWaitForVsync(intptr_t baton);
-  void AsyncWaitForRunEngineSuccess(FLUTTER_API_SYMBOL(FlutterEngine)
-                                        flutter_engine);
+
+  bool IsValid();
 
  private:
-  static const int VBLANK_LOOP_REQUEST = 1;
-  static const int VBLANK_LOOP_DEL_PIPE = 2;
-  void AsyncWaitForVsyncCallback();
-  void DeleteVblankEventPipe();
-  static void CreateVblankEventLoop(void* data);
+  bool CreateTDMVblank();
+  void HandleVblankLoopRequest();
   static void TdmClientVblankCallback(tdm_client_vblank* vblank,
                                       tdm_error error, unsigned int sequence,
                                       unsigned int tv_sec, unsigned int tv_usec,
                                       void* user_data);
-  static void VblankEventLoopCallback(void* data, void* buffer,
-                                      unsigned int nbyte);
-  tdm_client* client_;
-  tdm_client_output* output_;
-  tdm_client_vblank* vblank_;
-  FLUTTER_API_SYMBOL(FlutterEngine) flutter_engine_;
-  intptr_t baton_;
-  Ecore_Pipe* vblank_ecore_pipe_;
+
+  tdm_client* client_{nullptr};
+  tdm_client_output* output_{nullptr};
+  tdm_client_vblank* vblank_{nullptr};
+  TizenEmbedderEngine* engine_{nullptr};
+  intptr_t baton_{0};
 };
 
 #endif  // EMBEDDER_TIZEN_VSYNC_WAITER_H_


### PR DESCRIPTION
* Don't have vblank_ecore_pipe as a member anymore
* Does not consider abnormal situations.
  This means, this situation should never happen.
* Refactor TizenVsyncWaiter

Signed-off-by: Boram Bae <boram21.bae@samsung.com>
