### PR TITLE
Improve text input

### DIFF
--- a/shell/platform/tizen/tizen_embedder_engine.h
+++ b/shell/platform/tizen/tizen_embedder_engine.h
@@ -64,6 +64,8 @@ struct FlutterTextureRegistrar {
 
 using UniqueAotDataPtr = std::unique_ptr<_FlutterEngineAOTData, AOTDataDeleter>;
 
+enum DeviceProfile { kUnknown, kMobile, kWearable, kTV };
+
 // Manages state associated with the underlying FlutterEngine.
 class TizenEmbedderEngine : public TizenRenderer::Delegate {
  public:
@@ -111,7 +113,7 @@ class TizenEmbedderEngine : public TizenRenderer::Delegate {
   std::unique_ptr<TextInputChannel> text_input_channel;
   std::unique_ptr<PlatformViewChannel> platform_view_channel;
 
-  const std::string device_profile;
+  const DeviceProfile device_profile;
   const double device_dpi;
 
  private:

--- a/shell/platform/tizen/tizen_log.h
+++ b/shell/platform/tizen/tizen_log.h
@@ -64,6 +64,6 @@ void StartLogging();
 #define FT_COMPILE_ASSERT(exp, name) static_assert((exp), #name)
 #endif
 
-#define FT_LOGD_UNIMPLEMENTED() FT_LOGD("UNIMPLEMENTED")
+#define FT_UNIMPLEMENTED() FT_LOGD("UNIMPLEMENTED!")
 
 #endif  // EMBEDDER_TIZEN_LOG_H_


### PR DESCRIPTION
* Improve inputting Korean
* Improve log to be useful for development
* Improve the readability of filter event
* Set more status to edit text properly
* Delete preedit text more appropriately
* Add DeviceProfile
* Removed the resizing code that was blocked for a while
  Please re-implement it, when the problem is fully identified
  and solved. See #28 for more details

When using ecore-imf, disappointingly, The behavior of
several factors related to text input in each device profile
is different(such as key-event, calling callbacks for imf).
So I've fine-tuned it, but this may not be the best.
Maybe it's better to separate it by profile in the future.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>
