### PR TITLE
Separate the embedder from the engine

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
   pool:
     name: Default
     demands: agent.os -equals Linux
-  timeoutInMinutes: 30
+  timeoutInMinutes: 60
   cancelTimeoutInMinutes: 1
   variables:
   - name: buildroot
@@ -38,6 +38,10 @@ jobs:
       git reset --hard HEAD
       gclient sync -D
       sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' build/config/compiler/BUILD.gn
+    displayName: Prepare for build
+    workingDirectory: $(buildroot)
+    failOnStderr: true
+  - bash: |
       flutter/tools/gn \
         --target-os linux \
         --linux-cpu $(arch) \
@@ -46,19 +50,40 @@ jobs:
         --target-triple $(targetTriple) \
         --runtime-mode $(mode) \
         --embedder-for-target \
-        --build-tizen-shell
-      ninja -C out/linux_$(mode)_$(arch)
+        --disable-desktop-embeddings \
+        --build-tizen-shell \
+        --out-dir output/default
+      ninja -C output/default/out/linux_$(mode)_$(arch)
     displayName: Build
     workingDirectory: $(buildroot)
     failOnStderr: true
   - bash: |
+      flutter/tools/gn \
+        --target-os linux \
+        --linux-cpu $(arch) \
+        --target-toolchain `pwd`/tizen_tools/toolchains \
+        --target-sysroot `pwd`/tizen_tools/sysroot/$(arch)_40 \
+        --target-triple $(targetTriple) \
+        --runtime-mode $(mode) \
+        --embedder-for-target \
+        --disable-desktop-embeddings \
+        --build-tizen-shell \
+        --tizen-sdk-4 \
+        --out-dir output/tizen40
+      ninja -C output/tizen40/out/linux_$(mode)_$(arch)
+    displayName: Build for Tizen 4.0
+    workingDirectory: $(buildroot)
+    failOnStderr: true
+  - bash: |
       OUTDIR=$(Build.StagingDirectory)
-      cp libflutter_linux_tizen.so $OUTDIR/libflutter.so
+      cp default/out/linux_$(mode)_$(arch)/libflutter_tizen.so $OUTDIR
+      cp tizen40/out/linux_$(mode)_$(arch)/libflutter_tizen.so $OUTDIR/libflutter_tizen40.so
+      cp tizen40/out/linux_$(mode)_$(arch)/libflutter_engine.so $OUTDIR
       if [ "$(System.JobName)" = "tizen-arm-release" ]; then
-        cp icudtl.dat $OUTDIR
+        cp default/out/linux_$(mode)_$(arch)/icudtl.dat $OUTDIR
       fi
     displayName: Copy artifacts
-    workingDirectory: $(buildroot)/out/linux_$(mode)_$(arch)
+    workingDirectory: $(buildroot)/output
     failOnStderr: true
   - publish: $(Build.StagingDirectory)
     artifact: $(System.JobName)

--- a/shell/platform/BUILD.gn
+++ b/shell/platform/BUILD.gn
@@ -4,6 +4,7 @@
 
 import("//build/fuchsia/sdk.gni")
 import("//flutter/shell/platform/config.gni")
+import("//flutter/shell/platform/tizen/config.gni")
 
 group("platform") {
   if (is_mac || is_ios) {
@@ -14,6 +15,9 @@ group("platform") {
     deps = []
     if (enable_desktop_embeddings) {
       deps += [ "linux" ]
+    }
+    if (build_tizen_shell) {
+      deps += [ "tizen" ]
     }
   } else if (is_win) {
     deps = []

--- a/shell/platform/common/cpp/BUILD.gn
+++ b/shell/platform/common/cpp/BUILD.gn
@@ -68,7 +68,7 @@ source_set("common_cpp") {
   deps = [
     ":common_cpp_library_headers",
     "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
-    "//flutter/shell/platform/embedder:embedder_as_internal_library",
+    # "//flutter/shell/platform/embedder:embedder_as_internal_library",
   ]
 
   public_deps = [

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -5,24 +5,18 @@
 assert(is_linux)
 
 import("//flutter/shell/platform/glfw/config.gni")
-import("//flutter/shell/platform/tizen/config.gni")
 import("//flutter/testing/testing.gni")
 
 group("linux") {
-  deps = []
-
+  deps = [
+    ":flutter_linux_gtk",
+    ":publish_headers_linux",
+  ]
   if (build_glfw_shell) {
     deps += [
       ":flutter_linux_glfw",
       "//flutter/shell/platform/glfw:publish_headers_glfw",
       "//flutter/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
-    ]
-  }
-
-  if (build_tizen_shell) {
-    deps += [
-      ":flutter_linux_tizen",
-      "//flutter/shell/platform/tizen:publish_headers_tizen",
     ]
   }
 }
@@ -40,16 +34,6 @@ config("disable_fatal_link_warnings") {
 if (build_glfw_shell) {
   shared_library("flutter_linux_glfw") {
     deps = [ "//flutter/shell/platform/glfw:flutter_glfw" ]
-
-    configs += [ ":disable_fatal_link_warnings" ]
-
-    public_configs = [ "//flutter:config" ]
-  }
-}
-
-if (build_tizen_shell) {
-  shared_library("flutter_linux_tizen") {
-    deps = [ "//flutter/shell/platform/tizen:flutter_tizen" ]
 
     configs += [ ":disable_fatal_link_warnings" ]
 
@@ -87,7 +71,7 @@ config("relative_flutter_linux_headers") {
 source_set("flutter_linux_sources") {
   public = _public_headers
 
-  # configs += [ "//flutter/shell/platform/linux/config:gtk" ]
+  configs += [ "//flutter/shell/platform/linux/config:gtk" ]
 
   sources = [
     "egl_utils.cc",
@@ -131,8 +115,8 @@ source_set("flutter_linux_sources") {
 
 source_set("flutter_linux") {
   configs += [
-    # "//flutter/shell/platform/linux/config:gtk",
-    # "//flutter/shell/platform/linux/config:egl",
+    "//flutter/shell/platform/linux/config:gtk",
+    "//flutter/shell/platform/linux/config:egl",
     "//third_party/khronos:khronos_headers",
   ]
 
@@ -172,7 +156,7 @@ executable("flutter_linux_unittests") {
 
   public_configs = [ "//flutter:config" ]
 
-  # configs += [ "//flutter/shell/platform/linux/config:gtk" ]
+  configs += [ "//flutter/shell/platform/linux/config:gtk" ]
 
   # Set flag to allow public headers to be directly included (library users should not do this)
   defines = [ "FLUTTER_LINUX_COMPILATION" ]

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -4,20 +4,26 @@
 # found in the LICENSE file.
 import("//flutter/shell/platform/tizen/config.gni")
 
-_public_headers = [ "public/flutter_tizen.h" ]
-
-# Any files that are built by clients (client_wrapper code, library headers for
-# implementations using this shared code, etc.) include the public headers
-# assuming they are in the include path. This configuration should be added to
-# any such code that is also built by GN to make the includes work.
-config("relative_flutter_tizen_headers") {
-  include_dirs = [ "public" ]
+group("tizen") {
+  deps = [ ":flutter_tizen_library" ]
 }
 
-# The headers are a separate source set since the client wrapper is allowed
-# to depend on the public headers, but none of the rest of the code.
+shared_library("flutter_tizen_library") {
+  output_name = "flutter_tizen"
+
+  ldflags = [ "-Wl,-rpath,\$ORIGIN" ]
+
+  deps = [ ":flutter_tizen" ]
+
+  public_configs = [ "//flutter:config" ]
+}
+
 source_set("flutter_tizen_headers") {
-  public = _public_headers
+  public = [
+    "public/flutter_platform_view.h",
+    "public/flutter_texture_registrar.h",
+    "public/flutter_tizen.h",
+  ]
 
   public_deps =
       [ "//flutter/shell/platform/common/cpp:common_cpp_library_headers" ]
@@ -57,7 +63,7 @@ source_set("flutter_tizen") {
     "//flutter/shell/platform/common/cpp:common_cpp",
     "//flutter/shell/platform/common/cpp:common_cpp_input",
     "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
-    "//flutter/shell/platform/embedder:embedder_as_internal_library",
+    "//flutter/shell/platform/embedder:flutter_engine",
     "//third_party/rapidjson",
   ]
 
@@ -83,7 +89,7 @@ source_set("flutter_tizen") {
     "$custom_sysroot/usr/include/wayland-extension"
   ]
   
-  lib_dirs = [ "$custom_sysroot/usr/lib" ]
+  lib_dirs = [ root_out_dir, "$custom_sysroot/usr/lib" ]
 
   cflags_cc = [
     "-Wno-newline-eof",
@@ -101,6 +107,7 @@ source_set("flutter_tizen") {
     "ecore_input",
     "EGL",
     "evas",
+    "flutter_engine",
     "GLESv2",
     "tbm",
     "tdm-client",
@@ -115,12 +122,4 @@ source_set("flutter_tizen") {
     sources += [ "tizen_renderer_ecore_wl2.cc" ]
     libs += [ "ecore_wl2" ]
   }
-}
-
-copy("publish_headers_tizen") {
-  sources = _public_headers
-  outputs = [ "$root_out_dir/{{source_file_part}}" ]
-
-  # The Tizen header assumes the presence of the common headers.
-  deps = [ "//flutter/shell/platform/common/cpp:publish_headers" ]
 }


### PR DESCRIPTION
- `libflutter_linux_tizen.so` is splitted into `libflutter_engine.so` and `libflutter_tizen.so`
  - Create `tizen` group
  - Directly configure Tizen build from `platform/BUILD.gn`
  - Revert any changes to `platform/linux/BUILD.gn`
  - Comment out `embedder_as_internal_library` dependency from `common_cpp` source set
  - Do not publish headers
- Update the CI script to copy `libflutter_tizen40.so`

Note: You now have to set `--disable-desktop-embeddings` flag to disable builds for linux desktop embedding.