### PR TITLE
Initialize EventChannel state

### DIFF
--- a/shell/platform/common/cpp/client_wrapper/include/flutter/event_channel.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/event_channel.h
@@ -37,7 +37,10 @@ class EventChannel {
   EventChannel(BinaryMessenger* messenger,
                const std::string& name,
                const MethodCodec<T>* codec)
-      : messenger_(messenger), name_(name), codec_(codec) {}
+      : messenger_(messenger),
+        name_(name),
+        codec_(codec),
+        is_listening_(false) {}
   ~EventChannel() = default;
 
   // Prevent copying.


### PR DESCRIPTION
`OnCancel` was fired randomly on EventChannel registering, because of uninitialized `is_listening_` variable.