### PR TITLE
Remove FlutterWindowProperties and get the screen size automatically

### DIFF
--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -21,12 +21,11 @@ struct FlutterWindowControllerState {
 };
 
 FlutterWindowControllerRef FlutterCreateWindow(
-    const FlutterWindowProperties& window_properties,
     const FlutterEngineProperties& engine_properties) {
   StartLogging();
 
   auto state = std::make_unique<FlutterWindowControllerState>();
-  state->engine = std::make_unique<TizenEmbedderEngine>(window_properties);
+  state->engine = std::make_unique<TizenEmbedderEngine>();
 
   if (!state->engine->RunEngine(engine_properties)) {
     FT_LOGE("Failed to run the Flutter engine.");

--- a/shell/platform/tizen/public/flutter_tizen.h
+++ b/shell/platform/tizen/public/flutter_tizen.h
@@ -20,18 +20,6 @@ extern "C" {
 // Opaque reference to a Flutter window controller.
 typedef struct FlutterWindowControllerState* FlutterWindowControllerRef;
 
-// Properties for configuring the initial settings of a Flutter window.
-typedef struct {
-  // The display title.
-  const char* title;
-  int32_t x;
-  int32_t y;
-  // Width in screen coordinates.
-  int32_t width;
-  // Height in screen coordinates.
-  int32_t height;
-} FlutterWindowProperties;
-
 // Properties for configuring a Flutter engine instance.
 typedef struct {
   // The path to the flutter_assets folder for the application to be run.
@@ -50,8 +38,7 @@ typedef struct {
 } FlutterEngineProperties;
 
 FLUTTER_EXPORT FlutterWindowControllerRef
-FlutterCreateWindow(const FlutterWindowProperties& window_properties,
-                    const FlutterEngineProperties& engine_properties);
+FlutterCreateWindow(const FlutterEngineProperties& engine_properties);
 
 // Returns the plugin registrar handle for the plugin with the given name.
 //

--- a/shell/platform/tizen/tizen_embedder_engine.h
+++ b/shell/platform/tizen/tizen_embedder_engine.h
@@ -69,8 +69,7 @@ enum DeviceProfile { kUnknown, kMobile, kWearable, kTV, kCommon };
 // Manages state associated with the underlying FlutterEngine.
 class TizenEmbedderEngine : public TizenRenderer::Delegate {
  public:
-  explicit TizenEmbedderEngine(
-      const FlutterWindowProperties& window_properties);
+  explicit TizenEmbedderEngine();
   virtual ~TizenEmbedderEngine();
   bool RunEngine(const FlutterEngineProperties& engine_properties);
   bool StopEngine();
@@ -114,7 +113,6 @@ class TizenEmbedderEngine : public TizenRenderer::Delegate {
   std::unique_ptr<PlatformViewChannel> platform_view_channel;
 
   const DeviceProfile device_profile;
-  const double device_dpi;
 
  private:
   static bool MakeContextCurrent(void* user_data);

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -30,6 +30,7 @@ class TizenRenderer {
   virtual void* OnProcResolver(const char* name) = 0;
 
   virtual TizenWindowGeometry GetGeometry() = 0;
+  virtual int32_t GetDpi() = 0;
   virtual uintptr_t GetWindowId() = 0;
 
   virtual void SetRotate(int angle) = 0;

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -13,8 +13,7 @@
 
 class TizenRendererEcoreWl2 : public TizenRenderer {
  public:
-  explicit TizenRendererEcoreWl2(TizenRenderer::Delegate &delegate, int32_t x,
-                                 int32_t y, int32_t w, int32_t h);
+  explicit TizenRendererEcoreWl2(TizenRenderer::Delegate &delegate);
   virtual ~TizenRendererEcoreWl2();
 
   bool OnMakeCurrent() override;
@@ -25,6 +24,7 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   void *OnProcResolver(const char *name) override;
 
   TizenWindowGeometry GetGeometry() override;
+  int32_t GetDpi() override;
   uintptr_t GetWindowId() override;
 
   void ResizeWithRotation(int32_t x, int32_t y, int32_t width, int32_t height,
@@ -32,13 +32,13 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   void SetRotate(int angle) override;
 
  private:
-  bool InitializeRenderer(int32_t x, int32_t y, int32_t w, int32_t h);
+  bool InitializeRenderer();
   void Show();
   void DestroyRenderer();
 
-  bool SetupDisplay();
-  bool SetupEcoreWlWindow(int32_t x, int32_t y, int32_t w, int32_t h);
-  bool SetupEglWindow(int32_t w, int32_t h);
+  bool SetupDisplay(int32_t &width, int32_t &height);
+  bool SetupEcoreWlWindow(int32_t width, int32_t height);
+  bool SetupEglWindow(int32_t width, int32_t height);
   EGLDisplay GetEGLDisplay();
   EGLNativeWindowType GetEGLNativeWindowType();
   void DestroyEglWindow();

--- a/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -14,8 +14,7 @@
 
 class TizenRendererEvasGL : public TizenRenderer {
  public:
-  explicit TizenRendererEvasGL(TizenRenderer::Delegate& delegate, int32_t x,
-                               int32_t y, int32_t w, int32_t h);
+  explicit TizenRendererEvasGL(TizenRenderer::Delegate& delegate);
   virtual ~TizenRendererEvasGL();
 
   bool OnMakeCurrent() override;
@@ -26,6 +25,7 @@ class TizenRendererEvasGL : public TizenRenderer {
   void* OnProcResolver(const char* name) override;
 
   TizenWindowGeometry GetGeometry() override;
+  int32_t GetDpi() override;
   uintptr_t GetWindowId() override;
 
   void ResizeWithRotation(int32_t x, int32_t y, int32_t width, int32_t height,
@@ -37,12 +37,12 @@ class TizenRendererEvasGL : public TizenRenderer {
  private:
   void ClearColor(float r, float g, float b, float a);
 
-  bool InitializeRenderer(int32_t x, int32_t y, int32_t w, int32_t h);
+  bool InitializeRenderer();
   void Show();
   void DestroyRenderer();
 
-  bool SetupEvasGL(int32_t x, int32_t y, int32_t w, int32_t h);
-  void* SetupEvasWindow(int32_t x, int32_t y, int32_t w, int32_t h);
+  bool SetupEvasGL();
+  void* SetupEvasWindow(int32_t& width, int32_t& height);
   void DestroyEvasGL();
   void DestroyEvasWindow();
 


### PR DESCRIPTION
The screen width/height/dpi values returned by the system_info API
are just pre-defined values and do not represent the actual
properties of the display. The correct values can be only obtained
after ecore_wl2_display is created.

Fixes https://github.com/flutter-tizen/flutter-tizen/issues/83 (screen size issue).

The target branch of this PR should be changed after https://github.com/flutter-tizen/engine/pull/67 is merged.