### PR TITLE
Convert timestamp to correct unit

### DIFF
--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -65,7 +65,7 @@ void TouchEventHandler::SendFlutterPointerEvent(FlutterPointerPhase phase,
   }
   event.scroll_delta_x = scroll_delta_x;
   event.scroll_delta_y = scroll_delta_y;
-  event.timestamp = timestamp / 1000;
+  event.timestamp = timestamp * 1000;
   FlutterEngineSendPointerEvent(engine_->flutter_engine, &event, 1);
 }
 


### PR DESCRIPTION
The correct timestamp unit to send to the Flutter Engine is in microseconds.
Fixing this allows running the correct `ScrollPhysics` logic. (inertia/kinetic scrolling)