### PR TITLE
Add a format checker to the CI pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ pr:
 - flutter-*-tizen
 
 jobs:
-- job: analyze
+- job: format
   pool:
     name: Default
     demands: agent.os -equals Linux
@@ -18,7 +18,7 @@ jobs:
   - bash: ci/format.sh
     displayName: Verify formatting
 - job: build
-  dependsOn: analyze
+  dependsOn: format
   strategy:
     matrix:
       tizen-arm-release:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,17 @@ pr:
 - flutter-*-tizen
 
 jobs:
+- job: analyze
+  pool:
+    name: Default
+    demands: agent.os -equals Linux
+  steps:
+  - checkout: self
+    path: src/flutter
+  - bash: ci/format.sh
+    displayName: Verify formatting
 - job: build
+  dependsOn: analyze
   strategy:
     matrix:
       tizen-arm-release:

--- a/shell/platform/common/cpp/BUILD.gn
+++ b/shell/platform/common/cpp/BUILD.gn
@@ -110,7 +110,6 @@ source_set("common_cpp") {
   deps = [
     ":common_cpp_library_headers",
     "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
-    # "//flutter/shell/platform/embedder:embedder_as_internal_library",
   ]
 
   public_deps = [

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -267,7 +267,8 @@ shared_library("flutter_engine_library") {
   output_name = "flutter_engine"
 
   # For Tizen 5.5 or older. See the script file for details.
-  ldflags = [ "-Wl,--version-script=" + rebase_path("flutter_engine_exports.lst") ]
+  ldflags =
+      [ "-Wl,--version-script=" + rebase_path("flutter_engine_exports.lst") ]
 
   if (is_mac && !embedder_for_target) {
     ldflags = [ "-Wl,-install_name,@rpath/FlutterEmbedder.framework/$_framework_binary_subpath" ]

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -96,8 +96,8 @@ template("embedder_for_profile") {
       "channels/settings_channel.cc",
       "channels/text_input_channel.cc",
       "external_texture_gl.cc",
-      "flutter_tizen_engine.cc",
       "flutter_tizen.cc",
+      "flutter_tizen_engine.cc",
       "key_event_handler.cc",
       "tizen_event_loop.cc",
       "tizen_log.cc",
@@ -152,7 +152,7 @@ template("embedder_for_profile") {
 
     configs += [
       ":tizen_rootstrap_include_dirs",
-      "//flutter/shell/platform/common/cpp:desktop_library_implementation"
+      "//flutter/shell/platform/common/cpp:desktop_library_implementation",
     ]
 
     public_configs = [ "//flutter:config" ]
@@ -214,12 +214,12 @@ copy("copy_icu") {
 
 group("tizen") {
   deps = [
-    ":flutter_tizen_mobile",
-    ":flutter_tizen_wearable",
-    ":flutter_tizen_tv",
+    ":copy_icu",
     ":flutter_tizen_common",
+    ":flutter_tizen_mobile",
+    ":flutter_tizen_tv",
+    ":flutter_tizen_wearable",
     ":publish_cpp_client_wrapper",
     ":publish_headers_tizen",
-    ":copy_icu",
   ]
 }

--- a/shell/platform/tizen/channels/key_event_channel.cc
+++ b/shell/platform/tizen/channels/key_event_channel.cc
@@ -215,7 +215,8 @@ static const std::map<int, int> kModifierMap = {
 KeyEventChannel::KeyEventChannel(flutter::BinaryMessenger* messenger)
     : channel_(
           std::make_unique<flutter::BasicMessageChannel<rapidjson::Document>>(
-              messenger, kChannelName,
+              messenger,
+              kChannelName,
               &flutter::JsonMessageCodec::GetInstance())) {}
 
 KeyEventChannel::~KeyEventChannel() {}

--- a/shell/platform/tizen/channels/navigation_channel.cc
+++ b/shell/platform/tizen/channels/navigation_channel.cc
@@ -14,7 +14,9 @@ static constexpr char kPopRouteMethod[] = "popRoute";
 
 NavigationChannel::NavigationChannel(flutter::BinaryMessenger* messenger)
     : channel_(std::make_unique<flutter::MethodChannel<rapidjson::Document>>(
-          messenger, kChannelName, &flutter::JsonMethodCodec::GetInstance())) {}
+          messenger,
+          kChannelName,
+          &flutter::JsonMethodCodec::GetInstance())) {}
 
 NavigationChannel::~NavigationChannel() {}
 

--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -17,7 +17,9 @@ static constexpr char kChannelName[] = "flutter/platform";
 PlatformChannel::PlatformChannel(flutter::BinaryMessenger* messenger,
                                  TizenRenderer* renderer)
     : channel_(std::make_unique<flutter::MethodChannel<rapidjson::Document>>(
-          messenger, kChannelName, &flutter::JsonMethodCodec::GetInstance())),
+          messenger,
+          kChannelName,
+          &flutter::JsonMethodCodec::GetInstance())),
       renderer_(renderer) {
   channel_->SetMethodCallHandler(
       [this](
@@ -327,8 +329,7 @@ void GetData(
   document.SetObject();
   rapidjson::Document::AllocatorType& allocator = document.GetAllocator();
   document.AddMember(rapidjson::Value(kTextKey, allocator),
-                      rapidjson::Value(string_clipboard, allocator),
-                      allocator);
+                     rapidjson::Value(string_clipboard, allocator), allocator);
   result->Success(document);
 }
 

--- a/shell/platform/tizen/channels/platform_channel.h
+++ b/shell/platform/tizen/channels/platform_channel.h
@@ -35,6 +35,6 @@ void GetData(
 void SetData(
     const flutter::MethodCall<rapidjson::Document>& call,
     std::unique_ptr<flutter::MethodResult<rapidjson::Document>> result);
-};
+};  // namespace Clipboard
 
 #endif  //  EMBEDDER_PLATFORM_CHANNEL_H_

--- a/shell/platform/tizen/channels/platform_view_channel.cc
+++ b/shell/platform/tizen/channels/platform_view_channel.cc
@@ -30,7 +30,8 @@ int ExtractIntFromMap(const flutter::EncodableValue& arguments,
   if (std::holds_alternative<flutter::EncodableMap>(arguments)) {
     flutter::EncodableMap values = std::get<flutter::EncodableMap>(arguments);
     flutter::EncodableValue value = values[flutter::EncodableValue(key)];
-    if (std::holds_alternative<int>(value)) return std::get<int>(value);
+    if (std::holds_alternative<int>(value))
+      return std::get<int>(value);
   }
   return -1;
 }
@@ -40,13 +41,15 @@ double ExtractDoubleFromMap(const flutter::EncodableValue& arguments,
   if (std::holds_alternative<flutter::EncodableMap>(arguments)) {
     flutter::EncodableMap values = std::get<flutter::EncodableMap>(arguments);
     flutter::EncodableValue value = values[flutter::EncodableValue(key)];
-    if (std::holds_alternative<double>(value)) return std::get<double>(value);
+    if (std::holds_alternative<double>(value))
+      return std::get<double>(value);
   }
   return -1;
 }
 
 flutter::EncodableMap ExtractMapFromMap(
-    const flutter::EncodableValue& arguments, const char* key) {
+    const flutter::EncodableValue& arguments,
+    const char* key) {
   if (std::holds_alternative<flutter::EncodableMap>(arguments)) {
     flutter::EncodableMap values = std::get<flutter::EncodableMap>(arguments);
     flutter::EncodableValue value = values[flutter::EncodableValue(key)];
@@ -57,7 +60,8 @@ flutter::EncodableMap ExtractMapFromMap(
 }
 
 flutter::EncodableList ExtractListFromMap(
-    const flutter::EncodableValue& arguments, const char* key) {
+    const flutter::EncodableValue& arguments,
+    const char* key) {
   if (std::holds_alternative<flutter::EncodableMap>(arguments)) {
     flutter::EncodableMap values = std::get<flutter::EncodableMap>(arguments);
     flutter::EncodableValue value = values[flutter::EncodableValue(key)];
@@ -72,7 +76,8 @@ PlatformViewChannel::PlatformViewChannel(flutter::BinaryMessenger* messenger,
     : engine_(engine),
       channel_(
           std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
-              messenger, kChannelName,
+              messenger,
+              kChannelName,
               &flutter::StandardMethodCodec::GetInstance())) {
   channel_->SetMethodCallHandler(
       [this](const flutter::MethodCall<flutter::EncodableValue>& call,
@@ -80,7 +85,9 @@ PlatformViewChannel::PlatformViewChannel(flutter::BinaryMessenger* messenger,
                  result) { HandleMethodCall(call, std::move(result)); });
 }
 
-PlatformViewChannel::~PlatformViewChannel() { Dispose(); }
+PlatformViewChannel::~PlatformViewChannel() {
+  Dispose();
+}
 
 void PlatformViewChannel::Dispose() {
   // Clean-up view_instances_

--- a/shell/platform/tizen/channels/settings_channel.cc
+++ b/shell/platform/tizen/channels/settings_channel.cc
@@ -12,7 +12,8 @@ static constexpr char kPlatformBrightnessKey[] = "platformBrightness";
 SettingsChannel::SettingsChannel(flutter::BinaryMessenger* messenger)
     : channel_(
           std::make_unique<flutter::BasicMessageChannel<rapidjson::Document>>(
-              messenger, kChannelName,
+              messenger,
+              kChannelName,
               &flutter::JsonMessageCodec::GetInstance())) {
   system_settings_set_changed_cb(SYSTEM_SETTINGS_KEY_LOCALE_TIMEFORMAT_24HOUR,
                                  OnSettingsChangedCallback, this);

--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -41,7 +41,8 @@ static const char* GetImfMethod() {
   Eina_List* modules;
 
   modules = ecore_imf_context_available_ids_get();
-  if (!modules) return nullptr;
+  if (!modules)
+    return nullptr;
 
   void* module;
   EINA_LIST_FREE(modules, module) { return (const char*)module; }
@@ -56,7 +57,8 @@ static bool IsASCIIPrintableKey(char c) {
   return false;
 }
 
-void TextInputChannel::CommitCallback(void* data, Ecore_IMF_Context* ctx,
+void TextInputChannel::CommitCallback(void* data,
+                                      Ecore_IMF_Context* ctx,
                                       void* event_info) {
   TextInputChannel* self = (TextInputChannel*)data;
   if (!self) {
@@ -72,7 +74,8 @@ void TextInputChannel::CommitCallback(void* data, Ecore_IMF_Context* ctx,
   self->OnCommit(str);
 }
 
-void TextInputChannel::PreeditCallback(void* data, Ecore_IMF_Context* ctx,
+void TextInputChannel::PreeditCallback(void* data,
+                                       Ecore_IMF_Context* ctx,
                                        void* event_info) {
   TextInputChannel* self = (TextInputChannel*)data;
   if (!self) {
@@ -108,7 +111,9 @@ void TextInputChannel::DeleteSurroundingCallback(void* data,
 }
 
 void TextInputChannel::InputPanelStateChangedCallback(
-    void* data, Ecore_IMF_Context* context, int value) {
+    void* data,
+    Ecore_IMF_Context* context,
+    int value) {
   FT_LOGD("Change input panel state[%d]", value);
   if (!data) {
     FT_LOGW("No Data");
@@ -130,7 +135,9 @@ void TextInputChannel::InputPanelStateChangedCallback(
 }
 
 void TextInputChannel::InputPanelGeometryChangedCallback(
-    void* data, Ecore_IMF_Context* context, int value) {
+    void* data,
+    Ecore_IMF_Context* context,
+    int value) {
   if (!data) {
     FT_LOGW("No Data");
     return;
@@ -205,7 +212,9 @@ Ecore_IMF_Keyboard_Locks EcoreInputModifierToEcoreIMFLock(
 TextInputChannel::TextInputChannel(flutter::BinaryMessenger* messenger,
                                    FlutterTizenEngine* engine)
     : channel_(std::make_unique<flutter::MethodChannel<rapidjson::Document>>(
-          messenger, kChannelName, &flutter::JsonMethodCodec::GetInstance())),
+          messenger,
+          kChannelName,
+          &flutter::JsonMethodCodec::GetInstance())),
       engine_(engine) {
   channel_->SetMethodCallHandler(
       [this](
@@ -367,7 +376,7 @@ bool TextInputChannel::FilterEvent(Ecore_Event_Key* keyDownEvent) {
   bool isIME = true;
 #else
   bool isIME = ecore_imf_context_keyboard_mode_get(imf_context_) ==
-          ECORE_IMF_INPUT_PANEL_SW_KEYBOARD_MODE;
+               ECORE_IMF_INPUT_PANEL_SW_KEYBOARD_MODE;
 #endif
 
   Ecore_IMF_Event_Key_Down ecoreKeyDownEvent;

--- a/shell/platform/tizen/channels/text_input_channel.h
+++ b/shell/platform/tizen/channels/text_input_channel.h
@@ -64,13 +64,17 @@ class TextInputChannel {
   std::unique_ptr<flutter::MethodChannel<rapidjson::Document>> channel_;
   std::unique_ptr<flutter::TextInputModel> active_model_;
 
-  static void CommitCallback(void* data, Ecore_IMF_Context* ctx,
+  static void CommitCallback(void* data,
+                             Ecore_IMF_Context* ctx,
                              void* event_info);
-  static void PreeditCallback(void* data, Ecore_IMF_Context* ctx,
+  static void PreeditCallback(void* data,
+                              Ecore_IMF_Context* ctx,
                               void* event_info);
-  static void PrivateCommandCallback(void* data, Ecore_IMF_Context* ctx,
+  static void PrivateCommandCallback(void* data,
+                                     Ecore_IMF_Context* ctx,
                                      void* event_info);
-  static void DeleteSurroundingCallback(void* data, Ecore_IMF_Context* ctx,
+  static void DeleteSurroundingCallback(void* data,
+                                        Ecore_IMF_Context* ctx,
                                         void* event_info);
   static void InputPanelStateChangedCallback(void* data,
                                              Ecore_IMF_Context* context,
@@ -80,7 +84,8 @@ class TextInputChannel {
                                                 int value);
   static Eina_Bool RetrieveSurroundingCallback(void* data,
                                                Ecore_IMF_Context* ctx,
-                                               char** text, int* cursor_pos);
+                                               char** text,
+                                               int* cursor_pos);
 
   int client_id_{0};
   SoftwareKeyboardGeometry current_keyboard_geometry_;

--- a/shell/platform/tizen/external_texture_gl.cc
+++ b/shell/platform/tizen/external_texture_gl.cc
@@ -93,7 +93,9 @@ bool ExternalTextureGL::OnFrameAvailable(tbm_surface_h tbm_surface) {
 }
 
 bool ExternalTextureGL::PopulateTextureWithIdentifier(
-    size_t width, size_t height, FlutterOpenGLTexture* opengl_texture) {
+    size_t width,
+    size_t height,
+    FlutterOpenGLTexture* opengl_texture) {
   if (!available_tbm_surface_) {
     FT_LOGD("[texture id:%ld] available_tbm_surface_ is null", texture_id_);
     return false;

--- a/shell/platform/tizen/external_texture_gl.h
+++ b/shell/platform/tizen/external_texture_gl.h
@@ -38,7 +38,8 @@ class ExternalTextureGL {
    * texture object.
    * Returns true on success, false on failure.
    */
-  bool PopulateTextureWithIdentifier(size_t width, size_t height,
+  bool PopulateTextureWithIdentifier(size_t width,
+                                     size_t height,
                                      FlutterOpenGLTexture* opengl_texture);
   bool OnFrameAvailable(tbm_surface_h tbm_surface);
 

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -26,7 +26,8 @@ static FlutterDesktopEngineRef HandleForEngine(FlutterTizenEngine* engine) {
 }
 
 FlutterDesktopEngineRef FlutterDesktopRunEngine(
-    const FlutterDesktopEngineProperties& engine_properties, bool headed) {
+    const FlutterDesktopEngineProperties& engine_properties,
+    bool headed) {
   StartLogging();
 
   auto engine = std::make_unique<FlutterTizenEngine>(headed);
@@ -44,12 +45,14 @@ void FlutterDesktopShutdownEngine(FlutterDesktopEngineRef engine_ref) {
 }
 
 void FlutterDesktopPluginRegistrarEnableInputBlocking(
-    FlutterDesktopPluginRegistrarRef registrar, const char* channel) {
+    FlutterDesktopPluginRegistrarRef registrar,
+    const char* channel) {
   registrar->engine->message_dispatcher->EnableInputBlockingForChannel(channel);
 }
 
 FlutterDesktopPluginRegistrarRef FlutterDesktopGetPluginRegistrar(
-    FlutterDesktopEngineRef engine, const char* plugin_name) {
+    FlutterDesktopEngineRef engine,
+    const char* plugin_name) {
   // Currently, one registrar acts as the registrar for all plugins, so the
   // name is ignored. It is part of the API to reduce churn in the future when
   // aligning more closely with the Flutter registrar system.
@@ -78,7 +81,8 @@ FlutterTextureRegistrarRef FlutterPluginRegistrarGetTexture(
 }
 
 bool FlutterDesktopMessengerSend(FlutterDesktopMessengerRef messenger,
-                                 const char* channel, const uint8_t* message,
+                                 const char* channel,
+                                 const uint8_t* message,
                                  const size_t message_size) {
   return FlutterDesktopMessengerSendWithReply(messenger, channel, message,
                                               message_size, nullptr, nullptr);
@@ -117,7 +121,8 @@ bool FlutterDesktopMessengerSendWithReply(FlutterDesktopMessengerRef messenger,
 
 void FlutterDesktopMessengerSendResponse(
     FlutterDesktopMessengerRef messenger,
-    const FlutterDesktopMessageResponseHandle* handle, const uint8_t* data,
+    const FlutterDesktopMessageResponseHandle* handle,
+    const uint8_t* data,
     size_t data_length) {
   FlutterEngineSendPlatformMessageResponse(messenger->engine->flutter_engine,
                                            handle, data, data_length);
@@ -171,7 +176,8 @@ int64_t FlutterRegisterExternalTexture(
 }
 
 bool FlutterUnregisterExternalTexture(
-    FlutterTextureRegistrarRef texture_registrar, int64_t texture_id) {
+    FlutterTextureRegistrarRef texture_registrar,
+    int64_t texture_id) {
   std::lock_guard<std::mutex> lock(texture_registrar->mutex);
   auto it = texture_registrar->textures.find(texture_id);
   if (it != texture_registrar->textures.end())
@@ -182,7 +188,8 @@ bool FlutterUnregisterExternalTexture(
 }
 
 bool FlutterMarkExternalTextureFrameAvailable(
-    FlutterTextureRegistrarRef texture_registrar, int64_t texture_id,
+    FlutterTextureRegistrarRef texture_registrar,
+    int64_t texture_id,
     void* tbm_surface) {
   std::lock_guard<std::mutex> lock(texture_registrar->mutex);
   auto it = texture_registrar->textures.find(texture_id);
@@ -201,7 +208,8 @@ bool FlutterMarkExternalTextureFrameAvailable(
 }
 
 void FlutterRegisterViewFactory(
-    FlutterDesktopPluginRegistrarRef registrar, const char* view_type,
+    FlutterDesktopPluginRegistrarRef registrar,
+    const char* view_type,
     std::unique_ptr<PlatformViewFactory> view_factory) {
   registrar->engine->platform_view_channel->ViewFactories().insert(
       std::pair<std::string, std::unique_ptr<PlatformViewFactory>>(
@@ -222,13 +230,15 @@ int64_t FlutterDesktopTextureRegistrarRegisterExternalTexture(
 }
 
 bool FlutterDesktopTextureRegistrarUnregisterExternalTexture(
-    FlutterDesktopTextureRegistrarRef texture_registrar, int64_t texture_id) {
+    FlutterDesktopTextureRegistrarRef texture_registrar,
+    int64_t texture_id) {
   FT_UNIMPLEMENTED();
   return false;
 }
 
 bool FlutterDesktopTextureRegistrarMarkExternalTextureFrameAvailable(
-    FlutterDesktopTextureRegistrarRef texture_registrar, int64_t texture_id) {
+    FlutterDesktopTextureRegistrarRef texture_registrar,
+    int64_t texture_id) {
   FT_UNIMPLEMENTED();
   return false;
 }

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -64,7 +64,9 @@ FlutterTizenEngine::FlutterTizenEngine(bool headed)
   }
 }
 
-FlutterTizenEngine::~FlutterTizenEngine() { renderer = nullptr; }
+FlutterTizenEngine::~FlutterTizenEngine() {
+  renderer = nullptr;
+}
 
 void FlutterTizenEngine::InitializeRenderer() {
 #ifdef TIZEN_RENDERER_EVAS_GL
@@ -255,7 +257,8 @@ void FlutterTizenEngine::SetPluginRegistrarDestructionCallback(
   plugin_registrar_destruction_callback_ = callback;
 }
 
-void FlutterTizenEngine::SendWindowMetrics(int32_t width, int32_t height,
+void FlutterTizenEngine::SendWindowMetrics(int32_t width,
+                                           int32_t height,
                                            double pixel_ratio) {
   FlutterWindowMetricsEvent event;
   event.struct_size = sizeof(FlutterWindowMetricsEvent);
@@ -331,7 +334,8 @@ void FlutterTizenEngine::OnOrientationChange(int32_t degree) {
 // The Flutter Engine calls out to this function when new platform messages are
 // available.
 void FlutterTizenEngine::OnFlutterPlatformMessage(
-    const FlutterPlatformMessage* engine_message, void* user_data) {
+    const FlutterPlatformMessage* engine_message,
+    void* user_data) {
   if (engine_message->struct_size != sizeof(FlutterPlatformMessage)) {
     FT_LOGE("Invalid message size received. Expected: %zu, but received %zu",
             sizeof(FlutterPlatformMessage), engine_message->struct_size);

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -122,7 +122,8 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
   bool IsHeaded() { return renderer != nullptr; }
 
   static void OnFlutterPlatformMessage(
-      const FlutterPlatformMessage* engine_message, void* user_data);
+      const FlutterPlatformMessage* engine_message,
+      void* user_data);
   FlutterDesktopMessage ConvertToDesktopMessage(
       const FlutterPlatformMessage& engine_message);
   FlutterRendererConfig GetRendererConfig();

--- a/shell/platform/tizen/key_event_handler.cc
+++ b/shell/platform/tizen/key_event_handler.cc
@@ -8,7 +8,7 @@
 
 static constexpr char kPlatformBackButtonName[] = "XF86Back";
 
-KeyEventHandler::KeyEventHandler(FlutterTizenEngine *engine) : engine_(engine) {
+KeyEventHandler::KeyEventHandler(FlutterTizenEngine* engine) : engine_(engine) {
   key_event_handlers_.push_back(
       ecore_event_handler_add(ECORE_EVENT_KEY_DOWN, OnKey, this));
   key_event_handlers_.push_back(
@@ -22,10 +22,10 @@ KeyEventHandler::~KeyEventHandler() {
   key_event_handlers_.clear();
 }
 
-Eina_Bool KeyEventHandler::OnKey(void *data, int type, void *event) {
-  auto *self = reinterpret_cast<KeyEventHandler *>(data);
-  auto *key = reinterpret_cast<Ecore_Event_Key *>(event);
-  auto *engine = self->engine_;
+Eina_Bool KeyEventHandler::OnKey(void* data, int type, void* event) {
+  auto* self = reinterpret_cast<KeyEventHandler*>(data);
+  auto* key = reinterpret_cast<Ecore_Event_Key*>(event);
+  auto* engine = self->engine_;
   auto is_down = type == ECORE_EVENT_KEY_DOWN;
 
   if (strcmp(key->keyname, kPlatformBackButtonName) == 0) {

--- a/shell/platform/tizen/public/flutter_platform_view.h
+++ b/shell/platform/tizen/public/flutter_platform_view.h
@@ -28,7 +28,11 @@ class PlatformView {
   flutter::PluginRegistrar* GetPluginRegistrar() { return registrar_; }
   virtual void Dispose() = 0;
   virtual void Resize(double width, double height) = 0;
-  virtual void Touch(int type, int button, double x, double y, double dx,
+  virtual void Touch(int type,
+                     int button,
+                     double x,
+                     double y,
+                     double dx,
                      double dy) = 0;
   virtual void SetDirection(int direction) = 0;
   virtual void ClearFocus() = 0;
@@ -60,7 +64,9 @@ class PlatformViewFactory {
   const flutter::MessageCodec<flutter::EncodableValue>& GetCodec() {
     return codec_;
   }
-  virtual PlatformView* Create(int viewId, double width, double height,
+  virtual PlatformView* Create(int viewId,
+                               double width,
+                               double height,
                                const ByteMessage& createParams) = 0;
   virtual void Dispose() = 0;
 
@@ -74,7 +80,8 @@ extern "C" {
 #endif
 
 FLUTTER_EXPORT void FlutterRegisterViewFactory(
-    FlutterDesktopPluginRegistrarRef registrar, const char* view_type,
+    FlutterDesktopPluginRegistrarRef registrar,
+    const char* view_type,
     std::unique_ptr<PlatformViewFactory> view_factory);
 
 #if defined(__cplusplus)

--- a/shell/platform/tizen/public/flutter_tizen.h
+++ b/shell/platform/tizen/public/flutter_tizen.h
@@ -41,8 +41,9 @@ typedef struct {
 // Runs an instance of a Flutter engine with the given properties.
 //
 // If |headed| is false, the engine is run in headless mode.
-FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopRunEngine(
-    const FlutterDesktopEngineProperties& engine_properties, bool headed);
+FLUTTER_EXPORT FlutterDesktopEngineRef
+FlutterDesktopRunEngine(const FlutterDesktopEngineProperties& engine_properties,
+                        bool headed);
 
 // Shuts down the given engine instance.
 //

--- a/shell/platform/tizen/public/flutter_tizen_texture_registrar.h
+++ b/shell/platform/tizen/public/flutter_tizen_texture_registrar.h
@@ -28,12 +28,14 @@ FlutterRegisterExternalTexture(FlutterTextureRegistrarRef texture_registrar);
 // Unregisters an existing texture from the Flutter engine for a |texture_id|.
 // Returns true on success, false on failure.
 FLUTTER_EXPORT bool FlutterUnregisterExternalTexture(
-    FlutterTextureRegistrarRef texture_registrar, int64_t texture_id);
+    FlutterTextureRegistrarRef texture_registrar,
+    int64_t texture_id);
 
 // Marks that a new texture frame is available for a given |texture_id|.
 // Returns true on success, false on failure.
 FLUTTER_EXPORT bool FlutterMarkExternalTextureFrameAvailable(
-    FlutterTextureRegistrarRef texture_registrar, int64_t texture_id,
+    FlutterTextureRegistrarRef texture_registrar,
+    int64_t texture_id,
     void* tbm_surface);
 
 #if defined(__cplusplus)

--- a/shell/platform/tizen/tizen_event_loop.cc
+++ b/shell/platform/tizen/tizen_event_loop.cc
@@ -73,7 +73,8 @@ Eina_Bool TizenEventLoop::TaskTimerCallback(void* data) {
   return EINA_FALSE;
 }
 
-void TizenEventLoop::ExcuteTaskEvents(void* data, void* buffer,
+void TizenEventLoop::ExcuteTaskEvents(void* data,
+                                      void* buffer,
                                       unsigned int nbyte) {
   auto* self = reinterpret_cast<TizenEventLoop*>(data);
   auto* p_task = reinterpret_cast<Task*>(buffer);
@@ -98,7 +99,8 @@ void TizenEventLoop::ExcuteTaskEvents(void* data, void* buffer,
 }
 
 TizenPlatformEventLoop::TizenPlatformEventLoop(
-    std::thread::id main_thread_id, TaskExpiredCallback on_task_expired)
+    std::thread::id main_thread_id,
+    TaskExpiredCallback on_task_expired)
     : TizenEventLoop(main_thread_id, on_task_expired) {}
 
 TizenPlatformEventLoop::~TizenPlatformEventLoop() {}
@@ -114,8 +116,7 @@ void TizenPlatformEventLoop::OnTaskExpired() {
 TizenRenderEventLoop::TizenRenderEventLoop(std::thread::id main_thread_id,
                                            TaskExpiredCallback on_task_expired,
                                            TizenRenderer* renderer)
-    : TizenEventLoop(main_thread_id, on_task_expired),
-      renderer_(renderer) {
+    : TizenEventLoop(main_thread_id, on_task_expired), renderer_(renderer) {
   evas_object_image_pixels_get_callback_set(
       (Evas_Object*)static_cast<TizenRendererEvasGL*>(renderer_)
           ->GetImageHandle(),

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -35,8 +35,11 @@ class TizenRenderer {
   virtual uintptr_t GetWindowId() = 0;
 
   virtual void SetRotate(int angle) = 0;
-  virtual void ResizeWithRotation(int32_t x, int32_t y, int32_t width,
-                                  int32_t height, int32_t degree) = 0;
+  virtual void ResizeWithRotation(int32_t x,
+                                  int32_t y,
+                                  int32_t width,
+                                  int32_t height,
+                                  int32_t degree) = 0;
   virtual void SetPreferredOrientations(const std::vector<int>& rotations) = 0;
 
  protected:

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -9,12 +9,14 @@
 
 #include "flutter/shell/platform/tizen/tizen_log.h"
 
-TizenRendererEcoreWl2::TizenRendererEcoreWl2(TizenRenderer::Delegate &delegate)
+TizenRendererEcoreWl2::TizenRendererEcoreWl2(TizenRenderer::Delegate& delegate)
     : TizenRenderer(delegate) {
   InitializeRenderer();
 }
 
-TizenRendererEcoreWl2::~TizenRendererEcoreWl2() { DestroyRenderer(); }
+TizenRendererEcoreWl2::~TizenRendererEcoreWl2() {
+  DestroyRenderer();
+}
 
 bool TizenRendererEcoreWl2::OnMakeCurrent() {
   if (!IsValid()) {
@@ -86,14 +88,14 @@ uint32_t TizenRendererEcoreWl2::OnGetFBO() {
   return 0;
 }
 
-void *TizenRendererEcoreWl2::OnProcResolver(const char *name) {
+void* TizenRendererEcoreWl2::OnProcResolver(const char* name) {
   auto address = eglGetProcAddress(name);
   if (address != nullptr) {
-    return reinterpret_cast<void *>(address);
+    return reinterpret_cast<void*>(address);
   }
-#define GL_FUNC(FunctionName)                      \
-  else if (strcmp(name, #FunctionName) == 0) {     \
-    return reinterpret_cast<void *>(FunctionName); \
+#define GL_FUNC(FunctionName)                     \
+  else if (strcmp(name, #FunctionName) == 0) {    \
+    return reinterpret_cast<void*>(FunctionName); \
   }
   GL_FUNC(eglGetCurrentDisplay)
   GL_FUNC(eglQueryString)
@@ -216,7 +218,7 @@ TizenRenderer::TizenWindowGeometry TizenRendererEcoreWl2::GetGeometry() {
 }
 
 int32_t TizenRendererEcoreWl2::GetDpi() {
-  auto *output = ecore_wl2_window_output_find(ecore_wl2_window_);
+  auto* output = ecore_wl2_window_output_find(ecore_wl2_window_);
   if (!output) {
     FT_LOGE("Could not find an output associated with the window.");
     return 0;
@@ -251,7 +253,9 @@ bool TizenRendererEcoreWl2::InitializeRenderer() {
   return true;
 }
 
-void TizenRendererEcoreWl2::Show() { ecore_wl2_window_show(ecore_wl2_window_); }
+void TizenRendererEcoreWl2::Show() {
+  ecore_wl2_window_show(ecore_wl2_window_);
+}
 
 void TizenRendererEcoreWl2::DestroyRenderer() {
   DestroyEglSurface();
@@ -260,7 +264,7 @@ void TizenRendererEcoreWl2::DestroyRenderer() {
   ShutdownDisplay();
 }
 
-bool TizenRendererEcoreWl2::SetupDisplay(int32_t &width, int32_t &height) {
+bool TizenRendererEcoreWl2::SetupDisplay(int32_t& width, int32_t& height) {
   if (!ecore_wl2_init()) {
     FT_LOGE("Could not initialize ecore_wl2");
     return false;
@@ -354,7 +358,7 @@ bool TizenRendererEcoreWl2::SetupEglSurface() {
     return false;
   }
 
-  EGLint *ptr = nullptr;
+  EGLint* ptr = nullptr;
   egl_surface_ = eglCreateWindowSurface(egl_display_, egl_config_,
                                         GetEGLNativeWindowType(), ptr);
   if (egl_surface_ == EGL_NO_SURFACE) {
@@ -416,7 +420,7 @@ bool TizenRendererEcoreWl2::ChooseEGLConfiguration() {
     PrintEGLError();
     return false;
   }
-  EGLConfig *configs = (EGLConfig *)calloc(num_config, sizeof(EGLConfig));
+  EGLConfig* configs = (EGLConfig*)calloc(num_config, sizeof(EGLConfig));
   EGLint num;
   // Get the List of EGL framebuffer configuration matches with config_attribs
   // in list "configs"
@@ -557,10 +561,11 @@ void TizenRendererEcoreWl2::DestroyEglSurface() {
   }
 }
 
-Eina_Bool TizenRendererEcoreWl2::RotationEventCb(void *data, int type,
-                                                 void *event) {
-  auto *self = reinterpret_cast<TizenRendererEcoreWl2 *>(data);
-  auto *ev = reinterpret_cast<Ecore_Wl2_Event_Window_Rotation *>(event);
+Eina_Bool TizenRendererEcoreWl2::RotationEventCb(void* data,
+                                                 int type,
+                                                 void* event) {
+  auto* self = reinterpret_cast<TizenRendererEcoreWl2*>(data);
+  auto* ev = reinterpret_cast<Ecore_Wl2_Event_Window_Rotation*>(event);
   self->delegate_.OnOrientationChange(ev->angle);
   return ECORE_CALLBACK_PASS_ON;
 }
@@ -570,8 +575,10 @@ void TizenRendererEcoreWl2::SetRotate(int angle) {
   received_rotation_ = true;
 }
 
-void TizenRendererEcoreWl2::ResizeWithRotation(int32_t x, int32_t y,
-                                               int32_t width, int32_t height,
+void TizenRendererEcoreWl2::ResizeWithRotation(int32_t x,
+                                               int32_t y,
+                                               int32_t width,
+                                               int32_t height,
                                                int32_t angle) {
   ecore_wl2_egl_window_resize_with_rotation(ecore_wl2_egl_window_, x, y, width,
                                             height, angle);
@@ -586,7 +593,7 @@ void TizenRendererEcoreWl2::SendRotationChangeDone() {
 }
 
 void TizenRendererEcoreWl2::SetPreferredOrientations(
-    const std::vector<int> &rotations) {
+    const std::vector<int>& rotations) {
   ecore_wl2_window_available_rotations_set(ecore_wl2_window_, rotations.data(),
                                            rotations.size());
 }

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -13,7 +13,7 @@
 
 class TizenRendererEcoreWl2 : public TizenRenderer {
  public:
-  explicit TizenRendererEcoreWl2(TizenRenderer::Delegate &delegate);
+  explicit TizenRendererEcoreWl2(TizenRenderer::Delegate& delegate);
   virtual ~TizenRendererEcoreWl2();
 
   bool OnMakeCurrent() override;
@@ -21,23 +21,26 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   bool OnMakeResourceCurrent() override;
   bool OnPresent() override;
   uint32_t OnGetFBO() override;
-  void *OnProcResolver(const char *name) override;
+  void* OnProcResolver(const char* name) override;
 
   TizenWindowGeometry GetGeometry() override;
   int32_t GetDpi() override;
   uintptr_t GetWindowId() override;
 
-  void ResizeWithRotation(int32_t x, int32_t y, int32_t width, int32_t height,
+  void ResizeWithRotation(int32_t x,
+                          int32_t y,
+                          int32_t width,
+                          int32_t height,
                           int32_t angle) override;
   void SetRotate(int angle) override;
-  void SetPreferredOrientations(const std::vector<int> &rotations) override;
+  void SetPreferredOrientations(const std::vector<int>& rotations) override;
 
  private:
   bool InitializeRenderer();
   void Show();
   void DestroyRenderer();
 
-  bool SetupDisplay(int32_t &width, int32_t &height);
+  bool SetupDisplay(int32_t& width, int32_t& height);
   bool SetupEcoreWlWindow(int32_t width, int32_t height);
   bool SetupEglWindow(int32_t width, int32_t height);
   EGLDisplay GetEGLDisplay();
@@ -51,12 +54,12 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   void PrintEGLError();
   void DestroyEglSurface();
 
-  static Eina_Bool RotationEventCb(void *data, int type, void *event);
+  static Eina_Bool RotationEventCb(void* data, int type, void* event);
   void SendRotationChangeDone();
 
-  Ecore_Wl2_Display *ecore_wl2_display_ = nullptr;
-  Ecore_Wl2_Window *ecore_wl2_window_ = nullptr;
-  Ecore_Wl2_Egl_Window *ecore_wl2_egl_window_ = nullptr;
+  Ecore_Wl2_Display* ecore_wl2_display_ = nullptr;
+  Ecore_Wl2_Window* ecore_wl2_window_ = nullptr;
+  Ecore_Wl2_Egl_Window* ecore_wl2_egl_window_ = nullptr;
 
   EGLConfig egl_config_;
   EGLDisplay egl_display_ = EGL_NO_DISPLAY;

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -20,7 +20,9 @@ TizenRendererEvasGL::TizenRendererEvasGL(TizenRenderer::Delegate& delegate)
   OnPresent();
 }
 
-TizenRendererEvasGL::~TizenRendererEvasGL() { DestroyRenderer(); }
+TizenRendererEvasGL::~TizenRendererEvasGL() {
+  DestroyRenderer();
+}
 
 void TizenRendererEvasGL::ClearColor(float r, float g, float b, float a) {
   glClearColor(r, g, b, a);
@@ -560,7 +562,9 @@ uintptr_t TizenRendererEvasGL::GetWindowId() {
       ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_)));
 }
 
-void* TizenRendererEvasGL::GetImageHandle() { return (void*)graphics_adapter_; }
+void* TizenRendererEvasGL::GetImageHandle() {
+  return (void*)graphics_adapter_;
+}
 
 bool TizenRendererEvasGL::InitializeRenderer() {
   if (!SetupEvasGL()) {
@@ -685,7 +689,8 @@ void TizenRendererEvasGL::DestroyEvasWindow() {
   evas_object_del(graphics_adapter_);
 }
 
-void TizenRendererEvasGL::RotationEventCb(void* data, Evas_Object* obj,
+void TizenRendererEvasGL::RotationEventCb(void* data,
+                                          Evas_Object* obj,
                                           void* event_info) {
   auto* self = reinterpret_cast<TizenRendererEvasGL*>(data);
   // TODO : Use current window rotation degree
@@ -698,8 +703,10 @@ void TizenRendererEvasGL::SetRotate(int angle) {
   received_rotation_ = true;
 }
 
-void TizenRendererEvasGL::ResizeWithRotation(int32_t x, int32_t y,
-                                             int32_t width, int32_t height,
+void TizenRendererEvasGL::ResizeWithRotation(int32_t x,
+                                             int32_t y,
+                                             int32_t width,
+                                             int32_t height,
                                              int32_t angle) {
   evas_object_move(evas_window_, x, y);
   evas_object_resize(evas_window_, width, height);

--- a/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -28,7 +28,10 @@ class TizenRendererEvasGL : public TizenRenderer {
   int32_t GetDpi() override;
   uintptr_t GetWindowId() override;
 
-  void ResizeWithRotation(int32_t x, int32_t y, int32_t width, int32_t height,
+  void ResizeWithRotation(int32_t x,
+                          int32_t y,
+                          int32_t width,
+                          int32_t height,
                           int32_t angle) override;
   void SetRotate(int angle) override;
   void SetPreferredOrientations(const std::vector<int>& rotations) override;

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -139,11 +139,16 @@ void TizenVsyncWaiter::DestroyTDMVblank() {
   }
 }
 
-bool TizenVsyncWaiter::TDMValid() { return vblank_ && client_; }
+bool TizenVsyncWaiter::TDMValid() {
+  return vblank_ && client_;
+}
 
-void TizenVsyncWaiter::TdmClientVblankCallback(
-    tdm_client_vblank* vblank, tdm_error error, unsigned int sequence,
-    unsigned int tv_sec, unsigned int tv_usec, void* user_data) {
+void TizenVsyncWaiter::TdmClientVblankCallback(tdm_client_vblank* vblank,
+                                               tdm_error error,
+                                               unsigned int sequence,
+                                               unsigned int tv_sec,
+                                               unsigned int tv_usec,
+                                               void* user_data) {
   TizenVsyncWaiter* tizen_vsync_waiter =
       reinterpret_cast<TizenVsyncWaiter*>(user_data);
   FT_ASSERT(tizen_vsync_waiter != nullptr);

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -24,8 +24,10 @@ class TizenVsyncWaiter {
   bool TDMValid();
   void SendMessage(int val);
   static void TdmClientVblankCallback(tdm_client_vblank* vblank,
-                                      tdm_error error, unsigned int sequence,
-                                      unsigned int tv_sec, unsigned int tv_usec,
+                                      tdm_error error,
+                                      unsigned int sequence,
+                                      unsigned int tv_sec,
+                                      unsigned int tv_usec,
                                       void* user_data);
   static void RequestVblankLoop(void* data, Ecore_Thread* thread);
   static void VblankLoopFinish(void* data, Ecore_Thread* thread);

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -10,7 +10,7 @@
 static const int DIRECTION_VERTICAL = 0;
 static const int DIRECTION_HORIZONTAL = 1;
 
-TouchEventHandler::TouchEventHandler(FlutterTizenEngine *engine)
+TouchEventHandler::TouchEventHandler(FlutterTizenEngine* engine)
     : engine_(engine) {
   touch_event_handlers_.push_back(
       ecore_event_handler_add(ECORE_EVENT_MOUSE_BUTTON_DOWN, OnTouch, this));
@@ -30,7 +30,8 @@ TouchEventHandler::~TouchEventHandler() {
 }
 
 void TouchEventHandler::SendFlutterPointerEvent(FlutterPointerPhase phase,
-                                                double x, double y,
+                                                double x,
+                                                double y,
                                                 double scroll_delta_x,
                                                 double scroll_delta_y,
                                                 size_t timestamp,
@@ -71,30 +72,30 @@ void TouchEventHandler::SendFlutterPointerEvent(FlutterPointerPhase phase,
   FlutterEngineSendPointerEvent(engine_->flutter_engine, &event, 1);
 }
 
-Eina_Bool TouchEventHandler::OnTouch(void *data, int type, void *event) {
-  auto *self = reinterpret_cast<TouchEventHandler *>(data);
+Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
+  auto* self = reinterpret_cast<TouchEventHandler*>(data);
 
   if (type == ECORE_EVENT_MOUSE_BUTTON_DOWN) {
     self->pointer_state_ = true;
-    auto *button_event = reinterpret_cast<Ecore_Event_Mouse_Button *>(event);
+    auto* button_event = reinterpret_cast<Ecore_Event_Mouse_Button*>(event);
     self->SendFlutterPointerEvent(kDown, button_event->x, button_event->y, 0, 0,
                                   button_event->timestamp,
                                   button_event->multi.device);
   } else if (type == ECORE_EVENT_MOUSE_BUTTON_UP) {
     self->pointer_state_ = false;
-    auto *button_event = reinterpret_cast<Ecore_Event_Mouse_Button *>(event);
+    auto* button_event = reinterpret_cast<Ecore_Event_Mouse_Button*>(event);
     self->SendFlutterPointerEvent(kUp, button_event->x, button_event->y, 0, 0,
                                   button_event->timestamp,
                                   button_event->multi.device);
   } else if (type == ECORE_EVENT_MOUSE_MOVE) {
     if (self->pointer_state_) {
-      auto *move_event = reinterpret_cast<Ecore_Event_Mouse_Move *>(event);
+      auto* move_event = reinterpret_cast<Ecore_Event_Mouse_Move*>(event);
       self->SendFlutterPointerEvent(kMove, move_event->x, move_event->y, 0, 0,
                                     move_event->timestamp,
                                     move_event->multi.device);
     }
   } else if (type == ECORE_EVENT_MOUSE_WHEEL) {
-    auto *wheel_event = reinterpret_cast<Ecore_Event_Mouse_Wheel *>(event);
+    auto* wheel_event = reinterpret_cast<Ecore_Event_Mouse_Wheel*>(event);
     double scroll_delta_x = 0.0, scroll_delta_y = 0.0;
     if (wheel_event->direction == DIRECTION_VERTICAL) {
       scroll_delta_y += wheel_event->z;

--- a/shell/platform/tizen/touch_event_handler.h
+++ b/shell/platform/tizen/touch_event_handler.h
@@ -25,9 +25,13 @@ class TouchEventHandler {
   std::vector<Ecore_Event_Handler*> touch_event_handlers_;
   bool pointer_state_ = false;
 
-  void SendFlutterPointerEvent(FlutterPointerPhase phase, double x, double y,
-                               double scroll_delta_x, double scroll_delta_y,
-                               size_t timestamp, int device_id);
+  void SendFlutterPointerEvent(FlutterPointerPhase phase,
+                               double x,
+                               double y,
+                               double scroll_delta_x,
+                               double scroll_delta_y,
+                               size_t timestamp,
+                               int device_id);
 
   static Eina_Bool OnTouch(void* data, int type, void* event);
 };


### PR DESCRIPTION
- Add the `format` job to the CI pipeline.
  - ~The linter job will be added in the future.~ (The lint warning/errors will not be analyzed by the CI.)
- Format GN files.
- Format C/C++ files using the Chromium style (as defined in the [`.clang-format`](https://github.com/flutter-tizen/engine/blob/flutter-2.0.1-tizen/.clang-format) file).

For maintainers: The Chromium C/C++ style is slightly different from the Google C/C++ style, but you don't need any special configuration if everything works correctly. clang-format and the VS Code extension should just work out of the box. They will find the `.clang-format` file from the repository root automatically.

To manually analyze code formatting, you can use either:
- [check_tidy.py](https://github.com/flutter-tizen/plugins/pull/93) (`check_tidy.py --dir shell/platform/tizen`)
- format.dart (`ci/format.sh`)
  - You must add this to your Git remote endpoints: `git remote add upstream https://github.com/flutter/engine.git`