### PR TITLE
Clean-up channel view resource upon exiting app

### DIFF
--- a/shell/platform/tizen/channels/platform_view_channel.cc
+++ b/shell/platform/tizen/channels/platform_view_channel.cc
@@ -74,19 +74,20 @@ PlatformViewChannel::PlatformViewChannel(flutter::BinaryMessenger* messenger)
                  result) { HandleMethodCall(call, std::move(result)); });
 }
 
-PlatformViewChannel::~PlatformViewChannel() {
+PlatformViewChannel::~PlatformViewChannel() { Dispose(); }
+
+void PlatformViewChannel::Dispose() {
+  // Clean-up view_instances_
+  for (auto const& [viewId, viewInstance] : view_instances_) {
+    delete viewInstance;
+  }
+  view_instances_.clear();
+
   // Clean-up view_factories_
   for (auto const& [viewType, viewFactory] : view_factories_) {
     viewFactory->Dispose();
   }
   view_factories_.clear();
-
-  // Clean-up view_instances_
-  for (auto const& [viewId, viewInstance] : view_instances_) {
-    viewInstance->Dispose();
-    delete viewInstance;
-  }
-  view_instances_.clear();
 }
 
 void PlatformViewChannel::SendKeyEvent(Ecore_Event_Key* key, bool is_down) {

--- a/shell/platform/tizen/channels/platform_view_channel.h
+++ b/shell/platform/tizen/channels/platform_view_channel.h
@@ -19,6 +19,7 @@ class PlatformViewChannel {
  public:
   explicit PlatformViewChannel(flutter::BinaryMessenger* messenger);
   virtual ~PlatformViewChannel();
+  void Dispose();
   std::map<std::string, std::unique_ptr<PlatformViewFactory>>& ViewFactories() {
     return view_factories_;
   }

--- a/shell/platform/tizen/tizen_embedder_engine.cc
+++ b/shell/platform/tizen/tizen_embedder_engine.cc
@@ -200,6 +200,9 @@ bool TizenEmbedderEngine::RunEngine(
 
 bool TizenEmbedderEngine::StopEngine() {
   if (flutter_engine) {
+    if (platform_view_channel) {
+      platform_view_channel->Dispose();
+    }
     if (plugin_registrar_destruction_callback_) {
       plugin_registrar_destruction_callback_(plugin_registrar_.get());
     }


### PR DESCRIPTION
If you do not clean up resources when the app is closed, it may cause a crash when the LWE web view is closed.