### PR TITLE
Update TextInputChannel to supprot platform view

### DIFF
--- a/shell/platform/tizen/channels/platform_view_channel.cc
+++ b/shell/platform/tizen/channels/platform_view_channel.cc
@@ -108,6 +108,23 @@ void PlatformViewChannel::SendKeyEvent(Ecore_Event_Key* key, bool is_down) {
   }
 }
 
+void PlatformViewChannel::DispatchCompositionUpdateEvent(
+    const std::string& key) {
+  auto instances = ViewInstances();
+  auto it = instances.find(CurrentFocusedViewId());
+  if (it != instances.end()) {
+    it->second->DispatchCompositionUpdateEvent(key.c_str(), key.size());
+  }
+}
+
+void PlatformViewChannel::DispatchCompositionEndEvent(const std::string& key) {
+  auto instances = ViewInstances();
+  auto it = instances.find(CurrentFocusedViewId());
+  if (it != instances.end()) {
+    it->second->DispatchCompositionEndEvent(key.c_str(), key.size());
+  }
+}
+
 int PlatformViewChannel::CurrentFocusedViewId() {
   for (auto it = view_instances_.begin(); it != view_instances_.end(); it++) {
     if (it->second->IsFocused()) {

--- a/shell/platform/tizen/channels/platform_view_channel.h
+++ b/shell/platform/tizen/channels/platform_view_channel.h
@@ -30,6 +30,9 @@ class PlatformViewChannel {
   void SendKeyEvent(Ecore_Event_Key* key, bool is_down);
   int CurrentFocusedViewId();
 
+  void DispatchCompositionUpdateEvent(const std::string& key);
+  void DispatchCompositionEndEvent(const std::string& key);
+
  private:
   TizenEmbedderEngine* engine_;
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;

--- a/shell/platform/tizen/channels/text_input_channel.h
+++ b/shell/platform/tizen/channels/text_input_channel.h
@@ -29,9 +29,13 @@ class TextInputChannel {
   void OnKeyDown(Ecore_Event_Key* key);
   void OnCommit(std::string str);
   void OnPreedit(std::string str, int cursor_pos);
+  void OnPreeditForPlatformView(std::string str, int cursor_pos);
+
   void ShowSoftwareKeyboard();
   void HideSoftwareKeyboard();
   bool IsSoftwareKeyboardShowing() { return is_software_keyboard_showing_; }
+  void SetSoftwareKeyboardShowing() { is_software_keyboard_showing_ = true; }
+
   void SetEditStatus(EditStatus edit_status);
   SoftwareKeyboardGeometry GetCurrentKeyboardGeometry() {
     return current_keyboard_geometry_;

--- a/shell/platform/tizen/key_event_handler.cc
+++ b/shell/platform/tizen/key_event_handler.cc
@@ -46,9 +46,6 @@ Eina_Bool KeyEventHandler::OnKey(void *data, int type, void *event) {
     if (engine->key_event_channel) {
       engine->key_event_channel->SendKeyEvent(key, is_down);
     }
-    if (engine->platform_view_channel) {
-      engine->platform_view_channel->SendKeyEvent(key, is_down);
-    }
   }
   return ECORE_CALLBACK_PASS_ON;
 }

--- a/shell/platform/tizen/public/flutter_platform_view.h
+++ b/shell/platform/tizen/public/flutter_platform_view.h
@@ -38,6 +38,8 @@ class PlatformView {
   // Key input event
   virtual void DispatchKeyDownEvent(Ecore_Event_Key* key) = 0;
   virtual void DispatchKeyUpEvent(Ecore_Event_Key* key) = 0;
+  virtual void DispatchCompositionUpdateEvent(const char* str, int size) = 0;
+  virtual void DispatchCompositionEndEvent(const char* str, int size) = 0;
 
   virtual void SetSoftwareKeyboardContext(Ecore_IMF_Context* context) = 0;
 


### PR DESCRIPTION
* Current the text input channel handles user input for only existing flutter components.
  Therefore, we added the logic so that the platform view can also handle the composition
  events happened by user input.