### PR TITLE
Fix false error at BasicMessageChannel.send(null)

### DIFF
--- a/shell/platform/common/cpp/client_wrapper/standard_codec.cc
+++ b/shell/platform/common/cpp/client_wrapper/standard_codec.cc
@@ -308,6 +308,9 @@ StandardMessageCodec::~StandardMessageCodec() = default;
 std::unique_ptr<EncodableValue> StandardMessageCodec::DecodeMessageInternal(
     const uint8_t* binary_message,
     size_t message_size) const {
+  if(!binary_message){
+    return std::make_unique<EncodableValue>();
+  }
   ByteBufferStreamReader stream(binary_message, message_size);
   return std::make_unique<EncodableValue>(serializer_->ReadValue(&stream));
 }


### PR DESCRIPTION
Fixes printing misleading error messages mentioned in https://github.com/flutter-tizen/plugins/pull/78#issuecomment-829955872

Currently, calling `BasicMessageChannel.send(null)` from dart side(generally platform interface packages) causes false errors to be triggered in `ByteBufferStreamReader.ReadByte`.

This results in printing misleading error messages in the console. (You can see the error messages in `video_player` and `wakelock` examples).

```
E/ConsoleMessage(30567): Invalid read in StandardCodecByteStreamReader
E/ConsoleMessage(30567): Invalid read in StandardCodecByteStreamReader
...
```

`ByteBufferStreamReader.ReadByte` is indirectly called by `StandardMessageCodec.DecodeMessageInternal`, and in Android, the null value case is checked in a corresponding Java method `StandardMessageCodec.decodeMessage`. I'm pushing a similar patch to match the code logic.

```java
// in platform/android/io/flutter/plugin/common/StandardMessageCodec.java
@Override
public Object decodeMessage(ByteBuffer message) {
  if (message == null) {
    return null;
  }
  message.order(ByteOrder.nativeOrder());
  final Object value = readValue(message);
  if (message.hasRemaining()) {
    throw new IllegalArgumentException("Message corrupted");
  }
  return value;
}
```

As a side note, since Windows platform also exposes the `client_wrapper` to plugins, it has the same problem.

```
# on Windows cmd
Invalid read in StandardCodecByteStreamReader
Invalid read in StandardCodecByteStreamReader
...
```

So maybe this should be fixed in upstream engine? I'm not sure though.