### PR TITLE
Embed ICU data in the engine

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,9 +83,6 @@ jobs:
       cp default/out/linux_$(mode)_$(arch)/libflutter_tizen.so $OUTDIR
       cp tizen40/out/linux_$(mode)_$(arch)/libflutter_tizen.so $OUTDIR/libflutter_tizen40.so
       cp tizen40/out/linux_$(mode)_$(arch)/libflutter_engine.so $OUTDIR
-      if [ "$(System.JobName)" = "tizen-arm-release" ]; then
-        cp default/out/linux_$(mode)_$(arch)/icudtl.dat $OUTDIR
-      fi
     displayName: Copy artifacts
     workingDirectory: $(buildroot)/output
     failOnStderr: true
@@ -120,7 +117,6 @@ jobs:
     failOnStderr: true
   - bash: |
       mv $(Pipeline.Workspace)/tizen-* .
-      mv tizen-arm-release/icudtl.dat common
       for platform in linux windows darwin; do
         for mode in release profile; do
           curl -o tmp.zip https://storage.googleapis.com/flutter_infra/flutter/$(upstreamVersion)/android-arm-$mode/$platform-x64.zip 2> /dev/null

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -165,6 +165,29 @@ if (current_toolchain == host_toolchain) {
   }
 }
 
+action("icudtl_object") {
+  script = "//flutter/sky/tools/objcopy.py"
+
+  objcopy = "$custom_toolchain/bin/$custom_target_triple-objcopy"
+  icudtl_input = "//third_party/icu/flutter/icudtl.dat"
+  icudtl_output = "$root_build_dir/flutter_icu/icudtl.o"
+
+  inputs = [ "$icudtl_input" ]
+
+  outputs = [ "$icudtl_output" ]
+
+  args = [
+    "--objcopy",
+    rebase_path(objcopy),
+    "--input",
+    rebase_path(icudtl_input),
+    "--output",
+    rebase_path(icudtl_output),
+    "--arch",
+    current_cpu,
+  ]
+}
+
 shared_library("flutter_engine_library") {
   visibility = [ ":*" ]
 
@@ -174,7 +197,9 @@ shared_library("flutter_engine_library") {
     ldflags = [ "-Wl,-install_name,@rpath/FlutterEmbedder.framework/$_framework_binary_subpath" ]
   }
 
-  deps = [ ":embedder" ]
+  sources = [ "$root_build_dir/flutter_icu/icudtl.o" ]
+
+  deps = [ ":embedder", ":icudtl_object" ]
 
   public_configs = [ "//flutter:config" ]
 }


### PR DESCRIPTION
This reduces the total app size by 10 MB. The original ICU data size is 11 MB (`icudtl.dat`) and it's 0.9 MB (`icudtl.o`) after object copy.

The `icudtl_object` action was copied from `//shell/platform/android/BUILD.gn`.