### PR TITLE
Add azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,91 @@
+# Azure Pipelines YAML pipeline.
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema
+name: ninja
+
+trigger:
+- flutter-*-tizen
+pr:
+- flutter-*-tizen
+
+jobs:
+- job: Linux
+  strategy:
+    matrix:
+      tizen-arm-release:
+        arch: arm
+        mode: release
+        targetTriple: armv7l-tizen-linux-gnueabi
+      tizen-arm-debug:
+        arch: arm
+        mode: debug
+        targetTriple: armv7l-tizen-linux-gnueabi
+      tizen-x86-debug:
+        arch: x86
+        mode: debug
+        targetTriple: i586-tizen-linux-gnueabi
+  pool:
+    name: Default
+    demands: agent.os -equals Linux
+  timeoutInMinutes: 30
+  cancelTimeoutInMinutes: 1
+  variables:
+  - name: buildroot
+    value: $(Pipeline.Workspace)/src
+  steps:
+  - checkout: self
+    clean: false
+    path: src/flutter
+  - bash: |
+      flutter/tools/gn \
+        --target-os linux \
+        --linux-cpu $(arch) \
+        --target-toolchain `pwd`/tizen_tools/toolchains \
+        --target-sysroot `pwd`/tizen_tools/sysroot/$(arch) \
+        --target-triple $(targetTriple) \
+        --runtime-mode $(mode) \
+        --embedder-for-target \
+        --build-tizen-shell
+      ninja -C out/linux_$(mode)_$(arch)
+    displayName: Build
+    workingDirectory: $(buildroot)
+    failOnStderr: true
+  - bash: |
+      OUTDIR=$(Build.StagingDirectory)
+      cp libflutter_linux_tizen.so $OUTDIR/libflutter.so
+      if [ "$(System.JobName)" = "tizen-arm-release" ]; then
+        cp icudtl.dat $OUTDIR
+        mkdir $OUTDIR/linux-x64
+        cp clang_x64/gen_snapshot $OUTDIR/linux-x64
+      fi
+    displayName: Copy artifacts
+    workingDirectory: $(buildroot)/out/linux_$(mode)_$(arch)
+    failOnStderr: true
+  - publish: $(Build.StagingDirectory)
+    artifact: $(System.JobName)
+- job: Release
+  dependsOn: Linux
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  pool:
+    name: Default
+    demands: agent.os -equals Linux
+  steps:
+  - checkout: self
+    path: src/flutter
+  - download: current
+  - bash: |
+      mkdir -p common/client_wrapper
+      mv $(Pipeline.Workspace)/tizen-* .
+      mv tizen-*/icudtl.dat common
+      PLATFORM=$(Pipeline.Workspace)/src/flutter/shell/platform
+      cp $PLATFORM/common/cpp/client_wrapper/*.{h,cc} common/client_wrapper
+      rm common/client_wrapper/{*_unittests.*,engine_method_result.cc}
+      cp -r $PLATFORM/common/cpp/public common
+      cp -r $PLATFORM/common/cpp/client_wrapper/include common/client_wrapper
+      cp $PLATFORM/tizen/public/*.h common/public
+      cp $PLATFORM/tizen/LICENSE .
+      zip -r linux-x64.zip *
+    displayName: Create a release
+    workingDirectory: $(Build.StagingDirectory)
+    failOnStderr: true
+  - publish: $(Build.StagingDirectory)/linux-x64.zip
+    artifact: Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ pr:
 - flutter-*-tizen
 
 jobs:
-- job: Linux
+- job: build
   strategy:
     matrix:
       tizen-arm-release:
@@ -56,38 +56,50 @@ jobs:
       cp libflutter_linux_tizen.so $OUTDIR/libflutter.so
       if [ "$(System.JobName)" = "tizen-arm-release" ]; then
         cp icudtl.dat $OUTDIR
-        mkdir $OUTDIR/linux-x64
-        cp clang_x64/gen_snapshot $OUTDIR/linux-x64
       fi
     displayName: Copy artifacts
     workingDirectory: $(buildroot)/out/linux_$(mode)_$(arch)
     failOnStderr: true
   - publish: $(Build.StagingDirectory)
     artifact: $(System.JobName)
-- job: Release
-  dependsOn: Linux
+- job: release
+  dependsOn: build
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   pool:
     name: Default
     demands: agent.os -equals Linux
+  workspace:
+    clean: outputs
+  variables:
+  - name: upstreamVersion
+    value: 4654fc6cf6416daae78eac2c211ad84c46e21625
   steps:
   - checkout: self
     path: src/flutter
   - download: current
   - bash: |
       mkdir -p common/client_wrapper
-      mv $(Pipeline.Workspace)/tizen-* .
-      mv tizen-*/icudtl.dat common
-      PLATFORM=$(Pipeline.Workspace)/src/flutter/shell/platform
-      cp $PLATFORM/common/cpp/client_wrapper/*.{h,cc} common/client_wrapper
+      ROOT=$(Pipeline.Workspace)/src/flutter/shell/platform
+      cp $ROOT/common/cpp/client_wrapper/*.{h,cc} common/client_wrapper
       rm common/client_wrapper/{*_unittests.*,engine_method_result.cc}
-      cp -r $PLATFORM/common/cpp/public common
-      cp -r $PLATFORM/common/cpp/client_wrapper/include common/client_wrapper
-      cp $PLATFORM/tizen/public/*.h common/public
-      cp $PLATFORM/tizen/LICENSE .
-      zip -r linux-x64.zip *
-    displayName: Create a release
-    workingDirectory: $(Build.StagingDirectory)
+      cp -r $ROOT/common/cpp/public common
+      cp -r $ROOT/common/cpp/client_wrapper/include common/client_wrapper
+      cp $ROOT/tizen/public/*.h common/public
+      cp $ROOT/tizen/LICENSE .
+    displayName: Copy peripherals
+    workingDirectory: $(Build.BinariesDirectory)
     failOnStderr: true
-  - publish: $(Build.StagingDirectory)/linux-x64.zip
-    artifact: Release
+  - bash: |
+      mv $(Pipeline.Workspace)/tizen-* .
+      mv tizen-arm-release/icudtl.dat common
+      for platform in linux windows darwin; do
+        curl -o tmp.zip https://storage.googleapis.com/flutter_infra/flutter/$(upstreamVersion)/android-arm-release/$platform-x64.zip 2> /dev/null
+        unzip tmp.zip -d tizen-arm-release/$platform-x64 && rm tmp.zip
+        zip -r $(Build.StagingDirectory)/$platform-x64.zip *
+        rm -r tizen-arm-release/$platform-x64
+      done
+    displayName: Create releases
+    workingDirectory: $(Build.BinariesDirectory)
+    failOnStderr: true
+  - publish: $(Build.StagingDirectory)
+    artifact: release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,9 +33,11 @@ jobs:
     value: $(Pipeline.Workspace)/src
   steps:
   - checkout: self
-    clean: false
     path: src/flutter
   - bash: |
+      git reset --hard HEAD
+      gclient sync -D
+      sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' build/config/compiler/BUILD.gn
       flutter/tools/gn \
         --target-os linux \
         --linux-cpu $(arch) \


### PR DESCRIPTION
Adds `azure-pipelines.yml`, a YAML pipeline file for Azure Pipelines. (Azure Pipelines is a part of [Azure DevOps](https://azure.microsoft.com/en-us/services/devops).)

The example CI run result: https://github.com/flutter-tizen/engine/runs/1637344660

As you can see in the build [result page](https://dev.azure.com/flutter-tizen/flutter-tizen/_build/results?buildId=27&view=results), the CI builds the engine source code in three different modes (`tizen-arm-release`/`tizen-arm-debug`/`tizen-x86-debug`) and publishes the artifacts (`libflutter.so` for each mode and a combined `linux-x64.zip`) as Pipeline Artifacts.

Azure Pipelines supports running builds on self-hosted agents. Currently our builds are run on one of our private Amazon EC2 instances (it will be scaled up later to increase the build speed). Setting up the build environment is not part of the CI so it should be done manually in the agent's shell by following https://github.com/flutter-tizen/engine/wiki/Building-the-engine. I also considered using a Docker container but it seemed not a good option as it complicates the pipeline very much.

The builds are currently incremental. Incremental building reduces the time required for each build (from 30 min to 3 min approximately) but may cause any unexpected problem.

For Azure Pipelines basics, see https://docs.microsoft.com/en-us/azure/devops/pipelines/customize-pipeline. For the YAML schema, see https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema.

The pipeline details:
- The pipeline is triggered by either a new commit or PR on any branch whose name matches `flutter-*-tizen`.
- The _Linux_ job compiles the engine source on a Linux agent to eventually create a release for the Linux x64 platform. A _Windows_ or _macOS_ job may be added in the future.
- The _Release_ job is run only when a new commit is created (i.e. a PR is merged). It assembles artifacts from the previous job and header files (such as `client_wrapper` and `tizen/public`) into `linux-x64.zip`. The generated file is used by the flutter-tizen tool.
