### PR TITLE
[HapticFeedback] Implement vibrate()

### DIFF
--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -55,6 +55,7 @@ config("tizen_rootstrap_include_dirs") {
     "$custom_sysroot/usr/include/feedback",
     "$custom_sysroot/usr/include/system",
     "$custom_sysroot/usr/include/wayland-extension",
+
     # For Evas_GL.
     "$custom_sysroot/usr/include/ecore-con-1",
     "$custom_sysroot/usr/include/ecore-file-1",
@@ -77,6 +78,8 @@ config("tizen_rootstrap_include_dirs") {
 # otherwise the Ecore_Wl2 renderer is used.
 template("embedder_for_profile") {
   forward_variables_from(invoker, [ "use_evas_gl_renderer" ])
+
+  profile = target_name
 
   if (!defined(use_evas_gl_renderer)) {
     use_evas_gl_renderer = false
@@ -122,17 +125,17 @@ template("embedder_for_profile") {
       "wayland-client",
     ]
 
-    if (target_name == "mobile") {
+    if (profile == "mobile") {
       libs += [
         "capi-base-common",
-        "feedback"
+        "feedback",
       ]
     }
 
-    if (target_name == "wearable") {
+    if (profile == "wearable") {
       libs += [
         "capi-base-common",
-        "feedback"
+        "feedback",
       ]
     }
 

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -52,6 +52,7 @@ config("tizen_rootstrap_include_dirs") {
     "$custom_sysroot/usr/include/emile-1",
     "$custom_sysroot/usr/include/eo-1",
     "$custom_sysroot/usr/include/evas-1",
+    "$custom_sysroot/usr/include/feedback",
     "$custom_sysroot/usr/include/system",
     "$custom_sysroot/usr/include/wayland-extension",
     # For Evas_GL.
@@ -64,7 +65,6 @@ config("tizen_rootstrap_include_dirs") {
     "$custom_sysroot/usr/include/elementary-1",
     "$custom_sysroot/usr/include/ethumb-1",
     "$custom_sysroot/usr/include/ethumb-client-1",
-    "$custom_sysroot/usr/include/feedback"
   ]
 
   lib_dirs = [ "$custom_sysroot/usr/lib" ]

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -64,6 +64,7 @@ config("tizen_rootstrap_include_dirs") {
     "$custom_sysroot/usr/include/elementary-1",
     "$custom_sysroot/usr/include/ethumb-1",
     "$custom_sysroot/usr/include/ethumb-client-1",
+    "$custom_sysroot/usr/include/feedback"
   ]
 
   lib_dirs = [ "$custom_sysroot/usr/lib" ]
@@ -120,6 +121,20 @@ template("embedder_for_profile") {
       "tdm-client",
       "wayland-client",
     ]
+
+    if (target_name == "mobile") {
+      libs += [
+        "capi-base-common",
+        "feedback"
+      ]
+    }
+
+    if (target_name == "wearable") {
+      libs += [
+        "capi-base-common",
+        "feedback"
+      ]
+    }
 
     defines = invoker.defines
 

--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -12,7 +12,7 @@
 
 static constexpr char kChannelName[] = "flutter/platform";
 
-#if defined(MOBILE) || defined(WEARABLE)
+#if defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
 static constexpr char kUnsupportedHapticFeedbackError[] =
     "HapticFeedback.vibrate() is not supported";
 static constexpr char kPermissionDeniedHapticFeedbackError[] =
@@ -21,7 +21,7 @@ static constexpr char kPermissionDeniedHapticFeedbackError[] =
     "to use this method";
 static constexpr char kUnknownHapticFeedbackError[] =
     "An unknown error on HapticFeedback.vibrate()";
-#endif
+#endif // defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
 
 PlatformChannel::PlatformChannel(flutter::BinaryMessenger* messenger)
     : channel_(std::make_unique<flutter::MethodChannel<rapidjson::Document>>(
@@ -36,7 +36,7 @@ PlatformChannel::PlatformChannel(flutter::BinaryMessenger* messenger)
 
 PlatformChannel::~PlatformChannel() {}
 
-#if defined(MOBILE) || defined(WEARABLE)
+#if defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
 namespace {
 
 class FeedbackManager {
@@ -132,7 +132,7 @@ class FeedbackManager {
 };
 
 }  //  namespace
-#endif
+#endif // defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
 
 void PlatformChannel::HandleMethodCall(
     const flutter::MethodCall<rapidjson::Document>& call,
@@ -147,7 +147,7 @@ void PlatformChannel::HandleMethodCall(
   } else if (method == "HapticFeedback.vibrate") {
     FT_LOGD("HapticFeedback.vibrate() call received");
 
-#if defined(MOBILE) || defined(WEARABLE)
+#if defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
     auto ret = FeedbackManager::GetInstance().Vibrate();
     if (FeedbackManager::ResultCode::OK == ret) {
       result->Success();
@@ -164,7 +164,7 @@ void PlatformChannel::HandleMethodCall(
     }
 #else
     result->NotImplemented();
-#endif
+#endif // defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
   } else if (method == "Clipboard.getData") {
     result->NotImplemented();
   } else if (method == "Clipboard.setData") {

--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -12,17 +12,6 @@
 
 static constexpr char kChannelName[] = "flutter/platform";
 
-#if defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
-static constexpr char kUnsupportedHapticFeedbackError[] =
-    "HapticFeedback.vibrate() is not supported";
-static constexpr char kPermissionDeniedHapticFeedbackError[] =
-    "No permission to run HapticFeedback.vibrate(). Add "
-    "\"http://tizen.org/privilege/feedback\" privilege to tizen-manifest.xml "
-    "to use this method";
-static constexpr char kUnknownHapticFeedbackError[] =
-    "An unknown error on HapticFeedback.vibrate()";
-#endif // defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
-
 PlatformChannel::PlatformChannel(flutter::BinaryMessenger* messenger)
     : channel_(std::make_unique<flutter::MethodChannel<rapidjson::Document>>(
           messenger, kChannelName, &flutter::JsonMethodCodec::GetInstance())) {
@@ -42,10 +31,10 @@ namespace {
 class FeedbackManager {
  public:
   enum class ResultCode {
-    OK,
-    NOT_SUPPORTED_ERROR,
-    PERMISSION_DENIED_ERROR,
-    UNKNOWN_ERROR
+    kOk,
+    kNotSupportedError,
+    kPermissionDeniedError,
+    kUnknownError
   };
 
   static FeedbackManager& GetInstance() {
@@ -65,26 +54,58 @@ class FeedbackManager {
       FT_LOGD(
           "Cannot run Vibrate(): FeedbackManager.properly_initialized_ is "
           "false");
-      return ResultCode::UNKNOWN_ERROR;
+      return ResultCode::kUnknownError;
+    }
+
+    if (!permission_granted_) {
+      FT_LOGD("Cannot run Vibrate(): permission denied");
+      return ResultCode::kPermissionDeniedError;
     }
 
     if (!vibration_supported_) {
       FT_LOGD("HapticFeedback.Vibrate() is not supported");
-      return ResultCode::NOT_SUPPORTED_ERROR;
+      return ResultCode::kNotSupportedError;
     }
 
     auto ret =
         feedback_play_type(FEEDBACK_TYPE_VIBRATION, FEEDBACK_PATTERN_SIP);
-    FT_LOGD("feedback_play_type() returned: [%d] (%s)", ret,
-            get_error_message(ret));
     if (FEEDBACK_ERROR_NONE == ret) {
-      return ResultCode::OK;
-    } else if (FEEDBACK_ERROR_PERMISSION_DENIED == ret) {
-      return ResultCode::UNKNOWN_ERROR;
+      FT_LOGD("feedback_play_type() succeeded");
+      return ResultCode::kOk;
+    }
+
+    FT_LOGD("feedback_play_type() failed with error: [%d] (%s)", ret,
+            get_error_message(ret));
+
+    if (FEEDBACK_ERROR_PERMISSION_DENIED == ret) {
+      permission_granted_ = false;
+      return ResultCode::kPermissionDeniedError;
     } else if (FEEDBACK_ERROR_NOT_SUPPORTED) {
-      return ResultCode::NOT_SUPPORTED_ERROR;
+      return ResultCode::kNotSupportedError;
     } else {
-      return ResultCode::UNKNOWN_ERROR;
+      return ResultCode::kUnknownError;
+    }
+  }
+
+  static std::string GetErrorMessage(const std::string& method_name,
+                                     ResultCode result_code) {
+    FT_LOGD(
+        "Enter FeedbackManager::GetErrorMessage(): method_name: (%s), "
+        "result_code: [%d]",
+        method_name.c_str(), static_cast<int>(result_code));
+
+    switch (result_code) {
+      case ResultCode::kNotSupportedError:
+        return method_name + "() is not supported";
+      case ResultCode::kPermissionDeniedError:
+        return std::string{"No permission to run "} + method_name +
+               "(). Add "
+               "\"http://tizen.org/privilege/feedback\" privilege to "
+               "tizen-manifest.xml "
+               "to use this method";
+      case ResultCode::kUnknownError:
+      default:
+        return std::string{"An unknown error on "} + method_name + "()";
     }
   }
 
@@ -103,12 +124,18 @@ class FeedbackManager {
 
     ret = feedback_is_supported_pattern(
         FEEDBACK_TYPE_VIBRATION, FEEDBACK_PATTERN_SIP, &vibration_supported_);
-    if (FEEDBACK_ERROR_NONE != ret) {
-      FT_LOGD("feedback_is_supported_pattern() failed with error: [%d] (%s)",
-              ret, get_error_message(ret));
+    if (FEEDBACK_ERROR_NONE == ret) {
+      FT_LOGD("feedback_is_supported_pattern() succeeded");
       return;
     }
-    FT_LOGD("feedback_is_supported_pattern() succeeded");
+
+    FT_LOGD("feedback_is_supported_pattern() failed with error: [%d] (%s)", ret,
+            get_error_message(ret));
+    if (FEEDBACK_ERROR_PERMISSION_DENIED == ret) {
+      permission_granted_ = false;
+    } else if (FEEDBACK_ERROR_NONE != ret) {
+      return;
+    }
   }
 
   ~FeedbackManager() {
@@ -128,11 +155,16 @@ class FeedbackManager {
   }
 
   bool properly_initialized_ = false;
+  /*
+   * We need this flag to differentiate between feedback_is_supported_pattern()
+   * failure due to a missing privilege and other causes.
+   */
+  bool permission_granted_ = true;
   bool vibration_supported_ = false;
 };
 
 }  //  namespace
-#endif // defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
+#endif  // defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
 
 void PlatformChannel::HandleMethodCall(
     const flutter::MethodCall<rapidjson::Document>& call,
@@ -147,24 +179,35 @@ void PlatformChannel::HandleMethodCall(
   } else if (method == "HapticFeedback.vibrate") {
     FT_LOGD("HapticFeedback.vibrate() call received");
 
+    const std::string error_message = "Could not vibrate";
+
+    const auto vibrate_variant_name = call.arguments()->GetString();
+
 #if defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
+    /*
+     * We use a single type of vibration (FEEDBACK_PATTERN_SIP) to implement
+     * HapticFeedback's vibrate, lightImpact, mediumImpact, heavyImpact
+     * and selectionClick methods, because Tizen's "feedback" module
+     * has no dedicated vibration types for them.
+     * Thus, we ignore the "arguments" contents for "HapticFeedback.vibrate"
+     * calls.
+     */
+
     auto ret = FeedbackManager::GetInstance().Vibrate();
-    if (FeedbackManager::ResultCode::OK == ret) {
+    if (FeedbackManager::ResultCode::kOk == ret) {
       result->Success();
       return;
     }
 
-    const std::string error_message = "Could not vibrate";
-    if (FeedbackManager::ResultCode::NOT_SUPPORTED_ERROR == ret) {
-      result->Error(kUnsupportedHapticFeedbackError, error_message);
-    } else if (FeedbackManager::ResultCode::PERMISSION_DENIED_ERROR == ret) {
-      result->Error(kPermissionDeniedHapticFeedbackError, error_message);
-    } else {
-      result->Error(kUnknownHapticFeedbackError, error_message);
-    }
+    const auto error_cause =
+        FeedbackManager::GetErrorMessage(vibrate_variant_name, ret);
+    FT_LOGE("%s: %s", error_cause.c_str(), error_message.c_str());
+    result->Error(error_cause, error_message);
 #else
-    result->NotImplemented();
-#endif // defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
+    const auto error_cause =
+        std::string{vibrate_variant_name} + "() is not supported";
+    result->Error(error_cause.c_str(), error_message.c_str());
+#endif  // defined(MOBILE_PROFILE) || defined(WEARABLE_PROFILE)
   } else if (method == "Clipboard.getData") {
     result->NotImplemented();
   } else if (method == "Clipboard.setData") {

--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -94,7 +94,7 @@ class FeedbackManager {
     FT_LOGD("Enter FeedbackManager::Vibrate()");
 
     if (ResultCode::kOk != initialization_status_) {
-      FT_LOGD("Cannot run Vibrate(): initialization_status_: [%d]",
+      FT_LOGE("Cannot run Vibrate(): initialization_status_: [%d]",
               static_cast<int>(initialization_status_));
       return initialization_status_;
     }
@@ -105,7 +105,7 @@ class FeedbackManager {
       FT_LOGD("feedback_play_type() succeeded");
       return ResultCode::kOk;
     }
-    FT_LOGD("feedback_play_type() failed with error: [%d] (%s)", ret,
+    FT_LOGE("feedback_play_type() failed with error: [%d] (%s)", ret,
             get_error_message(ret));
 
     return NativeErrorToResultCode(ret);
@@ -136,7 +136,7 @@ class FeedbackManager {
 
     auto ret = feedback_initialize();
     if (FEEDBACK_ERROR_NONE != ret) {
-      FT_LOGD("feedback_initialize() failed with error: [%d] (%s)", ret,
+      FT_LOGE("feedback_initialize() failed with error: [%d] (%s)", ret,
               get_error_message(ret));
       initialization_status_ = NativeErrorToResultCode(ret);
       return;
@@ -151,7 +151,7 @@ class FeedbackManager {
 
     auto ret = feedback_deinitialize();
     if (FEEDBACK_ERROR_NONE != ret) {
-      FT_LOGD("feedback_deinitialize() failed with error: [%d] (%s)", ret,
+      FT_LOGE("feedback_deinitialize() failed with error: [%d] (%s)", ret,
               get_error_message(ret));
       return;
     }


### PR DESCRIPTION
[Before] HapticFeedback.vibrate() was not implemented

[After] The code below will cause a short vibration:

      HapticFeedback.vibrate();

Signed-off-by: Pawel Wasowski <p.wasowski2@samsung.com>


HapticFeedback.vibrate() was one of the features to implement on this list https://github.com/flutter-tizen/engine/issues/53#issue-837284297

Before building with this change, be sure to use tizen_tools with this commit applied: https://github.com/flutter-tizen/tizen_tools/pull/10

The change will only work on devices that support it. I have tested it on a Samsung Z3 (aka TM1) smartphone with Tizen 6.5.
