### PR TITLE
Revert "Show more symbols on profiling builds (#104)"

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -282,7 +282,7 @@ def to_gn_args(args):
 
     # We should not need a special case for x86, but this seems to introduce text relocations
     # even with -fPIC everywhere.
-    gn_args['enable_profiling'] = args.runtime_mode != 'release' and args.android_cpu != 'x86'
+    # gn_args['enable_profiling'] = args.runtime_mode != 'release' and args.android_cpu != 'x86'
 
     if args.arm_float_abi:
       gn_args['arm_float_abi'] = args.arm_float_abi


### PR DESCRIPTION
This reverts commit 1c0b087169790d30c0bdde1e62f8effb852fbbd5.

Too large artifacts.

![image](https://user-images.githubusercontent.com/40190588/121828373-5a12bd80-ccfa-11eb-9162-c88d9ce9e84e.png)

![image](https://user-images.githubusercontent.com/40190588/121828345-4a937480-ccfa-11eb-88ea-5fc24ad26ac2.png)

