### PR TITLE
Fix a crash in ExternalTextureGL

### DIFF
--- a/shell/platform/tizen/external_texture_gl.cc
+++ b/shell/platform/tizen/external_texture_gl.cc
@@ -71,21 +71,23 @@ ExternalTextureGL::~ExternalTextureGL() {
 bool ExternalTextureGL::OnFrameAvailable(tbm_surface_h tbm_surface) {
   mutex_.lock();
   if (!tbm_surface) {
-    FT_LOGE("tbm_surface is null");
+    FT_LOGE("[texture id:%ld] tbm_surface is null", texture_id_);
     mutex_.unlock();
     return false;
   }
 
   if (available_tbm_surface_) {
     FT_LOGD(
-        "Discard! an available tbm surface that has not yet been used exists");
+        "[texture id:%ld] Discard! an available tbm surface that has not yet "
+        "been used exists",
+        texture_id_);
     mutex_.unlock();
     return false;
   }
 
   tbm_surface_info_s info;
   if (tbm_surface_get_info(tbm_surface, &info) != TBM_SURFACE_ERROR_NONE) {
-    FT_LOGD("tbm_surface not valid, pass");
+    FT_LOGD("[texture id:%ld] tbm_surface not valid, pass", texture_id_);
     mutex_.unlock();
     return false;
   }
@@ -101,14 +103,14 @@ bool ExternalTextureGL::PopulateTextureWithIdentifier(
     size_t width, size_t height, FlutterOpenGLTexture* opengl_texture) {
   mutex_.lock();
   if (!available_tbm_surface_) {
-    FT_LOGD("available_tbm_surface_ is null");
+    FT_LOGD("[texture id:%ld] available_tbm_surface_ is null", texture_id_);
     mutex_.unlock();
     return false;
   }
   tbm_surface_info_s info;
   if (tbm_surface_get_info(available_tbm_surface_, &info) !=
       TBM_SURFACE_ERROR_NONE) {
-    FT_LOGD("tbm_surface is invalid");
+    FT_LOGD("[texture id:%ld] tbm_surface is invalid", texture_id_);
     UnmarkTbmSurfaceToUse(available_tbm_surface_);
     available_tbm_surface_ = nullptr;
     mutex_.unlock();
@@ -153,7 +155,8 @@ bool ExternalTextureGL::PopulateTextureWithIdentifier(
       (EGLClientBuffer)available_tbm_surface_, attribs);
 
   if (!egl_src_image) {
-    FT_LOGE("egl_src_image create fail!!, errorcode == %d", eglGetError());
+    FT_LOGE("[texture id:%ld] egl_src_image create fail!!, errorcode == %d",
+            texture_id_, eglGetError());
     mutex_.unlock();
     return false;
   }
@@ -187,7 +190,7 @@ bool ExternalTextureGL::PopulateTextureWithIdentifier(
   opengl_texture->format = GL_RGBA8;
   opengl_texture->destruction_callback = (VoidCallback)UnmarkTbmSurfaceToUse;
 
-  // Abandon ownership of tmb_surface
+  // Abandon ownership of tbm_surface
   opengl_texture->user_data = available_tbm_surface_;
   available_tbm_surface_ = nullptr;
 

--- a/shell/platform/tizen/external_texture_gl.h
+++ b/shell/platform/tizen/external_texture_gl.h
@@ -41,15 +41,12 @@ class ExternalTextureGL {
   bool PopulateTextureWithIdentifier(size_t width, size_t height,
                                      FlutterOpenGLTexture* opengl_texture);
   bool OnFrameAvailable(tbm_surface_h tbm_surface);
-  void DestructionTbmSurface();
-  void DestructionTbmSurfaceWithLock();
 
  private:
   std::unique_ptr<ExternalTextureGLState> state_;
   std::mutex mutex_;
-  tbm_surface_h texture_tbm_surface_;
-  static void DestructionCallback(void* user_data);
-  const long texture_id_;
+  tbm_surface_h available_tbm_surface_{nullptr};
+  const long texture_id_{0};
 };
 
 #endif  // FLUTTER_SHELL_PLATFORM_TIZEN_EXTERNAL_TEXTURE_GL_H_

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -210,7 +210,7 @@ bool FlutterMarkExternalTextureFrameAvailable(
   }
   if (!texture_registrar->textures[texture_id]->OnFrameAvailable(
           (tbm_surface_h)tbm_surface)) {
-    FT_LOGE("OnFrameAvailable fail texture_id = %" PRId64, texture_id);
+    // If a texture that has not been used already exists, it can fail
     return false;
   }
   return (FlutterEngineMarkExternalTextureFrameAvailable(

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -181,6 +181,7 @@ void FlutterNotifyLowMemoryWarning(FlutterWindowControllerRef controller) {
 int64_t FlutterRegisterExternalTexture(
     FlutterTextureRegistrarRef texture_registrar) {
   FT_LOGD("FlutterDesktopRegisterExternalTexture");
+  std::lock_guard<std::mutex> lock(texture_registrar->mutex);
   auto texture_gl = std::make_unique<ExternalTextureGL>();
   int64_t texture_id = texture_gl->TextureId();
   texture_registrar->textures[texture_id] = std::move(texture_gl);
@@ -193,16 +194,19 @@ int64_t FlutterRegisterExternalTexture(
 
 bool FlutterUnregisterExternalTexture(
     FlutterTextureRegistrarRef texture_registrar, int64_t texture_id) {
+  std::lock_guard<std::mutex> lock(texture_registrar->mutex);
   auto it = texture_registrar->textures.find(texture_id);
   if (it != texture_registrar->textures.end())
     texture_registrar->textures.erase(it);
-  return (FlutterEngineUnregisterExternalTexture(
-              texture_registrar->flutter_engine, texture_id) == kSuccess);
+  bool ret = FlutterEngineUnregisterExternalTexture(
+                 texture_registrar->flutter_engine, texture_id) == kSuccess;
+  return ret;
 }
 
 bool FlutterMarkExternalTextureFrameAvailable(
     FlutterTextureRegistrarRef texture_registrar, int64_t texture_id,
     void* tbm_surface) {
+  std::lock_guard<std::mutex> lock(texture_registrar->mutex);
   auto it = texture_registrar->textures.find(texture_id);
   if (it == texture_registrar->textures.end()) {
     FT_LOGE("can't find texture texture_id = %" PRId64, texture_id);
@@ -213,8 +217,9 @@ bool FlutterMarkExternalTextureFrameAvailable(
     // If a texture that has not been used already exists, it can fail
     return false;
   }
-  return (FlutterEngineMarkExternalTextureFrameAvailable(
-              texture_registrar->flutter_engine, texture_id) == kSuccess);
+  bool ret = FlutterEngineMarkExternalTextureFrameAvailable(
+                 texture_registrar->flutter_engine, texture_id) == kSuccess;
+  return ret;
 }
 
 void FlutterRegisterViewFactory(

--- a/shell/platform/tizen/tizen_embedder_engine.h
+++ b/shell/platform/tizen/tizen_embedder_engine.h
@@ -60,6 +60,7 @@ struct FlutterTextureRegistrar {
 
   // The texture registrar managing external texture adapters.
   std::map<int64_t, std::unique_ptr<ExternalTextureGL>> textures;
+  std::mutex mutex;
 };
 
 using UniqueAotDataPtr = std::unique_ptr<_FlutterEngineAOTData, AOTDataDeleter>;


### PR DESCRIPTION
This PR includes : 
* Fix a crash in ExternalTextureGL db57b57
* Include the texture id in the log 16b80f2
* Lock the mutex in the external texture related API 0747722

Signed-off-by: Boram Bae <boram21.bae@samsung.com>
