### PR TITLE
[SystemChrome] setPreferredOrientations implementation added

### DIFF
--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -25,7 +25,7 @@ PlatformChannel::PlatformChannel(flutter::BinaryMessenger* messenger,
       });
   // renderer pointer is managed by TizenEmbedderEngine
   // !! can be nullptr in case of service application !!
-  tizen_renderer = renderer;
+  tizen_renderer_ = renderer;
 }
 
 PlatformChannel::~PlatformChannel() {}
@@ -49,7 +49,7 @@ void PlatformChannel::HandleMethodCall(
   } else if (method == "Clipboard.hasStrings") {
     result->NotImplemented();
   } else if (method == "SystemChrome.setPreferredOrientations") {
-    if (tizen_renderer) {
+    if (tizen_renderer_) {
       static const std::string kPortraitUp = "DeviceOrientation.portraitUp";
       static const std::string kPortraitDown = "DeviceOrientation.portraitDown";
       static const std::string kLandscapeLeft =
@@ -79,7 +79,7 @@ void PlatformChannel::HandleMethodCall(
         FT_LOGD("No rotations passed, using default values");
         rotations = {0, 90, 180, 270};
       }
-      tizen_renderer->SetPreferredOrientations(rotations);
+      tizen_renderer_->SetPreferredOrientations(rotations);
       result->Success();
     } else {
       result->Error("Not supported for service applications");

--- a/shell/platform/tizen/channels/platform_channel.h
+++ b/shell/platform/tizen/channels/platform_channel.h
@@ -7,15 +7,18 @@
 
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_channel.h"
+#include "flutter/shell/platform/tizen/tizen_renderer.h"
 #include "rapidjson/document.h"
 
 class PlatformChannel {
  public:
-  explicit PlatformChannel(flutter::BinaryMessenger* messenger);
+  explicit PlatformChannel(flutter::BinaryMessenger* messenger,
+                           TizenRenderer* renderer);
   virtual ~PlatformChannel();
 
  private:
   std::unique_ptr<flutter::MethodChannel<rapidjson::Document>> channel_;
+  TizenRenderer* tizen_renderer;
 
   void HandleMethodCall(
       const flutter::MethodCall<rapidjson::Document>& call,

--- a/shell/platform/tizen/channels/platform_channel.h
+++ b/shell/platform/tizen/channels/platform_channel.h
@@ -18,7 +18,7 @@ class PlatformChannel {
 
  private:
   std::unique_ptr<flutter::MethodChannel<rapidjson::Document>> channel_;
-  TizenRenderer* tizen_renderer;
+  TizenRenderer* tizen_renderer_;
 
   void HandleMethodCall(
       const flutter::MethodCall<rapidjson::Document>& call,

--- a/shell/platform/tizen/tizen_embedder_engine.cc
+++ b/shell/platform/tizen/tizen_embedder_engine.cc
@@ -218,7 +218,7 @@ bool TizenEmbedderEngine::RunEngine(
   navigation_channel = std::make_unique<NavigationChannel>(
       internal_plugin_registrar_->messenger());
   platform_channel = std::make_unique<PlatformChannel>(
-      internal_plugin_registrar_->messenger());
+      internal_plugin_registrar_->messenger(), tizen_renderer.get());
   settings_channel = std::make_unique<SettingsChannel>(
       internal_plugin_registrar_->messenger());
   text_input_channel = std::make_unique<TextInputChannel>(

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -37,7 +37,7 @@ class TizenRenderer {
   virtual void SetRotate(int angle) = 0;
   virtual void ResizeWithRotation(int32_t x, int32_t y, int32_t width,
                                   int32_t height, int32_t degree) = 0;
-  virtual void SetPreferredOrientations(std::vector<int> rotations) = 0;
+  virtual void SetPreferredOrientations(const std::vector<int>& rotations) = 0;
 
  protected:
   explicit TizenRenderer(TizenRenderer::Delegate& delegate);

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -6,6 +6,7 @@
 #define EMBEDDER_TIZEN_RENDERER_H
 
 #include <cstdint>
+#include <vector>
 
 class TizenRenderer {
  public:
@@ -36,6 +37,7 @@ class TizenRenderer {
   virtual void SetRotate(int angle) = 0;
   virtual void ResizeWithRotation(int32_t x, int32_t y, int32_t width,
                                   int32_t height, int32_t degree) = 0;
+  virtual void SetPreferredOrientations(std::vector<int> rotations) = 0;
 
  protected:
   explicit TizenRenderer(TizenRenderer::Delegate& delegate);

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -587,7 +587,7 @@ void TizenRendererEcoreWl2::SendRotationChangeDone() {
 }
 
 void TizenRendererEcoreWl2::SetPreferredOrientations(
-    std::vector<int> rotations) {
+    const std::vector<int> &rotations) {
   ecore_wl2_window_available_rotations_set(ecore_wl2_window_, rotations.data(),
                                            rotations.size());
 }

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -585,3 +585,9 @@ void TizenRendererEcoreWl2::SendRotationChangeDone() {
       ecore_wl2_window_, ecore_wl2_window_rotation_get(ecore_wl2_window_), w,
       h);
 }
+
+void TizenRendererEcoreWl2::SetPreferredOrientations(
+    std::vector<int> rotations) {
+  ecore_wl2_window_available_rotations_set(ecore_wl2_window_, rotations.data(),
+                                           rotations.size());
+}

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -30,7 +30,7 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   void ResizeWithRotation(int32_t x, int32_t y, int32_t width, int32_t height,
                           int32_t angle) override;
   void SetRotate(int angle) override;
-  void SetPreferredOrientations(std::vector<int> rotations) override;
+  void SetPreferredOrientations(const std::vector<int> &rotations) override;
 
  private:
   bool InitializeRenderer();

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -30,6 +30,7 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   void ResizeWithRotation(int32_t x, int32_t y, int32_t width, int32_t height,
                           int32_t angle) override;
   void SetRotate(int angle) override;
+  void SetPreferredOrientations(std::vector<int> rotations) override;
 
  private:
   bool InitializeRenderer();

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -709,3 +709,8 @@ void TizenRendererEvasGL::ResizeWithRotation(int32_t x, int32_t y,
 void TizenRendererEvasGL::SendRotationChangeDone() {
   elm_win_wm_rotation_manual_rotation_done(evas_window_);
 }
+
+void TizenRendererEvasGL::SetPreferredOrientations(std::vector<int> rotations) {
+  elm_win_wm_rotation_available_rotations_set(
+      evas_window_, (const int*)(rotations.data()), rotations.size());
+}

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -710,7 +710,9 @@ void TizenRendererEvasGL::SendRotationChangeDone() {
   elm_win_wm_rotation_manual_rotation_done(evas_window_);
 }
 
-void TizenRendererEvasGL::SetPreferredOrientations(std::vector<int> rotations) {
+void TizenRendererEvasGL::SetPreferredOrientations(
+    const std::vector<int>& rotations) {
   elm_win_wm_rotation_available_rotations_set(
-      evas_window_, (const int*)(rotations.data()), rotations.size());
+      evas_window_, static_cast<const int*>(rotations.data()),
+      rotations.size());
 }

--- a/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -31,6 +31,7 @@ class TizenRendererEvasGL : public TizenRenderer {
   void ResizeWithRotation(int32_t x, int32_t y, int32_t width, int32_t height,
                           int32_t angle) override;
   void SetRotate(int angle) override;
+  void SetPreferredOrientations(std::vector<int> rotations) override;
 
   void* GetImageHandle();
 

--- a/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -31,7 +31,7 @@ class TizenRendererEvasGL : public TizenRenderer {
   void ResizeWithRotation(int32_t x, int32_t y, int32_t width, int32_t height,
                           int32_t angle) override;
   void SetRotate(int angle) override;
-  void SetPreferredOrientations(std::vector<int> rotations) override;
+  void SetPreferredOrientations(const std::vector<int>& rotations) override;
 
   void* GetImageHandle();
 


### PR DESCRIPTION
[Before] not implemented

[After] Using API below allows to narrow some rotations of application UI
e.g.
/// to limit some orientations
List<DeviceOrientation> orientations = [DeviceOrientation.portraitUp, DeviceOrientation.landscapeLeft];
SystemChrome.setPreferredOrientations(orientations).then(
    (value) => print("preferred orientations were set"));

/// to clear previous limitations
List<DeviceOrientation> orientations = [];
SystemChrome.setPreferredOrientations(orientations).then(
    (value) => print("preferred orientations were CLEARED"));

This PR is related to part of https://github.sec.samsung.net/f-project/home/issues/35:

Even though there's no corresponding Tizen system API for locking the app orientation, can't we somehow manage the desired orientation information in the embedder to use with TizenEmbedderEngine::SetWindowOrientation? I think we should investigate this particular method in more details because many apps may want to use a fixed orientation.
