### PR TITLE
Resolve some linter warnings

### DIFF
--- a/shell/platform/tizen/channels/platform_view_channel.cc
+++ b/shell/platform/tizen/channels/platform_view_channel.cc
@@ -19,8 +19,9 @@ std::string ExtractStringFromMap(const flutter::EncodableValue& arguments,
   if (std::holds_alternative<flutter::EncodableMap>(arguments)) {
     flutter::EncodableMap values = std::get<flutter::EncodableMap>(arguments);
     flutter::EncodableValue value = values[flutter::EncodableValue(key)];
-    if (std::holds_alternative<std::string>(value))
+    if (std::holds_alternative<std::string>(value)) {
       return std::get<std::string>(value);
+    }
   }
   return std::string();
 }
@@ -30,8 +31,9 @@ int ExtractIntFromMap(const flutter::EncodableValue& arguments,
   if (std::holds_alternative<flutter::EncodableMap>(arguments)) {
     flutter::EncodableMap values = std::get<flutter::EncodableMap>(arguments);
     flutter::EncodableValue value = values[flutter::EncodableValue(key)];
-    if (std::holds_alternative<int>(value))
+    if (std::holds_alternative<int>(value)) {
       return std::get<int>(value);
+    }
   }
   return -1;
 }
@@ -41,8 +43,9 @@ double ExtractDoubleFromMap(const flutter::EncodableValue& arguments,
   if (std::holds_alternative<flutter::EncodableMap>(arguments)) {
     flutter::EncodableMap values = std::get<flutter::EncodableMap>(arguments);
     flutter::EncodableValue value = values[flutter::EncodableValue(key)];
-    if (std::holds_alternative<double>(value))
+    if (std::holds_alternative<double>(value)) {
       return std::get<double>(value);
+    }
   }
   return -1;
 }
@@ -53,8 +56,9 @@ flutter::EncodableMap ExtractMapFromMap(
   if (std::holds_alternative<flutter::EncodableMap>(arguments)) {
     flutter::EncodableMap values = std::get<flutter::EncodableMap>(arguments);
     flutter::EncodableValue value = values[flutter::EncodableValue(key)];
-    if (std::holds_alternative<flutter::EncodableMap>(value))
+    if (std::holds_alternative<flutter::EncodableMap>(value)) {
       return std::get<flutter::EncodableMap>(value);
+    }
   }
   return flutter::EncodableMap();
 }
@@ -65,8 +69,9 @@ flutter::EncodableList ExtractListFromMap(
   if (std::holds_alternative<flutter::EncodableMap>(arguments)) {
     flutter::EncodableMap values = std::get<flutter::EncodableMap>(arguments);
     flutter::EncodableValue value = values[flutter::EncodableValue(key)];
-    if (std::holds_alternative<flutter::EncodableList>(value))
+    if (std::holds_alternative<flutter::EncodableList>(value)) {
       return std::get<flutter::EncodableList>(value);
+    }
   }
   return flutter::EncodableList();
 }

--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -41,11 +41,12 @@ static const char* GetImfMethod() {
   Eina_List* modules;
 
   modules = ecore_imf_context_available_ids_get();
-  if (!modules)
+  if (!modules) {
     return nullptr;
+  }
 
   void* module;
-  EINA_LIST_FREE(modules, module) { return (const char*)module; }
+  EINA_LIST_FREE(modules, module) { return static_cast<const char*>(module); }
 
   return nullptr;
 }
@@ -91,11 +92,11 @@ static bool TextInputTypeToEcoreIMFInputPanelLayout(
 void TextInputChannel::CommitCallback(void* data,
                                       Ecore_IMF_Context* ctx,
                                       void* event_info) {
-  TextInputChannel* self = (TextInputChannel*)data;
+  TextInputChannel* self = static_cast<TextInputChannel*>(data);
   if (!self) {
     return;
   }
-  char* str = (char*)event_info;
+  char* str = static_cast<char*>(event_info);
   if (self->engine_ && self->engine_->platform_view_channel &&
       self->engine_->platform_view_channel->CurrentFocusedViewId() > -1) {
     self->engine_->platform_view_channel->DispatchCompositionEndEvent(str);
@@ -108,7 +109,7 @@ void TextInputChannel::CommitCallback(void* data,
 void TextInputChannel::PreeditCallback(void* data,
                                        Ecore_IMF_Context* ctx,
                                        void* event_info) {
-  TextInputChannel* self = (TextInputChannel*)data;
+  TextInputChannel* self = static_cast<TextInputChannel*>(data);
   if (!self) {
     return;
   }
@@ -130,14 +131,12 @@ void TextInputChannel::PreeditCallback(void* data,
 void TextInputChannel::PrivateCommandCallback(void* data,
                                               Ecore_IMF_Context* ctx,
                                               void* event_info) {
-  // TODO
   FT_UNIMPLEMENTED();
 }
 
 void TextInputChannel::DeleteSurroundingCallback(void* data,
                                                  Ecore_IMF_Context* ctx,
                                                  void* event_info) {
-  // TODO
   FT_UNIMPLEMENTED();
 }
 
@@ -150,7 +149,7 @@ void TextInputChannel::InputPanelStateChangedCallback(
     FT_LOGW("No Data");
     return;
   }
-  TextInputChannel* self = (TextInputChannel*)data;
+  TextInputChannel* self = static_cast<TextInputChannel*>(data);
   switch (value) {
     case ECORE_IMF_INPUT_PANEL_STATE_SHOW:
       self->SetSoftwareKeyboardShowing();
@@ -173,7 +172,7 @@ void TextInputChannel::InputPanelGeometryChangedCallback(
     FT_LOGW("No Data");
     return;
   }
-  TextInputChannel* self = (TextInputChannel*)data;
+  TextInputChannel* self = static_cast<TextInputChannel*>(data);
   ecore_imf_context_input_panel_geometry_get(
       self->imf_context_, &self->current_keyboard_geometry_.x,
       &self->current_keyboard_geometry_.y, &self->current_keyboard_geometry_.w,
@@ -263,7 +262,8 @@ TextInputChannel::TextInputChannel(flutter::BinaryMessenger* messenger,
   }
   if (imf_context_) {
     ecore_imf_context_client_window_set(
-        imf_context_, (void*)engine_->renderer->GetWindowId());
+        imf_context_,
+        reinterpret_cast<void*>(engine_->renderer->GetWindowId()));
     RegisterIMFCallback();
   } else {
     FT_LOGE("Failed to create imfContext");
@@ -296,7 +296,7 @@ void TextInputChannel::HandleMethodCall(
   } else if (method.compare(kHideMethod) == 0) {
     HideSoftwareKeyboard();
   } else if (method.compare(kSetPlatformViewClient) == 0) {
-    // TODO: implement if necessary
+    FT_UNIMPLEMENTED();
   } else if (method.compare(kClearClientMethod) == 0) {
     active_model_ = nullptr;
   } else if (method.compare(kSetClientMethod) == 0) {
@@ -403,7 +403,8 @@ bool TextInputChannel::FilterEvent(Ecore_Event_Key* keyDownEvent) {
   bool handled = false;
 
 #ifdef TIZEN_RENDERER_EVAS_GL
-  // TODO: Hardware keyboard not supported when running in Evas GL mode.
+  // TODO(bbrto21): Hardware keyboard is not supported when running in Evas GL
+  // mode.
   bool isIME = true;
 #else
   bool isIME = ecore_imf_context_keyboard_mode_get(imf_context_) ==

--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -60,29 +60,29 @@ static bool IsASCIIPrintableKey(char c) {
 
 static bool TextInputTypeToEcoreIMFInputPanelLayout(
     std::string text_input_type,
-    Ecore_IMF_Input_Panel_Layout& panel_layout) {
+    Ecore_IMF_Input_Panel_Layout* panel_layout) {
   if (text_input_type == "TextInputType.text" ||
       text_input_type == "TextInputType.multiline") {
-    panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_NORMAL;
+    *panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_NORMAL;
   } else if (text_input_type == "TextInputType.number") {
-    panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_NUMBER;
+    *panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_NUMBER;
   } else if (text_input_type == "TextInputType.phone") {
-    panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_PHONENUMBER;
+    *panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_PHONENUMBER;
   } else if (text_input_type == "TextInputType.datetime") {
-    panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_DATETIME;
+    *panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_DATETIME;
   } else if (text_input_type == "TextInputType.emailAddress") {
-    panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_EMAIL;
+    *panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_EMAIL;
   } else if (text_input_type == "TextInputType.url") {
-    panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_URL;
+    *panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_URL;
   } else if (text_input_type == "TextInputType.visiblePassword") {
-    panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_PASSWORD;
+    *panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_PASSWORD;
   } else if (text_input_type == "TextInputType.name" ||
              text_input_type == "TextInputType.address") {
     FT_LOGW(
         "Actual requested text input type is [%s], but select "
         "TextInputType.text as fallback type",
         text_input_type.c_str());
-    panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_NORMAL;
+    *panel_layout = ECORE_IMF_INPUT_PANEL_LAYOUT_NORMAL;
   } else {
     return false;
   }
@@ -618,7 +618,7 @@ void TextInputChannel::ShowSoftwareKeyboard() {
   if (imf_context_ && !is_software_keyboard_showing_) {
     is_software_keyboard_showing_ = true;
     Ecore_IMF_Input_Panel_Layout panel_layout;
-    if (TextInputTypeToEcoreIMFInputPanelLayout(input_type_, panel_layout)) {
+    if (TextInputTypeToEcoreIMFInputPanelLayout(input_type_, &panel_layout)) {
       ecore_imf_context_input_panel_layout_set(imf_context_, panel_layout);
     }
     ecore_imf_context_input_panel_show(imf_context_);

--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -403,8 +403,7 @@ bool TextInputChannel::FilterEvent(Ecore_Event_Key* keyDownEvent) {
   bool handled = false;
 
 #ifdef TIZEN_RENDERER_EVAS_GL
-  // TODO(bbrto21): Hardware keyboard is not supported when running in Evas GL
-  // mode.
+  // Hardware keyboard not supported when running in Evas GL mode.
   bool isIME = true;
 #else
   bool isIME = ecore_imf_context_keyboard_mode_get(imf_context_) ==

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -334,7 +334,7 @@ void FlutterTizenEngine::SendWindowMetrics(int32_t width,
     // https://docs.tizen.org/application/native/guides/ui/efl/multiple-screens
     double dpi = 72.0;
     if (renderer && device_profile != DeviceProfile::kTV) {
-      dpi = (double)renderer->GetDpi();
+      dpi = static_cast<double>(renderer->GetDpi());
     }
     double profile_factor = 1.0;
     if (device_profile == DeviceProfile::kWearable) {

--- a/shell/platform/tizen/tizen_event_loop.cc
+++ b/shell/platform/tizen/tizen_event_loop.cc
@@ -80,7 +80,7 @@ void TizenEventLoop::ExcuteTaskEvents(void* data,
   auto* p_task = reinterpret_cast<Task*>(buffer);
 
   const double flutter_duration =
-      ((double)(p_task->fire_time.time_since_epoch().count()) -
+      (static_cast<double>(p_task->fire_time.time_since_epoch().count()) -
        FlutterEngineGetCurrentTime()) /
       1000000000.0;
   if (flutter_duration > 0) {
@@ -118,10 +118,9 @@ TizenRenderEventLoop::TizenRenderEventLoop(std::thread::id main_thread_id,
                                            TizenRenderer* renderer)
     : TizenEventLoop(main_thread_id, on_task_expired), renderer_(renderer) {
   evas_object_image_pixels_get_callback_set(
-      (Evas_Object*)static_cast<TizenRendererEvasGL*>(renderer_)
-          ->GetImageHandle(),
+      static_cast<TizenRendererEvasGL*>(renderer_)->GetImageHandle(),
       [](void* data, Evas_Object* o) {  // Render callback
-        TizenRenderEventLoop* self = (TizenRenderEventLoop*)data;
+        TizenRenderEventLoop* self = static_cast<TizenRenderEventLoop*>(data);
         {
           std::lock_guard<std::mutex> lock(self->expired_tasks_mutex_);
           for (const auto& task : self->expired_tasks_) {
@@ -142,8 +141,7 @@ void TizenRenderEventLoop::OnTaskExpired() {
   expired_tasks_count = expired_tasks_.size();
   if (!has_pending_renderer_callback_ && expired_tasks_count) {
     evas_object_image_pixels_dirty_set(
-        (Evas_Object*)static_cast<TizenRendererEvasGL*>(renderer_)
-            ->GetImageHandle(),
+        static_cast<TizenRendererEvasGL*>(renderer_)->GetImageHandle(),
         EINA_TRUE);
     has_pending_renderer_callback_ = true;
   } else {

--- a/shell/platform/tizen/tizen_log.cc
+++ b/shell/platform/tizen/tizen_log.cc
@@ -14,7 +14,7 @@ static pthread_t stderr_thread;
 static bool is_running = false;
 
 static void* LoggingFunction(void* arg) {
-  int* pipe = (int*)arg;
+  int* pipe = static_cast<int*>(arg);
   auto priority = pipe == stdout_pipe ? DLOG_INFO : DLOG_ERROR;
 
   ssize_t size;

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -227,7 +227,7 @@ int32_t TizenRendererEcoreWl2::GetDpi() {
 }
 
 uintptr_t TizenRendererEcoreWl2::GetWindowId() {
-  return (uintptr_t)ecore_wl2_window_id_get(ecore_wl2_window_);
+  return ecore_wl2_window_id_get(ecore_wl2_window_);
 }
 
 bool TizenRendererEcoreWl2::InitializeRenderer() {
@@ -306,13 +306,11 @@ bool TizenRendererEcoreWl2::SetupEglWindow(int32_t width, int32_t height) {
 }
 
 EGLDisplay TizenRendererEcoreWl2::GetEGLDisplay() {
-  return eglGetDisplay(
-      (EGLNativeDisplayType)ecore_wl2_display_get(ecore_wl2_display_));
+  return eglGetDisplay(ecore_wl2_display_get(ecore_wl2_display_));
 }
 
 EGLNativeWindowType TizenRendererEcoreWl2::GetEGLNativeWindowType() {
-  return (EGLNativeWindowType)ecore_wl2_egl_window_native_get(
-      ecore_wl2_egl_window_);
+  return ecore_wl2_egl_window_native_get(ecore_wl2_egl_window_);
 }
 
 void TizenRendererEcoreWl2::DestroyEglWindow() {

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -562,8 +562,8 @@ uintptr_t TizenRendererEvasGL::GetWindowId() {
       ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_)));
 }
 
-void* TizenRendererEvasGL::GetImageHandle() {
-  return (void*)graphics_adapter_;
+Evas_Object* TizenRendererEvasGL::GetImageHandle() {
+  return graphics_adapter_;
 }
 
 bool TizenRendererEvasGL::InitializeRenderer() {
@@ -577,7 +577,7 @@ bool TizenRendererEvasGL::InitializeRenderer() {
 }
 
 void TizenRendererEvasGL::Show() {
-  evas_object_show((Evas_Object*)GetImageHandle());
+  evas_object_show(GetImageHandle());
   evas_object_show(evas_window_);
 }
 
@@ -588,8 +588,7 @@ void TizenRendererEvasGL::DestroyRenderer() {
 
 bool TizenRendererEvasGL::SetupEvasGL() {
   int32_t width, height;
-  evas_gl_ = evas_gl_new(
-      evas_object_evas_get((Evas_Object*)SetupEvasWindow(width, height)));
+  evas_gl_ = evas_gl_new(evas_object_evas_get(SetupEvasWindow(width, height)));
   if (!evas_gl_) {
     FT_LOGE("SetupEvasWindow fail");
     return false;
@@ -628,12 +627,13 @@ bool TizenRendererEvasGL::SetupEvasGL() {
 
   Evas_Native_Surface ns;
   evas_gl_native_surface_get(evas_gl_, gl_surface_, &ns);
-  evas_object_image_native_surface_set((Evas_Object*)GetImageHandle(), &ns);
+  evas_object_image_native_surface_set(GetImageHandle(), &ns);
 
   return true;
 }
 
-void* TizenRendererEvasGL::SetupEvasWindow(int32_t& width, int32_t& height) {
+Evas_Object* TizenRendererEvasGL::SetupEvasWindow(int32_t& width,
+                                                  int32_t& height) {
   elm_config_accel_preference_set("hw:opengl");
 
   evas_window_ = elm_win_add(NULL, NULL, ELM_WIN_BASIC);
@@ -665,12 +665,11 @@ void* TizenRendererEvasGL::SetupEvasWindow(int32_t& width, int32_t& height) {
   evas_object_image_alpha_set(graphics_adapter_, EINA_TRUE);
   elm_win_resize_object_add(evas_window_, graphics_adapter_);
 
-  int rotations[4] = {0, 90, 180, 270};
-  elm_win_wm_rotation_available_rotations_set(evas_window_,
-                                              (const int*)(&rotations), 4);
+  const int rotations[4] = {0, 90, 180, 270};
+  elm_win_wm_rotation_available_rotations_set(evas_window_, &rotations[0], 4);
   evas_object_smart_callback_add(evas_window_, "rotation,changed",
                                  RotationEventCb, this);
-  return (void*)evas_window_;
+  return evas_window_;
 }
 
 void TizenRendererEvasGL::DestroyEvasGL() {
@@ -693,7 +692,7 @@ void TizenRendererEvasGL::RotationEventCb(void* data,
                                           Evas_Object* obj,
                                           void* event_info) {
   auto* self = reinterpret_cast<TizenRendererEvasGL*>(data);
-  // TODO : Use current window rotation degree
+  // TODO(bbrto21): Use current window rotation degree
   FT_UNIMPLEMENTED();
   self->delegate_.OnOrientationChange(0);
 }

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -692,7 +692,6 @@ void TizenRendererEvasGL::RotationEventCb(void* data,
                                           Evas_Object* obj,
                                           void* event_info) {
   auto* self = reinterpret_cast<TizenRendererEvasGL*>(data);
-  // TODO(bbrto21): Use current window rotation degree
   FT_UNIMPLEMENTED();
   self->delegate_.OnOrientationChange(0);
 }

--- a/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -36,7 +36,7 @@ class TizenRendererEvasGL : public TizenRenderer {
   void SetRotate(int angle) override;
   void SetPreferredOrientations(const std::vector<int>& rotations) override;
 
-  void* GetImageHandle();
+  Evas_Object* GetImageHandle();
 
  private:
   void ClearColor(float r, float g, float b, float a);
@@ -46,7 +46,7 @@ class TizenRendererEvasGL : public TizenRenderer {
   void DestroyRenderer();
 
   bool SetupEvasGL();
-  void* SetupEvasWindow(int32_t& width, int32_t& height);
+  Evas_Object* SetupEvasWindow(int32_t& width, int32_t& height);
   void DestroyEvasGL();
   void DestroyEvasWindow();
 

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -55,7 +55,8 @@ void TizenVsyncWaiter::SendMessage(int val) {
   }
   Msg* msg;
   void* ref;
-  msg = (Msg*)eina_thread_queue_send(vblank_thread_queue, sizeof(Msg), &ref);
+  msg = static_cast<Msg*>(
+      eina_thread_queue_send(vblank_thread_queue, sizeof(Msg), &ref));
   msg->value = val;
   eina_thread_queue_send_done(vblank_thread_queue, ref);
 }
@@ -70,7 +71,7 @@ void TizenVsyncWaiter::RequestVblankLoop(void* data, Ecore_Thread* thread) {
       FT_LOGE("Vblank thread queue is not valid");
       return;
     }
-    msg = (Msg*)eina_thread_queue_wait(vblank_thread_queue, &ref);
+    msg = static_cast<Msg*>(eina_thread_queue_wait(vblank_thread_queue, &ref));
     if (msg) {
       eina_thread_queue_wait_done(vblank_thread_queue, ref);
     } else {


### PR DESCRIPTION
Resolve some warnings generated by clang-tidy to meet the Google C++ style convention.
- Add missing braces.
- Convert C-style casts to C++-style casts (`static_cast`, `reinterpret_cast`). Return types of some functions (e.g. `GetImageHandle`) were changed as necessary.
- Format TODOs.

There only remain 4 warnings now. I'm not going to fix them right now.

How to run clang-tidy:
1. Add this line to the `.clang-tidy` file.<p>
   ```
   WarningsAsErrors: 'google-*'
   ```
1. Replace `calcTidyPath(firstCommand)` with `'clang-tidy-11'` in `ci/bin/lint.dart`.
1. Run `ci/lint.sh`.