### PR TITLE
Use proc table for embedder APIs

### DIFF
--- a/shell/platform/tizen/channels/lifecycle_channel.cc
+++ b/shell/platform/tizen/channels/lifecycle_channel.cc
@@ -4,6 +4,7 @@
 
 #include "lifecycle_channel.h"
 
+#include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/tizen_log.h"
 
 static constexpr char kChannelName[] = "flutter/lifecycle";
@@ -12,20 +13,15 @@ static constexpr char kResumed[] = "AppLifecycleState.resumed";
 static constexpr char kPaused[] = "AppLifecycleState.paused";
 static constexpr char kDetached[] = "AppLifecycleState.detached";
 
-LifecycleChannel::LifecycleChannel(FLUTTER_API_SYMBOL(FlutterEngine)
-                                       flutter_engine)
-    : flutter_engine_(flutter_engine) {}
+LifecycleChannel::LifecycleChannel(FlutterTizenEngine* engine)
+    : engine_(engine) {}
 
 LifecycleChannel::~LifecycleChannel() {}
 
 void LifecycleChannel::SendLifecycleMessage(const char message[]) {
-  FlutterPlatformMessage platformMessage = {};
-  platformMessage.struct_size = sizeof(FlutterPlatformMessage);
-  platformMessage.channel = kChannelName;
-  platformMessage.message = reinterpret_cast<const uint8_t*>(message);
-  platformMessage.message_size = strlen(message);
-  platformMessage.response_handle = nullptr;
-  FlutterEngineSendPlatformMessage(flutter_engine_, &platformMessage);
+  engine_->SendPlatformMessage(kChannelName,
+                               reinterpret_cast<const uint8_t*>(message),
+                               strlen(message), nullptr, nullptr);
 }
 
 void LifecycleChannel::AppIsInactive() {

--- a/shell/platform/tizen/channels/lifecycle_channel.h
+++ b/shell/platform/tizen/channels/lifecycle_channel.h
@@ -5,11 +5,11 @@
 #ifndef EMBEDDER_LIFECYCLE_CHANNEL_H_
 #define EMBEDDER_LIFECYCLE_CHANNEL_H_
 
-#include "flutter/shell/platform/embedder/embedder.h"
+class FlutterTizenEngine;
 
 class LifecycleChannel {
  public:
-  explicit LifecycleChannel(FLUTTER_API_SYMBOL(FlutterEngine) flutter_engine);
+  explicit LifecycleChannel(FlutterTizenEngine* engine);
   virtual ~LifecycleChannel();
 
   void AppIsInactive();
@@ -19,7 +19,7 @@ class LifecycleChannel {
   void SendLifecycleMessage(const char message[]);
 
  private:
-  FLUTTER_API_SYMBOL(FlutterEngine) flutter_engine_;
+  FlutterTizenEngine* engine_{nullptr};
 };
 
 #endif  // EMBEDDER_LIFECYCLE_CHANNEL_H_

--- a/shell/platform/tizen/channels/localization_channel.h
+++ b/shell/platform/tizen/channels/localization_channel.h
@@ -7,10 +7,11 @@
 
 #include "flutter/shell/platform/embedder/embedder.h"
 
+class FlutterTizenEngine;
+
 class LocalizationChannel {
  public:
-  explicit LocalizationChannel(FLUTTER_API_SYMBOL(FlutterEngine)
-                                   flutter_engine);
+  explicit LocalizationChannel(FlutterTizenEngine* engine);
   virtual ~LocalizationChannel();
 
   void SendLocales();
@@ -20,7 +21,7 @@ class LocalizationChannel {
   FlutterLocale* GetFlutterLocale(const char* locale);
   void DestroyFlutterLocale(FlutterLocale* flutter_locale);
 
-  FLUTTER_API_SYMBOL(FlutterEngine) flutter_engine_;
+  FlutterTizenEngine* engine_;
 };
 
 #endif  // EMBEDDER_LOCALIZATION_CHANNEL_H_

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -88,29 +88,8 @@ bool FlutterDesktopMessengerSendWithReply(FlutterDesktopMessengerRef messenger,
                                           const size_t message_size,
                                           const FlutterDesktopBinaryReply reply,
                                           void* user_data) {
-  FlutterPlatformMessageResponseHandle* response_handle = nullptr;
-  if (reply != nullptr && user_data != nullptr) {
-    FlutterEngineResult result = FlutterPlatformMessageCreateResponseHandle(
-        messenger->engine->flutter_engine, reply, user_data, &response_handle);
-    if (result != kSuccess) {
-      FT_LOGE("Failed to create response handle");
-      return false;
-    }
-  }
-  FlutterPlatformMessage platform_message = {
-      sizeof(FlutterPlatformMessage),
-      channel,
-      message,
-      message_size,
-      response_handle,
-  };
-  FlutterEngineResult message_result = FlutterEngineSendPlatformMessage(
-      messenger->engine->flutter_engine, &platform_message);
-  if (response_handle != nullptr) {
-    FlutterPlatformMessageReleaseResponseHandle(
-        messenger->engine->flutter_engine, response_handle);
-  }
-  return message_result == kSuccess;
+  return messenger->engine->SendPlatformMessage(channel, message, message_size,
+                                                reply, user_data);
 }
 
 void FlutterDesktopMessengerSendResponse(
@@ -118,8 +97,7 @@ void FlutterDesktopMessengerSendResponse(
     const FlutterDesktopMessageResponseHandle* handle,
     const uint8_t* data,
     size_t data_length) {
-  FlutterEngineSendPlatformMessageResponse(messenger->engine->flutter_engine,
-                                           handle, data, data_length);
+  messenger->engine->SendPlatformMessageResponse(handle, data, data_length);
 }
 
 void FlutterDesktopMessengerSetCallback(FlutterDesktopMessengerRef messenger,
@@ -151,8 +129,7 @@ void FlutterDesktopNotifyAppIsDetached(FlutterDesktopEngineRef engine) {
 }
 
 void FlutterDesktopNotifyLowMemoryWarning(FlutterDesktopEngineRef engine) {
-  auto flutter_engine = EngineFromHandle(engine)->flutter_engine;
-  FlutterEngineNotifyLowMemoryWarning(flutter_engine);
+  EngineFromHandle(engine)->NotifyLowMemoryWarning();
 }
 
 void FlutterRegisterViewFactory(

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -40,13 +40,16 @@ static DeviceProfile GetDeviceProfile() {
 
 FlutterTizenEngine::FlutterTizenEngine(bool headed)
     : device_profile(GetDeviceProfile()) {
+  embedder_api_.struct_size = sizeof(FlutterEngineProcTable);
+  FlutterEngineGetProcAddresses(&embedder_api_);
+
   // Run flutter task on Tizen main loop.
   // Tizen engine has four threads (GPU thread, UI thread, IO thread, platform
   // thread). UI threads need to send flutter task to platform thread.
   event_loop_ = std::make_unique<TizenPlatformEventLoop>(
       std::this_thread::get_id(),  // main thread
       [this](const auto* task) {
-        if (FlutterEngineRunTask(this->flutter_engine, task) != kSuccess) {
+        if (embedder_api_.RunTask(this->flutter_engine, task) != kSuccess) {
           FT_LOGE("Could not post an engine task.");
         }
       });
@@ -75,7 +78,7 @@ void FlutterTizenEngine::InitializeRenderer() {
   render_loop_ = std::make_unique<TizenRenderEventLoop>(
       std::this_thread::get_id(),  // main thread
       [this](const auto* task) {
-        if (FlutterEngineRunTask(this->flutter_engine, task) != kSuccess) {
+        if (embedder_api_.RunTask(this->flutter_engine, task) != kSuccess) {
           FT_LOGE("Could not post an engine task.");
         }
       },
@@ -87,9 +90,13 @@ void FlutterTizenEngine::InitializeRenderer() {
 #endif
 }
 
+void FlutterTizenEngine::NotifyLowMemoryWarning() {
+  embedder_api_.NotifyLowMemoryWarning(flutter_engine);
+}
+
 // Attempts to load AOT data from the given path, which must be absolute and
 // non-empty. Logs and returns nullptr on failure.
-UniqueAotDataPtr LoadAotData(std::string aot_data_path) {
+UniqueAotDataPtr FlutterTizenEngine::LoadAotData(std::string aot_data_path) {
   if (aot_data_path.empty()) {
     FT_LOGE(
         "Attempted to load AOT data, but no aot_library_path was provided.");
@@ -104,7 +111,7 @@ UniqueAotDataPtr LoadAotData(std::string aot_data_path) {
   source.type = kFlutterEngineAOTDataSourceTypeElfPath;
   source.elf_path = aot_data_path.c_str();
   FlutterEngineAOTData data = nullptr;
-  auto result = FlutterEngineCreateAOTData(&source, &data);
+  auto result = embedder_api_.CreateAOTData(&source, &data);
   if (result != kSuccess) {
     FT_LOGE("Failed to load AOT data from: %s", aot_data_path.c_str());
     return nullptr;
@@ -180,7 +187,7 @@ bool FlutterTizenEngine::RunEngine(
   }
 #endif
 
-  if (FlutterEngineRunsAOTCompiledDartCode()) {
+  if (embedder_api_.RunsAOTCompiledDartCode()) {
     aot_data_ = LoadAotData(engine_properties.aot_library_path);
     if (!aot_data_) {
       FT_LOGE("Unable to start engine without AOT data.");
@@ -191,8 +198,8 @@ bool FlutterTizenEngine::RunEngine(
 
   FlutterRendererConfig renderer_config = GetRendererConfig();
 
-  auto result = FlutterEngineRun(FLUTTER_ENGINE_VERSION, &renderer_config,
-                                 &args, this, &flutter_engine);
+  auto result = embedder_api_.Run(FLUTTER_ENGINE_VERSION, &renderer_config,
+                                  &args, this, &flutter_engine);
   if (result == kSuccess && flutter_engine != nullptr) {
     FT_LOGD("FlutterEngineRun Success!");
   } else {
@@ -207,9 +214,10 @@ bool FlutterTizenEngine::RunEngine(
       internal_plugin_registrar_->messenger(), renderer.get());
   settings_channel = std::make_unique<SettingsChannel>(
       internal_plugin_registrar_->messenger());
-  localization_channel = std::make_unique<LocalizationChannel>(flutter_engine);
+  localization_channel = std::make_unique<LocalizationChannel>(this);
   localization_channel->SendLocales();
-  lifecycle_channel = std::make_unique<LifecycleChannel>(flutter_engine);
+  lifecycle_channel = std::make_unique<LifecycleChannel>(this);
+
   if (IsHeaded()) {
     texture_registrar_ = std::make_unique<FlutterTizenTextureRegistrar>(this);
     key_event_channel = std::make_unique<KeyEventChannel>(
@@ -237,7 +245,7 @@ bool FlutterTizenEngine::StopEngine() {
     if (plugin_registrar_destruction_callback_) {
       plugin_registrar_destruction_callback_(plugin_registrar_.get());
     }
-    FlutterEngineResult result = FlutterEngineShutdown(flutter_engine);
+    FlutterEngineResult result = embedder_api_.Shutdown(flutter_engine);
     flutter_engine = nullptr;
     return (result == kSuccess);
   }
@@ -255,6 +263,52 @@ FlutterTizenTextureRegistrar* FlutterTizenEngine::GetTextureRegistrar() {
 void FlutterTizenEngine::SetPluginRegistrarDestructionCallback(
     FlutterDesktopOnPluginRegistrarDestroyed callback) {
   plugin_registrar_destruction_callback_ = callback;
+}
+
+bool FlutterTizenEngine::SendPlatformMessage(
+    const char* channel,
+    const uint8_t* message,
+    const size_t message_size,
+    const FlutterDesktopBinaryReply reply,
+    void* user_data) {
+  FlutterPlatformMessageResponseHandle* response_handle = nullptr;
+  if (reply != nullptr && user_data != nullptr) {
+    FlutterEngineResult result =
+        embedder_api_.PlatformMessageCreateResponseHandle(
+            flutter_engine, reply, user_data, &response_handle);
+    if (result != kSuccess) {
+      std::cout << "Failed to create response handle\n";
+      return false;
+    }
+  }
+
+  FlutterPlatformMessage platform_message = {
+      sizeof(FlutterPlatformMessage),
+      channel,
+      message,
+      message_size,
+      response_handle,
+  };
+
+  FlutterEngineResult message_result =
+      embedder_api_.SendPlatformMessage(flutter_engine, &platform_message);
+  if (response_handle != nullptr) {
+    embedder_api_.PlatformMessageReleaseResponseHandle(flutter_engine,
+                                                       response_handle);
+  }
+  return message_result == kSuccess;
+}
+
+void FlutterTizenEngine::SendPlatformMessageResponse(
+    const FlutterDesktopMessageResponseHandle* handle,
+    const uint8_t* data,
+    size_t data_length) {
+  embedder_api_.SendPlatformMessageResponse(flutter_engine, handle, data,
+                                            data_length);
+}
+
+void FlutterTizenEngine::SendPointerEvent(const FlutterPointerEvent& event) {
+  embedder_api_.SendPointerEvent(flutter_engine, &event, 1);
 }
 
 void FlutterTizenEngine::SendWindowMetrics(int32_t width,
@@ -285,7 +339,7 @@ void FlutterTizenEngine::SendWindowMetrics(int32_t width,
   } else {
     event.pixel_ratio = pixel_ratio;
   }
-  FlutterEngineSendWindowMetricsEvent(flutter_engine, &event);
+  embedder_api_.SendWindowMetricsEvent(flutter_engine, &event);
 }
 
 // This must be called at least once in order to initialize the value of
@@ -329,6 +383,33 @@ void FlutterTizenEngine::SetWindowOrientation(int32_t degree) {
 
 void FlutterTizenEngine::OnOrientationChange(int32_t degree) {
   SetWindowOrientation(degree);
+}
+
+void FlutterTizenEngine::OnVsync(intptr_t baton,
+                                 uint64_t frame_start_time_nanos,
+                                 uint64_t frame_target_time_nanos) {
+  embedder_api_.OnVsync(flutter_engine, baton, frame_start_time_nanos,
+                        frame_target_time_nanos);
+}
+
+void FlutterTizenEngine::UpdateLocales(const FlutterLocale** locales,
+                                       size_t locales_count) {
+  embedder_api_.UpdateLocales(flutter_engine, locales, locales_count);
+}
+
+bool FlutterTizenEngine::RegisterExternalTexture(int64_t texture_id) {
+  return (embedder_api_.RegisterExternalTexture(flutter_engine, texture_id) ==
+          kSuccess);
+}
+
+bool FlutterTizenEngine::UnregisterExternalTexture(int64_t texture_id) {
+  return (embedder_api_.UnregisterExternalTexture(flutter_engine, texture_id) ==
+          kSuccess);
+}
+
+bool FlutterTizenEngine::MarkExternalTextureFrameAvailable(int64_t texture_id) {
+  return (embedder_api_.MarkExternalTextureFrameAvailable(
+              flutter_engine, texture_id) == kSuccess);
 }
 
 // The Flutter Engine calls out to this function when new platform messages are

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -49,7 +49,7 @@ FlutterTizenEngine::FlutterTizenEngine(bool headed)
   event_loop_ = std::make_unique<TizenPlatformEventLoop>(
       std::this_thread::get_id(),  // main thread
       [this](const auto* task) {
-        if (embedder_api_.RunTask(this->flutter_engine, task) != kSuccess) {
+        if (embedder_api_.RunTask(this->engine_, task) != kSuccess) {
           FT_LOGE("Could not post an engine task.");
         }
       });
@@ -78,7 +78,7 @@ void FlutterTizenEngine::InitializeRenderer() {
   render_loop_ = std::make_unique<TizenRenderEventLoop>(
       std::this_thread::get_id(),  // main thread
       [this](const auto* task) {
-        if (embedder_api_.RunTask(this->flutter_engine, task) != kSuccess) {
+        if (embedder_api_.RunTask(this->engine_, task) != kSuccess) {
           FT_LOGE("Could not post an engine task.");
         }
       },
@@ -91,7 +91,7 @@ void FlutterTizenEngine::InitializeRenderer() {
 }
 
 void FlutterTizenEngine::NotifyLowMemoryWarning() {
-  embedder_api_.NotifyLowMemoryWarning(flutter_engine);
+  embedder_api_.NotifyLowMemoryWarning(engine_);
 }
 
 // Attempts to load AOT data from the given path, which must be absolute and
@@ -176,7 +176,18 @@ bool FlutterTizenEngine::RunEngine(
   args.icu_data_path = engine_properties.icu_data_path;
   args.command_line_argc = static_cast<int>(argv.size());
   args.command_line_argv = &argv[0];
-  args.platform_message_callback = OnFlutterPlatformMessage;
+  args.platform_message_callback =
+      [](const FlutterPlatformMessage* engine_message, void* user_data) {
+        if (engine_message->struct_size != sizeof(FlutterPlatformMessage)) {
+          FT_LOGE(
+              "Invalid message size received. Expected: %zu, but received %zu",
+              sizeof(FlutterPlatformMessage), engine_message->struct_size);
+          return;
+        }
+        auto engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+        auto message = engine->ConvertToDesktopMessage(*engine_message);
+        engine->message_dispatcher->HandleMessage(message);
+      };
   args.custom_task_runners = &custom_task_runners;
 #ifndef TIZEN_RENDERER_EVAS_GL
   if (IsHeaded()) {
@@ -199,8 +210,8 @@ bool FlutterTizenEngine::RunEngine(
   FlutterRendererConfig renderer_config = GetRendererConfig();
 
   auto result = embedder_api_.Run(FLUTTER_ENGINE_VERSION, &renderer_config,
-                                  &args, this, &flutter_engine);
-  if (result == kSuccess && flutter_engine != nullptr) {
+                                  &args, this, &engine_);
+  if (result == kSuccess && engine_ != nullptr) {
     FT_LOGD("FlutterEngineRun Success!");
   } else {
     FT_LOGE("FlutterEngineRun Failure! result: %d", result);
@@ -238,15 +249,15 @@ bool FlutterTizenEngine::RunEngine(
 }
 
 bool FlutterTizenEngine::StopEngine() {
-  if (flutter_engine) {
+  if (engine_) {
     if (platform_view_channel) {
       platform_view_channel->Dispose();
     }
     if (plugin_registrar_destruction_callback_) {
       plugin_registrar_destruction_callback_(plugin_registrar_.get());
     }
-    FlutterEngineResult result = embedder_api_.Shutdown(flutter_engine);
-    flutter_engine = nullptr;
+    FlutterEngineResult result = embedder_api_.Shutdown(engine_);
+    engine_ = nullptr;
     return (result == kSuccess);
   }
   return false;
@@ -275,9 +286,9 @@ bool FlutterTizenEngine::SendPlatformMessage(
   if (reply != nullptr && user_data != nullptr) {
     FlutterEngineResult result =
         embedder_api_.PlatformMessageCreateResponseHandle(
-            flutter_engine, reply, user_data, &response_handle);
+            engine_, reply, user_data, &response_handle);
     if (result != kSuccess) {
-      std::cout << "Failed to create response handle\n";
+      FT_LOGE("Failed to create response handle");
       return false;
     }
   }
@@ -291,9 +302,9 @@ bool FlutterTizenEngine::SendPlatformMessage(
   };
 
   FlutterEngineResult message_result =
-      embedder_api_.SendPlatformMessage(flutter_engine, &platform_message);
+      embedder_api_.SendPlatformMessage(engine_, &platform_message);
   if (response_handle != nullptr) {
-    embedder_api_.PlatformMessageReleaseResponseHandle(flutter_engine,
+    embedder_api_.PlatformMessageReleaseResponseHandle(engine_,
                                                        response_handle);
   }
   return message_result == kSuccess;
@@ -303,12 +314,11 @@ void FlutterTizenEngine::SendPlatformMessageResponse(
     const FlutterDesktopMessageResponseHandle* handle,
     const uint8_t* data,
     size_t data_length) {
-  embedder_api_.SendPlatformMessageResponse(flutter_engine, handle, data,
-                                            data_length);
+  embedder_api_.SendPlatformMessageResponse(engine_, handle, data, data_length);
 }
 
 void FlutterTizenEngine::SendPointerEvent(const FlutterPointerEvent& event) {
-  embedder_api_.SendPointerEvent(flutter_engine, &event, 1);
+  embedder_api_.SendPointerEvent(engine_, &event, 1);
 }
 
 void FlutterTizenEngine::SendWindowMetrics(int32_t width,
@@ -339,7 +349,7 @@ void FlutterTizenEngine::SendWindowMetrics(int32_t width,
   } else {
     event.pixel_ratio = pixel_ratio;
   }
-  embedder_api_.SendWindowMetricsEvent(flutter_engine, &event);
+  embedder_api_.SendWindowMetricsEvent(engine_, &event);
 }
 
 // This must be called at least once in order to initialize the value of
@@ -388,44 +398,32 @@ void FlutterTizenEngine::OnOrientationChange(int32_t degree) {
 void FlutterTizenEngine::OnVsync(intptr_t baton,
                                  uint64_t frame_start_time_nanos,
                                  uint64_t frame_target_time_nanos) {
-  embedder_api_.OnVsync(flutter_engine, baton, frame_start_time_nanos,
+  embedder_api_.OnVsync(engine_, baton, frame_start_time_nanos,
                         frame_target_time_nanos);
 }
 
 void FlutterTizenEngine::UpdateLocales(const FlutterLocale** locales,
                                        size_t locales_count) {
-  embedder_api_.UpdateLocales(flutter_engine, locales, locales_count);
+  embedder_api_.UpdateLocales(engine_, locales, locales_count);
 }
 
 bool FlutterTizenEngine::RegisterExternalTexture(int64_t texture_id) {
-  return (embedder_api_.RegisterExternalTexture(flutter_engine, texture_id) ==
+  return (embedder_api_.RegisterExternalTexture(engine_, texture_id) ==
           kSuccess);
 }
 
 bool FlutterTizenEngine::UnregisterExternalTexture(int64_t texture_id) {
-  return (embedder_api_.UnregisterExternalTexture(flutter_engine, texture_id) ==
+  return (embedder_api_.UnregisterExternalTexture(engine_, texture_id) ==
           kSuccess);
 }
 
 bool FlutterTizenEngine::MarkExternalTextureFrameAvailable(int64_t texture_id) {
   return (embedder_api_.MarkExternalTextureFrameAvailable(
-              flutter_engine, texture_id) == kSuccess);
+              engine_, texture_id) == kSuccess);
 }
 
 // The Flutter Engine calls out to this function when new platform messages are
 // available.
-void FlutterTizenEngine::OnFlutterPlatformMessage(
-    const FlutterPlatformMessage* engine_message,
-    void* user_data) {
-  if (engine_message->struct_size != sizeof(FlutterPlatformMessage)) {
-    FT_LOGE("Invalid message size received. Expected: %zu, but received %zu",
-            sizeof(FlutterPlatformMessage), engine_message->struct_size);
-    return;
-  }
-  auto engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
-  auto message = engine->ConvertToDesktopMessage(*engine_message);
-  engine->message_dispatcher->HandleMessage(message);
-}
 
 // Converts a FlutterPlatformMessage to an equivalent FlutterDesktopMessage.
 FlutterDesktopMessage FlutterTizenEngine::ConvertToDesktopMessage(

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -67,9 +67,6 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
   FlutterTizenEngine& operator=(FlutterTizenEngine const&) = delete;
 
   void InitializeRenderer();
-
-  void NotifyLowMemoryWarning();
-
   bool RunEngine(const FlutterDesktopEngineProperties& engine_properties);
   bool StopEngine();
 
@@ -82,26 +79,44 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
   void SetPluginRegistrarDestructionCallback(
       FlutterDesktopOnPluginRegistrarDestroyed callback);
 
+  // Sends the given message to the engine, calling |reply| with |user_data|
+  // when a reponse is received from the engine if they are non-null.
   bool SendPlatformMessage(const char* channel,
                            const uint8_t* message,
                            const size_t message_size,
                            const FlutterDesktopBinaryReply reply,
                            void* user_data);
+
+  // Sends the given data as the response to an earlier platform message.
   void SendPlatformMessageResponse(
       const FlutterDesktopMessageResponseHandle* handle,
       const uint8_t* data,
       size_t data_length);
+
+  // Informs the engine of an incoming pointer event.
   void SendPointerEvent(const FlutterPointerEvent& event);
+
+  // Sends a window metrics update to the Flutter engine using current window
+  // dimensions in physical
   void SendWindowMetrics(int32_t width, int32_t height, double pixel_ratio);
+
   void SetWindowOrientation(int32_t degree);
   void OnOrientationChange(int32_t degree) override;
   void OnVsync(intptr_t baton,
                uint64_t frame_start_time_nanos,
                uint64_t frame_target_time_nanos);
+
+  void NotifyLowMemoryWarning();
   void UpdateLocales(const FlutterLocale** locales, size_t locales_count);
 
+  // Attempts to register the texture with the given |texture_id|.
   bool RegisterExternalTexture(int64_t texture_id);
+
+  // Attempts to unregister the texture with the given |texture_id|.
   bool UnregisterExternalTexture(int64_t texture_id);
+
+  // Notifies the engine about a new frame being available for the
+  // given |texture_id|.
   bool MarkExternalTextureFrameAvailable(int64_t texture_id);
 
   // The plugin messenger handle given to API clients.
@@ -127,19 +142,15 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
 
  private:
   bool IsHeaded() { return renderer != nullptr; }
-
-  static void OnFlutterPlatformMessage(
-      const FlutterPlatformMessage* engine_message,
-      void* user_data);
+  UniqueAotDataPtr LoadAotData(std::string aot_data_path);
   FlutterDesktopMessage ConvertToDesktopMessage(
       const FlutterPlatformMessage& engine_message);
   FlutterRendererConfig GetRendererConfig();
-  UniqueAotDataPtr LoadAotData(std::string aot_data_path);
 
   FlutterEngineProcTable embedder_api_ = {};
 
   // The Flutter engine instance.
-  FLUTTER_API_SYMBOL(FlutterEngine) flutter_engine;
+  FLUTTER_API_SYMBOL(FlutterEngine) engine_;
 
   // The handlers listening to platform events.
   std::unique_ptr<KeyEventHandler> key_event_handler_;

--- a/shell/platform/tizen/flutter_tizen_texture_registrar.cc
+++ b/shell/platform/tizen/flutter_tizen_texture_registrar.cc
@@ -45,7 +45,7 @@ int64_t FlutterTizenTextureRegistrar::RegisterTexture(
     textures_[texture_id] = std::move(texture_gl);
   }
 
-  FlutterEngineRegisterExternalTexture(engine_->flutter_engine, texture_id);
+  engine_->RegisterExternalTexture(texture_id);
   return texture_id;
 }
 
@@ -58,15 +58,12 @@ bool FlutterTizenTextureRegistrar::UnregisterTexture(int64_t texture_id) {
     }
     textures_.erase(it);
   }
-
-  return FlutterEngineUnregisterExternalTexture(engine_->flutter_engine,
-                                                texture_id) == kSuccess;
+  return engine_->UnregisterExternalTexture(texture_id);
 }
 
 bool FlutterTizenTextureRegistrar::MarkTextureFrameAvailable(
     int64_t texture_id) {
-  return FlutterEngineMarkExternalTextureFrameAvailable(engine_->flutter_engine,
-                                                        texture_id) == kSuccess;
+  return engine_->MarkExternalTextureFrameAvailable(texture_id);
 }
 
 bool FlutterTizenTextureRegistrar::PopulateTexture(

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -153,10 +153,10 @@ void TizenVsyncWaiter::TdmClientVblankCallback(tdm_client_vblank* vblank,
       reinterpret_cast<TizenVsyncWaiter*>(user_data);
   FT_ASSERT(tizen_vsync_waiter != nullptr);
   FT_ASSERT(tizen_vsync_waiter->engine_ != nullptr);
-  FT_ASSERT(tizen_vsync_waiter->engine_->flutter_engine != nullptr);
+
   uint64_t frame_start_time_nanos = tv_sec * 1e9 + tv_usec * 1e3;
   uint64_t frame_target_time_nanos = 16.6 * 1e6 + frame_start_time_nanos;
-  FlutterEngineOnVsync(tizen_vsync_waiter->engine_->flutter_engine,
-                       tizen_vsync_waiter->baton_, frame_start_time_nanos,
-                       frame_target_time_nanos);
+  tizen_vsync_waiter->engine_->OnVsync(tizen_vsync_waiter->baton_,
+                                       frame_start_time_nanos,
+                                       frame_target_time_nanos);
 }

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -36,10 +36,6 @@ void TouchEventHandler::SendFlutterPointerEvent(FlutterPointerPhase phase,
                                                 double scroll_delta_y,
                                                 size_t timestamp,
                                                 int device_id = 0) {
-  if (!engine_->flutter_engine) {
-    return;
-  }
-
   // Correct errors caused by window rotation.
   auto window_geometry = engine_->renderer->GetGeometry();
   double width = window_geometry.w;
@@ -69,7 +65,8 @@ void TouchEventHandler::SendFlutterPointerEvent(FlutterPointerPhase phase,
   event.scroll_delta_y = scroll_delta_y * 2;
   event.timestamp = timestamp * 1000;
   event.device = device_id;
-  FlutterEngineSendPointerEvent(engine_->flutter_engine, &event, 1);
+
+  engine_->SendPointerEvent(event);
 }
 
 Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {


### PR DESCRIPTION
* Use the proc table like other platform implementations
* Use FlutterEngine as private memeber of FlutterTizenEngine
* Only FlutterTizenEngine is dependent on FlutterEngine

Signed-off-by: Boram Bae <boram21.bae@samsung.com>
