### PR TITLE
Migrate to Flutter 2.2.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,14 @@ jobs:
   steps:
   - checkout: self
     path: src/flutter
+  - bash: |
+      git reset --hard HEAD
+      gclient sync -D
+      sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' build/config/compiler/BUILD.gn
+      sed -i 's/"-Wno-psabi",//g' build/config/compiler/BUILD.gn
+    displayName: Run gclient sync
+    workingDirectory: $(Pipeline.Workspace)/src
+    failOnStderr: true
   - bash: ci/format.sh
     displayName: Verify formatting
 - job: build
@@ -54,20 +62,9 @@ jobs:
     demands: agent.os -equals Linux
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 1
-  variables:
-  - name: buildroot
-    value: $(Pipeline.Workspace)/src
   steps:
   - checkout: self
     path: src/flutter
-  - bash: |
-      git reset --hard HEAD
-      gclient sync -D
-      sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' build/config/compiler/BUILD.gn
-      sed -i 's/"-Wno-psabi",//g' build/config/compiler/BUILD.gn
-    displayName: Prepare for build
-    workingDirectory: $(buildroot)
-    failOnStderr: true
   - bash: |
       flutter/tools/gn \
         --target-os linux \
@@ -81,7 +78,7 @@ jobs:
         --build-tizen-shell
       ninja -C out/linux_$(mode)_$(arch)
     displayName: Build
-    workingDirectory: $(buildroot)
+    workingDirectory: $(Pipeline.Workspace)/src
     failOnStderr: true
   - bash: |
       OUTDIR=$(Build.StagingDirectory)
@@ -92,7 +89,7 @@ jobs:
         rm $OUTDIR/common/cpp_client_wrapper/engine_method_result.cc
       fi
     displayName: Copy artifacts
-    workingDirectory: $(buildroot)
+    workingDirectory: $(Pipeline.Workspace)/src
     failOnStderr: true
   - publish: $(Build.StagingDirectory)
     artifact: $(System.JobName)
@@ -105,7 +102,7 @@ jobs:
     clean: outputs
   variables:
   - name: upstreamVersion
-    value: 40441def692f444660a11e20fac37af9050245ab
+    value: 0fdb562ac8068ce3dda6b69aca3f355f4d1d2718
   steps:
   - checkout: self
     path: src/flutter

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//flutter/shell/platform/common/cpp/client_wrapper/publish.gni")
+import("//flutter/shell/platform/common/client_wrapper/publish.gni")
 import("//flutter/shell/platform/tizen/config.gni")
 
 # Sets the rpath of dependent targets (shared libs) to $ORIGIN.
@@ -153,7 +153,7 @@ template("embedder_for_profile") {
 
     configs += [
       ":tizen_rootstrap_include_dirs",
-      "//flutter/shell/platform/common/cpp:desktop_library_implementation",
+      "//flutter/shell/platform/common:desktop_library_implementation",
     ]
 
     public_configs = [ "//flutter:config" ]
@@ -161,10 +161,10 @@ template("embedder_for_profile") {
     public_deps = [ ":flutter_engine" ]
 
     deps = [
-      "//flutter/shell/platform/common/cpp:common_cpp",
-      "//flutter/shell/platform/common/cpp:common_cpp_input",
-      "//flutter/shell/platform/common/cpp:common_cpp_library_headers",
-      "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
+      "//flutter/shell/platform/common:common_cpp",
+      "//flutter/shell/platform/common:common_cpp_input",
+      "//flutter/shell/platform/common:common_cpp_library_headers",
+      "//flutter/shell/platform/common/client_wrapper:client_wrapper",
       "//third_party/rapidjson",
     ]
   }
@@ -193,10 +193,10 @@ publish_client_wrapper_core("publish_cpp_client_wrapper") {
 }
 
 _common_cpp_public_headers = [
-  "//flutter/shell/platform/common/cpp/public/flutter_export.h",
-  "//flutter/shell/platform/common/cpp/public/flutter_messenger.h",
-  "//flutter/shell/platform/common/cpp/public/flutter_plugin_registrar.h",
-  "//flutter/shell/platform/common/cpp/public/flutter_texture_registrar.h",
+  "//flutter/shell/platform/common/public/flutter_export.h",
+  "//flutter/shell/platform/common/public/flutter_messenger.h",
+  "//flutter/shell/platform/common/public/flutter_plugin_registrar.h",
+  "//flutter/shell/platform/common/public/flutter_texture_registrar.h",
 ]
 
 copy("publish_headers_tizen") {

--- a/shell/platform/tizen/channels/key_event_channel.h
+++ b/shell/platform/tizen/channels/key_event_channel.h
@@ -7,9 +7,9 @@
 
 #include <Ecore_Input.h>
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/basic_message_channel.h"
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h"
-#include "flutter/shell/platform/common/cpp/json_message_codec.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
+#include "flutter/shell/platform/common/json_message_codec.h"
 #include "rapidjson/document.h"
 
 class KeyEventChannel {

--- a/shell/platform/tizen/channels/navigation_channel.cc
+++ b/shell/platform/tizen/channels/navigation_channel.cc
@@ -4,7 +4,7 @@
 
 #include "navigation_channel.h"
 
-#include "flutter/shell/platform/common/cpp/json_method_codec.h"
+#include "flutter/shell/platform/common/json_method_codec.h"
 
 static constexpr char kChannelName[] = "flutter/navigation";
 

--- a/shell/platform/tizen/channels/navigation_channel.h
+++ b/shell/platform/tizen/channels/navigation_channel.h
@@ -5,8 +5,8 @@
 #ifndef EMBEDDER_NAVIGATION_CHANNEL_H_
 #define EMBEDDER_NAVIGATION_CHANNEL_H_
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h"
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_channel.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
 #include "rapidjson/document.h"
 
 class NavigationChannel {

--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -9,7 +9,7 @@
 
 #include <map>
 
-#include "flutter/shell/platform/common/cpp/json_method_codec.h"
+#include "flutter/shell/platform/common/json_method_codec.h"
 #include "flutter/shell/platform/tizen/tizen_log.h"
 
 static constexpr char kChannelName[] = "flutter/platform";

--- a/shell/platform/tizen/channels/platform_channel.h
+++ b/shell/platform/tizen/channels/platform_channel.h
@@ -5,8 +5,8 @@
 #ifndef EMBEDDER_PLATFORM_CHANNEL_H_
 #define EMBEDDER_PLATFORM_CHANNEL_H_
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h"
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_channel.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
 #include "flutter/shell/platform/tizen/tizen_renderer.h"
 #include "rapidjson/document.h"
 

--- a/shell/platform/tizen/channels/platform_view_channel.cc
+++ b/shell/platform/tizen/channels/platform_view_channel.cc
@@ -3,10 +3,10 @@
 // found in the LICENSE file.
 #include "platform_view_channel.h"
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registrar.h"
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_message_codec.h"
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_method_codec.h"
-#include "flutter/shell/platform/common/cpp/json_method_codec.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
+#include "flutter/shell/platform/common/json_method_codec.h"
 #include "flutter/shell/platform/tizen/channels/text_input_channel.h"
 #include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/public/flutter_platform_view.h"

--- a/shell/platform/tizen/channels/platform_view_channel.h
+++ b/shell/platform/tizen/channels/platform_view_channel.h
@@ -9,8 +9,8 @@
 
 #include <map>
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h"
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_channel.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
 #include "rapidjson/document.h"
 
 class FlutterTizenEngine;

--- a/shell/platform/tizen/channels/settings_channel.h
+++ b/shell/platform/tizen/channels/settings_channel.h
@@ -7,9 +7,9 @@
 
 #include <system/system_settings.h>
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/basic_message_channel.h"
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h"
-#include "flutter/shell/platform/common/cpp/json_message_codec.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
+#include "flutter/shell/platform/common/json_message_codec.h"
 #include "rapidjson/document.h"
 
 class SettingsChannel {

--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -366,8 +366,8 @@ void TextInputChannel::HandleMethodCall(
       return;
     }
     active_model_->SetText(text->value.GetString());
-    active_model_->SetSelection(TextRange(selection_base->value.GetInt(),
-                                          selection_extent->value.GetInt()));
+    active_model_->SetSelection(flutter::TextRange(
+        selection_base->value.GetInt(), selection_extent->value.GetInt()));
   } else {
     result->NotImplemented();
     return;
@@ -382,7 +382,7 @@ void TextInputChannel::SendStateUpdate(const flutter::TextInputModel& model) {
   auto& allocator = args->GetAllocator();
   args->PushBack(client_id_, allocator);
 
-  TextRange selection = model.selection();
+  flutter::TextRange selection = model.selection();
   rapidjson::Value editing_state(rapidjson::kObjectType);
   editing_state.AddMember(kComposingBaseKey, -1, allocator);
   editing_state.AddMember(kComposingExtentKey, -1, allocator);

--- a/shell/platform/tizen/channels/text_input_channel.h
+++ b/shell/platform/tizen/channels/text_input_channel.h
@@ -11,10 +11,10 @@
 
 #include <string>
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h"
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_channel.h"
-#include "flutter/shell/platform/common/cpp/json_method_codec.h"
-#include "flutter/shell/platform/common/cpp/text_input_model.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
+#include "flutter/shell/platform/common/json_method_codec.h"
+#include "flutter/shell/platform/common/text_input_model.h"
 
 class FlutterTizenEngine;
 class TextInputChannel {

--- a/shell/platform/tizen/external_texture.h
+++ b/shell/platform/tizen/external_texture.h
@@ -7,7 +7,7 @@
 
 #include <atomic>
 #include <memory>
-#include "flutter/shell/platform/common/cpp/public/flutter_texture_registrar.h"
+#include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 
 #ifdef TIZEN_RENDERER_EVAS_GL

--- a/shell/platform/tizen/external_texture_pixel_gl.h
+++ b/shell/platform/tizen/external_texture_pixel_gl.h
@@ -7,7 +7,7 @@
 
 #include <memory>
 
-#include "flutter/shell/platform/common/cpp/public/flutter_texture_registrar.h"
+#include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/tizen/external_texture.h"
 

--- a/shell/platform/tizen/external_texture_surface_gl.cc
+++ b/shell/platform/tizen/external_texture_surface_gl.cc
@@ -4,7 +4,7 @@
 
 #include "external_texture_surface_gl.h"
 
-#include "flutter/shell/platform/common/cpp/public/flutter_texture_registrar.h"
+#include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
 
 #ifdef TIZEN_RENDERER_EVAS_GL
 #undef EFL_BETA_API_SUPPORT

--- a/shell/platform/tizen/external_texture_surface_gl.h
+++ b/shell/platform/tizen/external_texture_surface_gl.h
@@ -5,7 +5,7 @@
 #ifndef EMBEDDER_EXTERNAL_TEXTURE_SURFACE_GL_H_
 #define EMBEDDER_EXTERNAL_TEXTURE_SURFACE_GL_H_
 
-#include "flutter/shell/platform/common/cpp/public/flutter_texture_registrar.h"
+#include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/tizen/external_texture.h"
 

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -7,9 +7,9 @@
 
 #include <inttypes.h>
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registrar.h"
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_message_codec.h"
-#include "flutter/shell/platform/common/cpp/incoming_message_dispatcher.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
+#include "flutter/shell/platform/common/incoming_message_dispatcher.h"
 #include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/public/flutter_platform_view.h"
 #include "flutter/shell/platform/tizen/tizen_log.h"

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -3,8 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef EMBEDDER_TIZEN_EMBEDDER_ENGINE_H_
-#define EMBEDDER_TIZEN_EMBEDDER_ENGINE_H_
+#ifndef EMBEDDER_FLUTTER_TIZEN_ENGINE_H_
+#define EMBEDDER_FLUTTER_TIZEN_ENGINE_H_
 
 #include <map>
 #include <memory>
@@ -189,4 +189,4 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
   FlutterTransformation transformation_;
 };
 
-#endif  // EMBEDDER_TIZEN_EMBEDDER_ENGINE_H_
+#endif  // EMBEDDER_FLUTTER_TIZEN_ENGINE_H_

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -9,8 +9,8 @@
 #include <map>
 #include <memory>
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registrar.h"
-#include "flutter/shell/platform/common/cpp/incoming_message_dispatcher.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
+#include "flutter/shell/platform/common/incoming_message_dispatcher.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/tizen/channels/key_event_channel.h"
 #include "flutter/shell/platform/tizen/channels/lifecycle_channel.h"

--- a/shell/platform/tizen/public/flutter_tizen.h
+++ b/shell/platform/tizen/public/flutter_tizen.h
@@ -3,8 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef PUBLIC_FLUTTER_TIZEN_EMBEDDER_H_
-#define PUBLIC_FLUTTER_TIZEN_EMBEDDER_H_
+#ifndef FLUTTER_SHELL_PLATFORM_TIZEN_PUBLIC_FLUTTER_TIZEN_H_
+#define FLUTTER_SHELL_PLATFORM_TIZEN_PUBLIC_FLUTTER_TIZEN_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -84,4 +84,4 @@ FLUTTER_EXPORT void FlutterDesktopNotifyAppIsDetached(
 }  // extern "C"
 #endif
 
-#endif  // PUBLIC_FLUTTER_TIZEN_EMBEDDER_H_
+#endif  // FLUTTER_SHELL_PLATFORM_TIZEN_PUBLIC_FLUTTER_TIZEN_H_

--- a/shell/platform/tizen/tizen_event_loop.h
+++ b/shell/platform/tizen/tizen_event_loop.h
@@ -3,8 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef TIZEN_EVENT_LOOP_H_
-#define TIZEN_EVENT_LOOP_H_
+#ifndef EMBEDDER_TIZEN_EVENT_LOOP_H_
+#define EMBEDDER_TIZEN_EVENT_LOOP_H_
 
 #include <Ecore.h>
 
@@ -99,4 +99,4 @@ class TizenRenderEventLoop : public TizenEventLoop {
 };
 #endif
 
-#endif  // TIZEN_EVENT_LOOP_H_
+#endif  // EMBEDDER_TIZEN_EVENT_LOOP_H_

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef EMBEDDER_TIZEN_RENDERER_H
-#define EMBEDDER_TIZEN_RENDERER_H
+#ifndef EMBEDDER_TIZEN_RENDERER_H_
+#define EMBEDDER_TIZEN_RENDERER_H_
 
 #include <cstdint>
 #include <vector>
@@ -51,4 +51,4 @@ class TizenRenderer {
   TizenRenderer::Delegate& delegate_;
 };
 
-#endif  // EMBEDDER_TIZEN_RENDERER_H
+#endif  // EMBEDDER_TIZEN_RENDERER_H_

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef EMBEDDER_TIZEN_RENDERER_ECORE_WL2_H
-#define EMBEDDER_TIZEN_RENDERER_ECORE_WL2_H
+#ifndef EMBEDDER_TIZEN_RENDERER_ECORE_WL2_H_
+#define EMBEDDER_TIZEN_RENDERER_ECORE_WL2_H_
 
 #define EFL_BETA_API_SUPPORT
 #include <EGL/egl.h>
@@ -69,4 +69,4 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   EGLSurface egl_resource_surface_ = EGL_NO_SURFACE;
 };
 
-#endif  // EMBEDDER_TIZEN_RENDERER_ECORE_WL2_H
+#endif  // EMBEDDER_TIZEN_RENDERER_ECORE_WL2_H_

--- a/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef EMBEDDER_TIZEN_RENDERER_EVAS_GL_H
-#define EMBEDDER_TIZEN_RENDERER_EVAS_GL_H
+#ifndef EMBEDDER_TIZEN_RENDERER_EVAS_GL_H_
+#define EMBEDDER_TIZEN_RENDERER_EVAS_GL_H_
 
 #undef EFL_BETA_API_SUPPORT
 #include <Ecore.h>
@@ -66,4 +66,4 @@ class TizenRendererEvasGL : public TizenRenderer {
   Evas_GL_Surface* gl_resource_surface_{nullptr};
 };
 
-#endif  // EMBEDDER_TIZEN_RENDERER_ECORE_WL2_H
+#endif  // EMBEDDER_TIZEN_RENDERER_EVAS_GL_H_


### PR DESCRIPTION
Minor fixes according to upstream changes:
- https://github.com/flutter/engine/pull/24423
- https://github.com/flutter/engine/pull/24210

Contributes to https://github.com/flutter-tizen/flutter-tizen/issues/124.

Please apply https://github.com/flutter-tizen/flutter-tizen/pull/138 to test the new engine.

Things we might consider:
- https://github.com/flutter/engine/pull/25402 (Logging callback added to embedder APIs) - We can now only dump flutter messages without redirecting all stdout/stderr messages to dlog.