### PR TITLE
Temporary fix for the invalid tbm_surface error

### DIFF
--- a/shell/platform/tizen/external_texture_gl.cc
+++ b/shell/platform/tizen/external_texture_gl.cc
@@ -64,6 +64,9 @@ bool ExternalTextureGL::OnFrameAvailable(tbm_surface_h tbm_surface) {
     return false;
   }
   texture_tbm_surface_ = tbm_surface;
+#ifndef WEARABLE_PROFILE
+  tbm_surface_internal_ref(texture_tbm_surface_);
+#endif
   mutex_.unlock();
   return true;
 }
@@ -173,7 +176,9 @@ void ExternalTextureGL::DestructionTbmSurface() {
     FT_LOGE("tbm_surface_h is NULL");
     return;
   }
-  tbm_surface_destroy(texture_tbm_surface_);
+#ifndef WEARABLE_PROFILE
+  tbm_surface_internal_unref(texture_tbm_surface_);
+#endif
   texture_tbm_surface_ = NULL;
 }
 


### PR DESCRIPTION
This partially reverts the change of #67.

Video frames are not displayed if the ref count is not properly increased (`tbm_surface_internal_ref`).

```
E/TBM     ( 4840): [634776.838197][4903][_tbm_surface_internal_is_valid 269]error: No valid tbm_surface(0xb2a04fb8)
E/TBM     ( 4840): [634776.838288][4903][tbm_surface_internal_get_info 1284]'_tbm_surface_internal_is_valid(surface)' failed.
D/ConsoleMessage( 4840): external_texture_gl.cc: PopulateTextureWithIdentifier(83) > tbm_surface not valid
...(repeats)
```

The internal APIs `tbm_surface_internal_ref` and `tbm_surface_internal_unref` cannot be used in wearable profile so we need a better solution than this change.

@xuelian-bai @xiaowei-guan @bwikbs Could you take a look if you have any idea?

cc @bbrto21