### PR TITLE
Fix a preedit text bug

### DIFF
--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -595,10 +595,9 @@ void TextInputChannel::OnPreedit(std::string str, int cursor_pos) {
 
   have_preedit_ = false;
   if (edit_status_ == EditStatus::kPreeditStart) {
-    TextRange selection = active_model_->selection();
-    preedit_start_pos_ = selection.base();
+    preedit_start_pos_ = active_model_->selection().base();
     active_model_->AddText(str);
-    preedit_end_pos_ = selection.base();
+    preedit_end_pos_ = active_model_->selection().base();
     have_preedit_ = true;
     SendStateUpdate(*active_model_);
     FT_LOGD("preedit start pos[%d], preedit end pos[%d]", preedit_start_pos_,


### PR DESCRIPTION
* The return value of TextInputModel::selection is not a reference

Signed-off-by: Boram Bae <boram21.bae@samsung.com>
