### PR TITLE
Create fallback font manager to solve performance drops

### DIFF
--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -99,6 +99,7 @@ size_t FontCollection::GetFontManagersCount() const {
 
 void FontCollection::SetupDefaultFontManager() {
   default_font_manager_ = GetDefaultFontManager();
+  fallback_font_manager_ = GetFallbackFontManager();
 }
 
 void FontCollection::SetDefaultFontManager(sk_sp<SkFontMgr> font_manager) {
@@ -144,6 +145,8 @@ std::vector<sk_sp<SkFontMgr>> FontCollection::GetFontManagerOrder() const {
     order.push_back(test_font_manager_);
   if (default_font_manager_)
     order.push_back(default_font_manager_);
+  if (fallback_font_manager_)
+    order.push_back(fallback_font_manager_);
   return order;
 }
 

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -91,6 +91,7 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
   };
 
   sk_sp<SkFontMgr> default_font_manager_;
+  sk_sp<SkFontMgr> fallback_font_manager_;
   sk_sp<SkFontMgr> asset_font_manager_;
   sk_sp<SkFontMgr> dynamic_font_manager_;
   sk_sp<SkFontMgr> test_font_manager_;

--- a/third_party/txt/src/txt/platform.cc
+++ b/third_party/txt/src/txt/platform.cc
@@ -14,4 +14,8 @@ sk_sp<SkFontMgr> GetDefaultFontManager() {
   return SkFontMgr::RefDefault();
 }
 
+sk_sp<SkFontMgr> GetFallbackFontManager() {
+  return nullptr;
+}
+
 }  // namespace txt

--- a/third_party/txt/src/txt/platform.h
+++ b/third_party/txt/src/txt/platform.h
@@ -17,6 +17,8 @@ std::vector<std::string> GetDefaultFontFamilies();
 
 sk_sp<SkFontMgr> GetDefaultFontManager();
 
+sk_sp<SkFontMgr> GetFallbackFontManager();
+
 }  // namespace txt
 
 #endif  // TXT_PLATFORM_H_

--- a/third_party/txt/src/txt/platform_linux.cc
+++ b/third_party/txt/src/txt/platform_linux.cc
@@ -78,7 +78,15 @@ sk_sp<SkFontMgr> GetDefaultFontManager() {
 #ifdef FLUTTER_USE_FONTCONFIG
   return SkFontMgr_New_FontConfig(nullptr);
 #else
-  return SkFontMgr_New_Custom_Directory("/usr/share/");
+  return SkFontMgr_New_Custom_Directory("/usr/share/fonts");
+#endif
+}
+
+sk_sp<SkFontMgr> GetFallbackFontManager() {
+#ifdef FLUTTER_USE_FONTCONFIG
+  return nullptr;
+#else
+  return SkFontMgr_New_Custom_Directory("/usr/share/fallback_fonts");
 #endif
 }
 


### PR DESCRIPTION
Fixes performance drop issue mentioned in https://github.com/flutter-tizen/engine/pull/69#issuecomment-828907075. I should have tested the change before it was merged, sorry about that. Now the engine searches fonts in two subdirecotries: `/usr/share/font` and `/usr/share/fallback_fonts`.

The following table compares the start time of the flutter sample counter app.
||STIME|
|---|---|
|using fontconfig|844|
|searching `/usr/share`|4660|
|searching `/usr/share/font` and `/usr/share/fallback_fonts`|740|

I had to make some changes to the third-party code to solve the performance issue. I admit its not ideal, so I will look for a better solution when I can.