### PR TITLE
Support screen rotations for tizen4.0 and tizen6.0

### DIFF
--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -102,7 +102,7 @@ void TextInputChannel::InputPanelStateChangedCallback(
     case ECORE_IMF_INPUT_PANEL_STATE_SHOW: {
       FT_LOGD("[PANEL_STATE_SHOW]\n");
       if (self->engine_->device_profile ==
-          "mobile") {  // FIXME : Needs improvement on other devices.
+          "mobileD") {  // FIXME : Needs improvement on other devices.
         ecore_timer_add(
             0.25,
             [](void* data) -> Eina_Bool {
@@ -611,7 +611,7 @@ void TextInputChannel::HideSoftwareKeyboard() {
     is_software_keyboard_showing_ = false;
 
     if (engine_->device_profile ==
-        "mobile") {  // FIXME : Needs improvement on other devices.
+        "mobileD") {  // FIXME : Needs improvement on other devices.
       auto window_geometry = engine_->tizen_renderer->GetGeometry();
 
       if (rotation == 90 || rotation == 270) {

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -221,9 +221,6 @@ void FlutterNotifyLowMemoryWarning(FlutterWindowControllerRef controller) {
 
 void FlutterRotateWindow(FlutterWindowControllerRef controller,
                          int32_t degree) {
-  if (controller->engine) {
-    controller->engine->SetWindowOrientation(degree);
-  }
 }
 
 int64_t FlutterRegisterExternalTexture(

--- a/shell/platform/tizen/tizen_embedder_engine.cc
+++ b/shell/platform/tizen/tizen_embedder_engine.cc
@@ -276,13 +276,9 @@ void TizenEmbedderEngine::SetWindowOrientation(int32_t degree) {
   tizen_renderer->SetRotate(degree);
   // Compute renderer transformation based on the angle of rotation.
   double rad = (360 - degree) * M_PI / 180;
-  auto geometry = tizen_renderer->GetWindowData();
+  auto geometry = tizen_renderer->GetGeometry();
   double width = geometry.w;
   double height = geometry.h;
-
-  if (text_input_channel->IsSoftwareKeyboardShowing()) {
-    height -= text_input_channel->GetCurrentKeyboardGeometry().h;
-  }
 
   double trans_x = 0.0, trans_y = 0.0;
   if (degree == 90) {

--- a/shell/platform/tizen/tizen_embedder_engine.cc
+++ b/shell/platform/tizen/tizen_embedder_engine.cc
@@ -37,11 +37,11 @@ TizenEmbedderEngine::TizenEmbedderEngine(
     : device_profile(GetDeviceProfile()), device_dpi(GetDeviceDpi()) {
 #ifdef FLUTTER_TIZEN_4
   tizen_renderer = std::make_unique<TizenRendererEcoreWl>(
-      window_properties.x, window_properties.y, window_properties.width,
+      *this, window_properties.x, window_properties.y, window_properties.width,
       window_properties.height);
 #else
   tizen_renderer = std::make_unique<TizenRendererEcoreWl2>(
-      window_properties.x, window_properties.y, window_properties.width,
+      *this, window_properties.x, window_properties.y, window_properties.width,
       window_properties.height);
 #endif
 
@@ -198,8 +198,11 @@ bool TizenEmbedderEngine::RunEngine(
   touch_event_handler_ = std::make_unique<TouchEventHandler>(this);
 
   SetWindowOrientation(0);
-
   return true;
+}
+
+void TizenEmbedderEngine::OnRotationChange(int angle) {
+  SetWindowOrientation(angle);
 }
 
 bool TizenEmbedderEngine::StopEngine() {
@@ -270,9 +273,10 @@ void TizenEmbedderEngine::SetWindowOrientation(int32_t degree) {
     return;
   }
 
+  tizen_renderer->SetRotate(degree);
   // Compute renderer transformation based on the angle of rotation.
   double rad = (360 - degree) * M_PI / 180;
-  auto geometry = tizen_renderer->GetGeometry();
+  auto geometry = tizen_renderer->GetWindowData();
   double width = geometry.w;
   double height = geometry.h;
 
@@ -297,8 +301,12 @@ void TizenEmbedderEngine::SetWindowOrientation(int32_t degree) {
   touch_event_handler_->rotation = degree;
   text_input_channel->rotation = degree;
   if (degree == 90 || degree == 270) {
+    tizen_renderer->ResizeWithRotation(geometry.x, geometry.y, height, width,
+                                       degree);
     SendWindowMetrics(height, width, 0.0);
   } else {
+    tizen_renderer->ResizeWithRotation(geometry.x, geometry.y, width, height,
+                                       degree);
     SendWindowMetrics(width, height, 0.0);
   }
 }

--- a/shell/platform/tizen/tizen_embedder_engine.h
+++ b/shell/platform/tizen/tizen_embedder_engine.h
@@ -65,7 +65,7 @@ struct FlutterTextureRegistrar {
 using UniqueAotDataPtr = std::unique_ptr<_FlutterEngineAOTData, AOTDataDeleter>;
 
 // Manages state associated with the underlying FlutterEngine.
-class TizenEmbedderEngine {
+class TizenEmbedderEngine : public TizenRenderer::Delegate {
  public:
   explicit TizenEmbedderEngine(
       const FlutterWindowProperties& window_properties);
@@ -87,6 +87,7 @@ class TizenEmbedderEngine {
   void AppIsResumed();
   void AppIsPaused();
   void AppIsDetached();
+  void OnRotationChange(int degree) override;
 
   // The Flutter engine instance.
   FLUTTER_API_SYMBOL(FlutterEngine) flutter_engine;

--- a/shell/platform/tizen/tizen_renderer.cc
+++ b/shell/platform/tizen/tizen_renderer.cc
@@ -62,9 +62,9 @@ bool TizenRenderer::OnPresent() {
     return false;
   }
 
-  if(window_data_.received_rotation) {
+  if(received_rotation) {
     SendRotationChangeDone();
-    window_data_.received_rotation = false;
+    received_rotation = false;
   }
 
   if (eglSwapBuffers(egl_display_, egl_surface_) != EGL_TRUE) {
@@ -454,13 +454,4 @@ void TizenRenderer::DestoryEglSurface() {
     eglTerminate(egl_display_);
     egl_display_ = EGL_NO_DISPLAY;
   }
-}
-
-TizenRenderer::TizenWindowGeometry TizenRenderer::GetWindowData(){
-    TizenWindowGeometry result;
-    result.x = window_data_.x;
-    result.y = window_data_.y;
-    result.w = window_data_.w;
-    result.h = window_data_.h;
-    return result;
 }

--- a/shell/platform/tizen/tizen_renderer.cc
+++ b/shell/platform/tizen/tizen_renderer.cc
@@ -9,6 +9,9 @@
 
 #include "flutter/shell/platform/tizen/tizen_log.h"
 
+TizenRenderer::TizenRenderer(TizenRenderer::Delegate& delegate)
+    : delegate_(delegate) {}
+
 TizenRenderer::~TizenRenderer() = default;
 
 bool TizenRenderer::OnMakeCurrent() {
@@ -58,6 +61,12 @@ bool TizenRenderer::OnPresent() {
     FT_LOGE("Invalid TizenRenderer");
     return false;
   }
+
+  if(window_data_.received_rotation) {
+    SendRotationChangeDone();
+    window_data_.received_rotation = false;
+  }
+
   if (eglSwapBuffers(egl_display_, egl_surface_) != EGL_TRUE) {
     FT_LOGE("Could not swap EGl buffer");
     PrintEGLError();
@@ -217,6 +226,7 @@ bool TizenRenderer::InitializeRenderer(int32_t x, int32_t y, int32_t w,
     FT_LOGE("setupEglSurface fail");
     return false;
   }
+  Show();
   is_valid_ = true;
   return true;
 }
@@ -444,4 +454,13 @@ void TizenRenderer::DestoryEglSurface() {
     eglTerminate(egl_display_);
     egl_display_ = EGL_NO_DISPLAY;
   }
+}
+
+TizenRenderer::TizenWindowGeometry TizenRenderer::GetWindowData(){
+    TizenWindowGeometry result;
+    result.x = window_data_.x;
+    result.y = window_data_.y;
+    result.w = window_data_.w;
+    result.h = window_data_.h;
+    return result;
 }

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -63,4 +63,4 @@ class TizenRenderer {
   bool ChooseEGLConfiguration();
   void PrintEGLError();
 };
-#endif
+#endif //EMBEDDER_TIZEN_RENDERER_H

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -7,15 +7,6 @@
 
 #include <EGL/egl.h>
 
-struct WindowData {
-  int32_t x{0};
-  int32_t y{0};
-  int32_t w{0};
-  int32_t h{0};
-  int rotation{0};
-  bool received_rotation{false};
-};
-
 class TizenRenderer {
  public:
   struct TizenWindowGeometry {
@@ -36,7 +27,6 @@ class TizenRenderer {
   uint32_t OnGetFBO();
   void* OnProcResolver(const char* name);
   virtual TizenWindowGeometry GetGeometry() = 0;
-  TizenWindowGeometry GetWindowData();
   bool IsValid();
   virtual void Show() = 0;
   virtual void SetRotate(int angle) = 0;
@@ -45,7 +35,7 @@ class TizenRenderer {
                                   int32_t height, int32_t degree) = 0;
 
  protected:
-  WindowData window_data_;
+  bool received_rotation{false};
   TizenRenderer::Delegate& delegate_;
   bool InitializeRenderer(int32_t x, int32_t y, int32_t w, int32_t h);
   virtual bool SetupDisplay() = 0;

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -7,12 +7,27 @@
 
 #include <EGL/egl.h>
 
+struct WindowData {
+  int32_t x{0};
+  int32_t y{0};
+  int32_t w{0};
+  int32_t h{0};
+  int rotation{0};
+  bool received_rotation{false};
+};
+
 class TizenRenderer {
  public:
   struct TizenWindowGeometry {
     int32_t x{0}, y{0}, w{0}, h{0};
   };
-  TizenRenderer() = default;
+
+  class Delegate {
+   public:
+    virtual void OnRotationChange(int angle) = 0;
+  };
+
+  TizenRenderer(TizenRenderer::Delegate& deleget);
   virtual ~TizenRenderer();
   bool OnMakeCurrent();
   bool OnClearCurrent();
@@ -21,12 +36,17 @@ class TizenRenderer {
   uint32_t OnGetFBO();
   void* OnProcResolver(const char* name);
   virtual TizenWindowGeometry GetGeometry() = 0;
+  TizenWindowGeometry GetWindowData();
   bool IsValid();
+  virtual void Show() = 0;
+  virtual void SetRotate(int angle) = 0;
   virtual int GetEcoreWindowId() = 0;
-  virtual void ResizeWithRotation(int32_t dx, int32_t dy, int32_t width,
+  virtual void ResizeWithRotation(int32_t x, int32_t y, int32_t width,
                                   int32_t height, int32_t degree) = 0;
 
  protected:
+  WindowData window_data_;
+  TizenRenderer::Delegate& delegate_;
   bool InitializeRenderer(int32_t x, int32_t y, int32_t w, int32_t h);
   virtual bool SetupDisplay() = 0;
   virtual bool SetupEcoreWlWindow(int32_t x, int32_t y, int32_t w,
@@ -35,12 +55,12 @@ class TizenRenderer {
   bool SetupEglSurface();
   virtual EGLDisplay GetEGLDisplay() = 0;
   virtual EGLNativeWindowType GetEGLNativeWindowType() = 0;
-
   void DestoryRenderer();
   void DestoryEglSurface();
   virtual void DestoryEglWindow() = 0;
   virtual void DestoryEcoreWlWindow() = 0;
   virtual void ShutdownDisplay() = 0;
+  virtual void SendRotationChangeDone() = 0;
 
  private:
   bool is_valid_ = false;

--- a/shell/platform/tizen/tizen_renderer_ecore_wl.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl.cc
@@ -6,10 +6,13 @@
 
 #include "flutter/shell/platform/tizen/tizen_log.h"
 
-TizenRendererEcoreWl::TizenRendererEcoreWl(int32_t x, int32_t y, int32_t w,
-                                           int32_t h) {
+TizenRendererEcoreWl::TizenRendererEcoreWl(TizenRenderer::Delegate &delegate,
+                                           int32_t x, int32_t y, int32_t w,
+                                           int32_t h)
+    : TizenRenderer(delegate) {
   InitializeRenderer(x, y, w, h);
 }
+
 TizenRendererEcoreWl::~TizenRendererEcoreWl() { DestoryRenderer(); }
 
 bool TizenRendererEcoreWl::SetupDisplay() {
@@ -25,12 +28,17 @@ bool TizenRendererEcoreWl::SetupDisplay() {
   }
   return true;
 }
+
 bool TizenRendererEcoreWl::SetupEcoreWlWindow(int32_t x, int32_t y, int32_t w,
                                               int32_t h) {
   if (w == 0 || h == 0) {
     FT_LOGE("Failed to create because of the wrong size");
     return false;
   }
+  window_data_.x = x;
+  window_data_.y = y;
+  window_data_.w = w;
+  window_data_.h = h;
   ecore_wl_window_ = ecore_wl_window_new(
       nullptr, x, y, w, h, ECORE_WL_WINDOW_BUFFER_TYPE_EGL_WINDOW);
   FT_LOGD("ecore_wl_window_: %p", ecore_wl_window_);
@@ -43,8 +51,46 @@ bool TizenRendererEcoreWl::SetupEcoreWlWindow(int32_t x, int32_t y, int32_t w,
   ecore_wl_window_aux_hint_add(ecore_wl_window_, 0,
                                "wm.policy.win.user.geometry", "1");
   ecore_wl_window_show(ecore_wl_window_);
+  int rotations[4] = {0, 90, 180, 270};
+  ecore_wl_window_rotation_available_rotations_set(
+      ecore_wl_window_, rotations, sizeof(rotations) / sizeof(int));
+  ecore_event_handler_add(ECORE_WL_EVENT_WINDOW_ROTATE, RotationEventCb, this);
   return true;
 }
+
+Eina_Bool TizenRendererEcoreWl::RotationEventCb(void *data, int type,
+                                                void *event) {
+  auto *self = reinterpret_cast<TizenRendererEcoreWl *>(data);
+  Ecore_Wl_Event_Window_Rotate *ev =
+      reinterpret_cast<Ecore_Wl_Event_Window_Rotate *>(event);
+  self->delegate_.OnRotationChange(ev->angle);
+  return ECORE_CALLBACK_PASS_ON;
+}
+
+void TizenRendererEcoreWl::Show() { ecore_wl_window_show(ecore_wl_window_); }
+void TizenRendererEcoreWl::SetRotate(int degree) {
+  ecore_wl_window_rotation_set(ecore_wl_window_, degree);
+  window_data_.received_rotation = true;
+}
+
+void TizenRendererEcoreWl::ResizeWithRotation(int32_t x, int32_t y,
+                                              int32_t width, int32_t height,
+                                              int32_t degree) {
+  ecore_wl_window_resize(ecore_wl_window_, width, height, 0);
+  ecore_wl_window_update_size(ecore_wl_window_, width, height);
+  wl_egl_window_set_buffer_transform(wl_egl_window_, degree / 90);
+  wl_egl_window_set_window_transform(wl_egl_window_, degree / 90);
+
+  if ((degree == 90) || (degree == 270))
+    wl_egl_window_resize(wl_egl_window_, height, width, x, y);
+  else
+    wl_egl_window_resize(wl_egl_window_, width, height, x, y);
+}
+
+void TizenRendererEcoreWl::SendRotationChangeDone() {
+  ecore_wl_window_rotation_change_done_send(ecore_wl_window_);
+}
+
 bool TizenRendererEcoreWl::SetupEglWindow(int32_t w, int32_t h) {
   wl_egl_window_ =
       wl_egl_window_create(ecore_wl_window_surface_get(ecore_wl_window_), w, h);
@@ -54,9 +100,11 @@ bool TizenRendererEcoreWl::SetupEglWindow(int32_t w, int32_t h) {
   }
   return true;
 }
+
 EGLDisplay TizenRendererEcoreWl::GetEGLDisplay() {
   return eglGetDisplay((EGLNativeDisplayType)wl_display_);
 }
+
 EGLNativeWindowType TizenRendererEcoreWl::GetEGLNativeWindowType() {
   return (EGLNativeWindowType)wl_egl_window_;
 }
@@ -67,32 +115,29 @@ void TizenRendererEcoreWl::DestoryEglWindow() {
     wl_egl_window_ = nullptr;
   }
 }
+
 void TizenRendererEcoreWl::DestoryEcoreWlWindow() {
   if (ecore_wl_window_) {
     ecore_wl_window_free(ecore_wl_window_);
     ecore_wl_window_ = nullptr;
   }
 }
+
 void TizenRendererEcoreWl::ShutdownDisplay() { ecore_wl_shutdown(); }
 
 TizenRenderer::TizenWindowGeometry TizenRendererEcoreWl::GetGeometry() {
   TizenWindowGeometry result;
-  ecore_wl_window_geometry_get(ecore_wl_window_, &result.x, &result.y,
-                               &result.w, &result.h);
-  return result;
-}
-
-void TizenRendererEcoreWl::ResizeWithRotation(int32_t dx, int32_t dy,
-                                              int32_t width, int32_t height,
-                                              int32_t degree) {
-  wl_egl_window_resize(wl_egl_window_, width, height, dx, dy);
-  wl_egl_window_rotation rotations[4] = {ROTATION_0, ROTATION_90, ROTATION_180,
-                                         ROTATION_270};
-  int index = 0;
-  if (degree > 0) {
-    index = (degree / 90) % 4;
+  int rotation = ecore_wl_window_rotation_get(ecore_wl_window_);
+  result.x = window_data_.x;
+  result.y = window_data_.y;
+  if (rotation == 90 || rotation == 270) {
+    result.w = window_data_.h;
+    result.h = window_data_.w;
+  } else {
+    result.w = window_data_.w;
+    result.h = window_data_.h;
   }
-  wl_egl_window_set_rotation(wl_egl_window_, rotations[index]);
+  return result;
 }
 
 int TizenRendererEcoreWl::GetEcoreWindowId() {

--- a/shell/platform/tizen/tizen_renderer_ecore_wl.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl.cc
@@ -35,10 +35,7 @@ bool TizenRendererEcoreWl::SetupEcoreWlWindow(int32_t x, int32_t y, int32_t w,
     FT_LOGE("Failed to create because of the wrong size");
     return false;
   }
-  window_data_.x = x;
-  window_data_.y = y;
-  window_data_.w = w;
-  window_data_.h = h;
+
   ecore_wl_window_ = ecore_wl_window_new(
       nullptr, x, y, w, h, ECORE_WL_WINDOW_BUFFER_TYPE_EGL_WINDOW);
   FT_LOGD("ecore_wl_window_: %p", ecore_wl_window_);
@@ -70,14 +67,12 @@ Eina_Bool TizenRendererEcoreWl::RotationEventCb(void *data, int type,
 void TizenRendererEcoreWl::Show() { ecore_wl_window_show(ecore_wl_window_); }
 void TizenRendererEcoreWl::SetRotate(int degree) {
   ecore_wl_window_rotation_set(ecore_wl_window_, degree);
-  window_data_.received_rotation = true;
+  received_rotation = true;
 }
 
 void TizenRendererEcoreWl::ResizeWithRotation(int32_t x, int32_t y,
                                               int32_t width, int32_t height,
                                               int32_t degree) {
-  ecore_wl_window_resize(ecore_wl_window_, width, height, 0);
-  ecore_wl_window_update_size(ecore_wl_window_, width, height);
   wl_egl_window_set_buffer_transform(wl_egl_window_, degree / 90);
   wl_egl_window_set_window_transform(wl_egl_window_, degree / 90);
 
@@ -127,16 +122,8 @@ void TizenRendererEcoreWl::ShutdownDisplay() { ecore_wl_shutdown(); }
 
 TizenRenderer::TizenWindowGeometry TizenRendererEcoreWl::GetGeometry() {
   TizenWindowGeometry result;
-  int rotation = ecore_wl_window_rotation_get(ecore_wl_window_);
-  result.x = window_data_.x;
-  result.y = window_data_.y;
-  if (rotation == 90 || rotation == 270) {
-    result.w = window_data_.h;
-    result.h = window_data_.w;
-  } else {
-    result.w = window_data_.w;
-    result.h = window_data_.h;
-  }
+  ecore_wl_window_geometry_get(ecore_wl_window_, &result.x, &result.y,
+                               &result.w, &result.h);
   return result;
 }
 

--- a/shell/platform/tizen/tizen_renderer_ecore_wl.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl.h
@@ -40,4 +40,4 @@ class TizenRendererEcoreWl : public TizenRenderer {
   wl_display* wl_display_ = nullptr;
   static Eina_Bool RotationEventCb(void* data, int type, void* event);
 };
-#endif
+#endif //EMBEDDER_TIZEN_RENDERER_ECORE_WL_H

--- a/shell/platform/tizen/tizen_renderer_ecore_wl.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl.h
@@ -13,12 +13,15 @@
 #include <Ecore_Wayland.h>
 class TizenRendererEcoreWl : public TizenRenderer {
  public:
-  TizenRendererEcoreWl(int32_t x, int32_t y, int32_t w, int32_t h);
+  TizenRendererEcoreWl(TizenRenderer::Delegate& delegate, int32_t x, int32_t y,
+                       int32_t w, int32_t h);
   ~TizenRendererEcoreWl();
   TizenRenderer::TizenWindowGeometry GetGeometry() override;
-  int GetEcoreWindowId() override;
-  void ResizeWithRotation(int32_t dx, int32_t dy, int32_t width, int32_t height,
+  void Show() override;
+  void SetRotate(int angle) override;
+  void ResizeWithRotation(int32_t x, int32_t y, int32_t width, int32_t height,
                           int32_t degree) override;
+  int GetEcoreWindowId() override;
 
  protected:
   void DestoryEglWindow() override;
@@ -29,10 +32,12 @@ class TizenRendererEcoreWl : public TizenRenderer {
   bool SetupEcoreWlWindow(int32_t x, int32_t y, int32_t w, int32_t h) override;
   bool SetupEglWindow(int32_t w, int32_t h) override;
   void ShutdownDisplay() override;
+  void SendRotationChangeDone() override;
 
  private:
   Ecore_Wl_Window* ecore_wl_window_ = nullptr;
   wl_egl_window* wl_egl_window_ = nullptr;
   wl_display* wl_display_ = nullptr;
+  static Eina_Bool RotationEventCb(void* data, int type, void* event);
 };
 #endif

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -6,10 +6,13 @@
 
 #include "flutter/shell/platform/tizen/tizen_log.h"
 
-TizenRendererEcoreWl2::TizenRendererEcoreWl2(int32_t x, int32_t y, int32_t w,
-                                             int32_t h) {
+TizenRendererEcoreWl2::TizenRendererEcoreWl2(TizenRenderer::Delegate &delegate,
+                                             int32_t x, int32_t y, int32_t w,
+                                             int32_t h)
+    : TizenRenderer(delegate) {
   InitializeRenderer(x, y, w, h);
 }
+
 TizenRendererEcoreWl2::~TizenRendererEcoreWl2() { DestoryRenderer(); }
 bool TizenRendererEcoreWl2::SetupDisplay() {
   if (!ecore_wl2_init()) {
@@ -32,19 +35,60 @@ bool TizenRendererEcoreWl2::SetupEcoreWlWindow(int32_t x, int32_t y, int32_t w,
     FT_LOGE("Failed to create because of the wrong size");
     return false;
   }
+  window_data_.x = x;
+  window_data_.y = y;
+  window_data_.w = w;
+  window_data_.h = h;
   ecore_wl2_window_ =
       ecore_wl2_window_new(ecore_wl2_display_, nullptr, x, y, w, h);
   ecore_wl2_window_type_set(ecore_wl2_window_, ECORE_WL2_WINDOW_TYPE_TOPLEVEL);
   ecore_wl2_window_alpha_set(ecore_wl2_window_, EINA_FALSE);
+  ecore_wl2_window_position_set(ecore_wl2_window_, x, y);
   ecore_wl2_window_aux_hint_add(ecore_wl2_window_, 0,
                                 "wm.policy.win.user.geometry", "1");
-  ecore_wl2_window_show(ecore_wl2_window_);
+  int rotations[4] = {0, 90, 180, 270};
+  ecore_wl2_window_available_rotations_set(ecore_wl2_window_, rotations,
+                                           sizeof(rotations) / sizeof(int));
+  ecore_event_handler_add(ECORE_WL2_EVENT_WINDOW_ROTATE, RotationEventCb, this);
   return true;
+}
+
+Eina_Bool TizenRendererEcoreWl2::RotationEventCb(void *data, int type,
+                                                 void *event) {
+  auto *self = reinterpret_cast<TizenRendererEcoreWl2 *>(data);
+  Ecore_Wl2_Event_Window_Rotation *ev =
+      reinterpret_cast<Ecore_Wl2_Event_Window_Rotation *>(event);
+  self->delegate_.OnRotationChange(ev->angle);
+  return ECORE_CALLBACK_PASS_ON;
+}
+
+void TizenRendererEcoreWl2::Show() { ecore_wl2_window_show(ecore_wl2_window_); }
+
+void TizenRendererEcoreWl2::SetRotate(int angle) {
+  window_data_.rotation = angle;
+  ecore_wl2_window_rotation_set(ecore_wl2_window_, window_data_.rotation);
+  window_data_.received_rotation = true;
+}
+
+void TizenRendererEcoreWl2::ResizeWithRotation(int32_t x, int32_t y,
+                                               int32_t width, int32_t height,
+                                               int32_t angle) {
+  ecore_wl2_window_rotation_geometry_set(ecore_wl2_window_, angle, x, y, width,
+                                         height);
+  ecore_wl2_egl_window_resize_with_rotation(ecore_wl2_egl_window_, x, y, width,
+                                            height, angle);
+}
+
+void TizenRendererEcoreWl2::SendRotationChangeDone() {
+  int x, y, w, h;
+  ecore_wl2_window_geometry_get(ecore_wl2_window_, &x, &y, &w, &h);
+  ecore_wl2_window_rotation_change_done_send(ecore_wl2_window_,
+                                             window_data_.rotation, w, h);
 }
 
 bool TizenRendererEcoreWl2::SetupEglWindow(int32_t w, int32_t h) {
   ecore_wl2_egl_window_ = ecore_wl2_egl_window_create(ecore_wl2_window_, w, h);
-  return true;
+  return ecore_wl2_egl_window_ != nullptr;
 }
 
 EGLDisplay TizenRendererEcoreWl2::GetEGLDisplay() {
@@ -70,6 +114,7 @@ void TizenRendererEcoreWl2::DestoryEcoreWlWindow() {
     ecore_wl2_window_ = nullptr;
   }
 }
+
 void TizenRendererEcoreWl2::ShutdownDisplay() {
   if (ecore_wl2_display_) {
     ecore_wl2_display_disconnect(ecore_wl2_display_);
@@ -87,11 +132,4 @@ TizenRenderer::TizenWindowGeometry TizenRendererEcoreWl2::GetGeometry() {
 
 int TizenRendererEcoreWl2::GetEcoreWindowId() {
   return ecore_wl2_window_id_get(ecore_wl2_window_);
-}
-
-void TizenRendererEcoreWl2::ResizeWithRotation(int32_t dx, int32_t dy,
-                                               int32_t width, int32_t height,
-                                               int32_t degree) {
-  ecore_wl2_egl_window_resize_with_rotation(ecore_wl2_egl_window_, dx, dy,
-                                            width, height, degree);
 }

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -35,10 +35,6 @@ bool TizenRendererEcoreWl2::SetupEcoreWlWindow(int32_t x, int32_t y, int32_t w,
     FT_LOGE("Failed to create because of the wrong size");
     return false;
   }
-  window_data_.x = x;
-  window_data_.y = y;
-  window_data_.w = w;
-  window_data_.h = h;
   ecore_wl2_window_ =
       ecore_wl2_window_new(ecore_wl2_display_, nullptr, x, y, w, h);
   ecore_wl2_window_type_set(ecore_wl2_window_, ECORE_WL2_WINDOW_TYPE_TOPLEVEL);
@@ -65,16 +61,13 @@ Eina_Bool TizenRendererEcoreWl2::RotationEventCb(void *data, int type,
 void TizenRendererEcoreWl2::Show() { ecore_wl2_window_show(ecore_wl2_window_); }
 
 void TizenRendererEcoreWl2::SetRotate(int angle) {
-  window_data_.rotation = angle;
-  ecore_wl2_window_rotation_set(ecore_wl2_window_, window_data_.rotation);
-  window_data_.received_rotation = true;
+  ecore_wl2_window_rotation_set(ecore_wl2_window_, angle);
+  received_rotation = true;
 }
 
 void TizenRendererEcoreWl2::ResizeWithRotation(int32_t x, int32_t y,
                                                int32_t width, int32_t height,
                                                int32_t angle) {
-  ecore_wl2_window_rotation_geometry_set(ecore_wl2_window_, angle, x, y, width,
-                                         height);
   ecore_wl2_egl_window_resize_with_rotation(ecore_wl2_egl_window_, x, y, width,
                                             height, angle);
 }
@@ -82,8 +75,9 @@ void TizenRendererEcoreWl2::ResizeWithRotation(int32_t x, int32_t y,
 void TizenRendererEcoreWl2::SendRotationChangeDone() {
   int x, y, w, h;
   ecore_wl2_window_geometry_get(ecore_wl2_window_, &x, &y, &w, &h);
-  ecore_wl2_window_rotation_change_done_send(ecore_wl2_window_,
-                                             window_data_.rotation, w, h);
+  ecore_wl2_window_rotation_change_done_send(
+      ecore_wl2_window_, ecore_wl2_window_rotation_get(ecore_wl2_window_), w,
+      h);
 }
 
 bool TizenRendererEcoreWl2::SetupEglWindow(int32_t w, int32_t h) {

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -39,4 +39,4 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   Ecore_Wl2_Egl_Window *ecore_wl2_egl_window_ = nullptr;
   static Eina_Bool RotationEventCb(void *data, int type, void *event);
 };
-#endif
+#endif //EMBEDDER_TIZEN_RENDERER_ECORE_WL2_H

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -12,12 +12,15 @@
 
 class TizenRendererEcoreWl2 : public TizenRenderer {
  public:
-  TizenRendererEcoreWl2(int32_t x, int32_t y, int32_t w, int32_t h);
+  TizenRendererEcoreWl2(TizenRenderer::Delegate &delegate, int32_t x, int32_t y,
+                        int32_t w, int32_t h);
   ~TizenRendererEcoreWl2();
   TizenWindowGeometry GetGeometry() override;
   int GetEcoreWindowId() override;
-  void ResizeWithRotation(int32_t dx, int32_t dy, int32_t width, int32_t height,
-                          int32_t degree) override;
+  void ResizeWithRotation(int32_t x, int32_t y, int32_t width, int32_t height,
+                          int32_t angle) override;
+  void Show() override;
+  void SetRotate(int angle) override;
 
  protected:
   void DestoryEglWindow() override;
@@ -28,10 +31,12 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   bool SetupEcoreWlWindow(int32_t x, int32_t y, int32_t w, int32_t h) override;
   bool SetupEglWindow(int32_t w, int32_t h) override;
   void ShutdownDisplay() override;
+  void SendRotationChangeDone() override;
 
  private:
   Ecore_Wl2_Display *ecore_wl2_display_ = nullptr;
   Ecore_Wl2_Window *ecore_wl2_window_ = nullptr;
   Ecore_Wl2_Egl_Window *ecore_wl2_egl_window_ = nullptr;
+  static Eina_Bool RotationEventCb(void *data, int type, void *event);
 };
 #endif

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -43,15 +43,16 @@ void TouchEventHandler::SendFlutterPointerEvent(FlutterPointerPhase phase,
   double width = window_geometry.w;
   double height = window_geometry.h;
   double new_x = x, new_y = y;
+
   if (rotation == 90) {
-    new_x = height - y;
+    new_x = width - y;
     new_y = x;
   } else if (rotation == 180) {
     new_x = width - x;
     new_y = height - y;
   } else if (rotation == 270) {
     new_x = y;
-    new_y = width - x;
+    new_y = height - x;
   }
 
   FlutterPointerEvent event = {};

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -45,14 +45,14 @@ void TouchEventHandler::SendFlutterPointerEvent(FlutterPointerPhase phase,
   double new_x = x, new_y = y;
 
   if (rotation == 90) {
-    new_x = width - y;
+    new_x = height - y;
     new_y = x;
   } else if (rotation == 180) {
     new_x = width - x;
     new_y = height - y;
   } else if (rotation == 270) {
     new_x = y;
-    new_y = height - x;
+    new_y = width - x;
   }
 
   FlutterPointerEvent event = {};


### PR DESCRIPTION
Screen rotations sequence:
1.Register ecore rotate event callback.
2.Set rotate for ecore window when receive rotate event.
3.Resize ecore window.
4.Resize egl window.
5.Reize flutter UI.
6.Send rotate done before swap buffer.