### PR TITLE
Show more symbols on profiling builds

### DIFF
--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -170,10 +170,6 @@ template("embedder_for_profile") {
       "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
       "//third_party/rapidjson",
     ]
-
-    if (enable_profiling) {
-      deps += [ "//flutter/runtime:libdart" ]
-    }
   }
 }
 

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -161,7 +161,6 @@ template("embedder_for_profile") {
     public_deps = [ ":flutter_engine" ]
 
     deps = [
-      "//flutter/runtime:libdart",
       "//flutter/shell/platform/common/cpp:common_cpp",
       "//flutter/shell/platform/common/cpp:common_cpp_input",
       "//flutter/shell/platform/common/cpp:common_cpp_library_headers",

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -5,6 +5,9 @@
 import("//flutter/shell/platform/common/cpp/client_wrapper/publish.gni")
 import("//flutter/shell/platform/tizen/config.gni")
 
+# define enable_profiling
+import("//build/config/profiler.gni")
+
 # Sets the rpath of dependent targets (shared libs) to $ORIGIN.
 # We assume that the flutter_engine library exists next to the embedder library
 # when they are deployed on Tizen devices.
@@ -167,6 +170,12 @@ template("embedder_for_profile") {
       "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
       "//third_party/rapidjson",
     ]
+
+    if (enable_profiling) {
+      deps += [
+        "//flutter/runtime:libdart"
+      ]
+    }
   }
 }
 

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -172,9 +172,7 @@ template("embedder_for_profile") {
     ]
 
     if (enable_profiling) {
-      deps += [
-        "//flutter/runtime:libdart"
-      ]
+      deps += [ "//flutter/runtime:libdart" ]
     }
   }
 }

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -161,6 +161,7 @@ template("embedder_for_profile") {
     public_deps = [ ":flutter_engine" ]
 
     deps = [
+      "//flutter/runtime:libdart",
       "//flutter/shell/platform/common/cpp:common_cpp",
       "//flutter/shell/platform/common/cpp:common_cpp_input",
       "//flutter/shell/platform/common/cpp:common_cpp_library_headers",

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -5,9 +5,6 @@
 import("//flutter/shell/platform/common/cpp/client_wrapper/publish.gni")
 import("//flutter/shell/platform/tizen/config.gni")
 
-# define enable_profiling
-import("//build/config/profiler.gni")
-
 # Sets the rpath of dependent targets (shared libs) to $ORIGIN.
 # We assume that the flutter_engine library exists next to the embedder library
 # when they are deployed on Tizen devices.

--- a/tools/gn
+++ b/tools/gn
@@ -282,7 +282,7 @@ def to_gn_args(args):
 
     # We should not need a special case for x86, but this seems to introduce text relocations
     # even with -fPIC everywhere.
-    # gn_args['enable_profiling'] = args.runtime_mode != 'release' and args.android_cpu != 'x86'
+    gn_args['enable_profiling'] = args.runtime_mode != 'release' and args.android_cpu != 'x86'
 
     if args.arm_float_abi:
       gn_args['arm_float_abi'] = args.arm_float_abi


### PR DESCRIPTION
This change turns on more symbols in profiling view of DevTools and thus partially solves #95.