### PR TITLE
Check the presence of glyphs when selecting font

### DIFF
--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -529,8 +529,8 @@ void FontCollection::itemize(const uint16_t* string,
           }
           start -= prevChLength;
         }
-        result->push_back(
-            {family->getClosestMatchWithChar(style,ch), static_cast<int>(start), 0});
+        result->push_back({family->getClosestMatchWithChar(style, ch),
+                           static_cast<int>(start), 0});
         run = &result->back();
         lastFamily = family.get();
       }

--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -510,8 +510,7 @@ void FontCollection::itemize(const uint16_t* string,
       const std::shared_ptr<FontFamily>& family = getFamilyForChar(
           ch, isVariationSelector(nextCh) ? nextCh : 0, langListId, variant);
 
-      if (utf16Pos == 0 || family.get() != lastFamily ||
-          family.get()->getLastMatchedCodePoint() != ch) {
+      if (utf16Pos == 0 || family.get() != lastFamily) {
         size_t start = utf16Pos;
         // Workaround for combining marks and emoji modifiers until we implement
         // per-cluster font selection: if a combining mark or an emoji modifier
@@ -530,7 +529,7 @@ void FontCollection::itemize(const uint16_t* string,
           }
           start -= prevChLength;
         }
-        result->push_back({family->getClosestMatchWithChar(style, ch),
+        result->push_back({family->getClosestMatch(style, ch, variant),
                            static_cast<int>(start), 0});
         run = &result->back();
         lastFamily = family.get();

--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -509,7 +509,6 @@ void FontCollection::itemize(const uint16_t* string,
     if (!shouldContinueRun) {
       const std::shared_ptr<FontFamily>& family = getFamilyForChar(
           ch, isVariationSelector(nextCh) ? nextCh : 0, langListId, variant);
-
       if (utf16Pos == 0 || family.get() != lastFamily) {
         size_t start = utf16Pos;
         // Workaround for combining marks and emoji modifiers until we implement

--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -509,7 +509,9 @@ void FontCollection::itemize(const uint16_t* string,
     if (!shouldContinueRun) {
       const std::shared_ptr<FontFamily>& family = getFamilyForChar(
           ch, isVariationSelector(nextCh) ? nextCh : 0, langListId, variant);
-      if (utf16Pos == 0 || family.get() != lastFamily) {
+      if (utf16Pos == 0 || family.get() != lastFamily ||
+          (!(U_GET_GC_MASK(prevCh) & U_GC_L_MASK) &&
+           (U_GET_GC_MASK(ch) & U_GC_L_MASK))) {
         size_t start = utf16Pos;
         // Workaround for combining marks and emoji modifiers until we implement
         // per-cluster font selection: if a combining mark or an emoji modifier
@@ -530,25 +532,6 @@ void FontCollection::itemize(const uint16_t* string,
         }
         result->push_back({family->getClosestMatch(style, ch, variant),
                            static_cast<int>(start), 0});
-        run = &result->back();
-        lastFamily = family.get();
-      } else if (family.get() == lastFamily &&
-                 // We need to change this condition to more general logic. And
-                 // when changing the font, it is necessary to check whether the
-                 // existing characters also have glyphs.
-                 !(U_GET_GC_MASK(prevCh) & U_GC_L_MASK) &&
-                 (U_GET_GC_MASK(ch) & U_GC_L_MASK)) {
-        size_t start = utf16Pos;
-        auto currentFont = family->getClosestMatch(style, ch, variant);
-        if (result->back().fakedFont.font != currentFont.font) {
-          const size_t prevChLength = U16_LENGTH(prevCh);
-          run->end -= prevChLength;
-          if (run->start == run->end) {
-            result->pop_back();
-          }
-          start -= prevChLength;
-        }
-        result->push_back({currentFont, static_cast<int>(start), 0});
         run = &result->back();
         lastFamily = family.get();
       }

--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -539,8 +539,8 @@ void FontCollection::itemize(const uint16_t* string,
                  !(U_GET_GC_MASK(prevCh) & U_GC_L_MASK) &&
                  (U_GET_GC_MASK(ch) & U_GC_L_MASK)) {
         size_t start = utf16Pos;
-        auto current_font = family->getClosestMatch(style, ch, variant);
-        if (result->back().fakedFont.font != current_font.font) {
+        auto currentFont = family->getClosestMatch(style, ch, variant);
+        if (result->back().fakedFont.font != currentFont.font) {
           const size_t prevChLength = U16_LENGTH(prevCh);
           run->end -= prevChLength;
           if (run->start == run->end) {
@@ -548,7 +548,7 @@ void FontCollection::itemize(const uint16_t* string,
           }
           start -= prevChLength;
         }
-        result->push_back({current_font, static_cast<int>(start), 0});
+        result->push_back({currentFont, static_cast<int>(start), 0});
         run = &result->back();
         lastFamily = family.get();
       }

--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -533,6 +533,25 @@ void FontCollection::itemize(const uint16_t* string,
                            static_cast<int>(start), 0});
         run = &result->back();
         lastFamily = family.get();
+      } else if (family.get() == lastFamily &&
+                 // We need to change this condition to more general logic. And
+                 // when changing the font, it is necessary to check whether the
+                 // existing characters also have glyphs.
+                 !(U_GET_GC_MASK(prevCh) & U_GC_L_MASK) &&
+                 (U_GET_GC_MASK(ch) & U_GC_L_MASK)) {
+        size_t start = utf16Pos;
+        auto current_font = family->getClosestMatch(style, ch, variant);
+        if (result->back().fakedFont.font != current_font.font) {
+          const size_t prevChLength = U16_LENGTH(prevCh);
+          run->end -= prevChLength;
+          if (run->start == run->end) {
+            result->pop_back();
+          }
+          start -= prevChLength;
+        }
+        result->push_back({current_font, static_cast<int>(start), 0});
+        run = &result->back();
+        lastFamily = family.get();
       }
     }
     prevCh = ch;

--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -509,6 +509,7 @@ void FontCollection::itemize(const uint16_t* string,
     if (!shouldContinueRun) {
       const std::shared_ptr<FontFamily>& family = getFamilyForChar(
           ch, isVariationSelector(nextCh) ? nextCh : 0, langListId, variant);
+
       if (utf16Pos == 0 || family.get() != lastFamily) {
         size_t start = utf16Pos;
         // Workaround for combining marks and emoji modifiers until we implement
@@ -529,7 +530,7 @@ void FontCollection::itemize(const uint16_t* string,
           start -= prevChLength;
         }
         result->push_back(
-            {family->getClosestMatch(style), static_cast<int>(start), 0});
+            {family->getClosestMatchWithChar(style,ch), static_cast<int>(start), 0});
         run = &result->back();
         lastFamily = family.get();
       }

--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -510,7 +510,8 @@ void FontCollection::itemize(const uint16_t* string,
       const std::shared_ptr<FontFamily>& family = getFamilyForChar(
           ch, isVariationSelector(nextCh) ? nextCh : 0, langListId, variant);
 
-      if (utf16Pos == 0 || family.get() != lastFamily) {
+      if (utf16Pos == 0 || family.get() != lastFamily ||
+          family.get()->getLastMatchedCodePoint() != ch) {
         size_t start = utf16Pos;
         // Workaround for combining marks and emoji modifiers until we implement
         // per-cluster font selection: if a combining mark or an emoji modifier

--- a/third_party/txt/src/minikin/FontFamily.cpp
+++ b/third_party/txt/src/minikin/FontFamily.cpp
@@ -164,7 +164,8 @@ FakedFont FontFamily::getClosestMatch(FontStyle style) const {
   return FakedFont{nullptr, FontFakery()};
 }
 
-FakedFont FontFamily::getClosestMatchWithChar(FontStyle style,uint32_t codepoint) const {
+FakedFont FontFamily::getClosestMatchWithChar(FontStyle style,
+                                              uint32_t codepoint) const {
   const Font* bestFont = nullptr;
   int bestMatch = 0;
   for (size_t i = 0; i < mFonts.size(); i++) {
@@ -174,13 +175,12 @@ FakedFont FontFamily::getClosestMatchWithChar(FontStyle style,uint32_t codepoint
     {
       hb_font_t* hb_font = getHbFontLocked(font.typeface.get());
       uint32_t unusedGlyph;
-      result =
-          hb_font_get_glyph(hb_font, codepoint, 0, &unusedGlyph);
+      result = hb_font_get_glyph(hb_font, codepoint, 0, &unusedGlyph);
       hb_font_destroy(hb_font);
     }
 
-    if(result){
-      if (i == 0 || match < bestMatch || bestMatch==0) {
+    if (result) {
+      if (i == 0 || match < bestMatch || bestMatch == 0) {
         bestFont = &font;
         bestMatch = match;
       }

--- a/third_party/txt/src/minikin/FontFamily.cpp
+++ b/third_party/txt/src/minikin/FontFamily.cpp
@@ -146,9 +146,10 @@ static FontFakery computeFakery(FontStyle wanted, FontStyle actual) {
   return FontFakery(isFakeBold, isFakeItalic);
 }
 
-FakedFont FontFamily::getClosestMatch(FontStyle style,
-                                      uint32_t codepoint /* = 0 */,
-                                      uint32_t variationSelector /* = 0 */) const {
+FakedFont FontFamily::getClosestMatch(
+    FontStyle style,
+    uint32_t codepoint /* = 0 */,
+    uint32_t variationSelector /* = 0 */) const {
   int bestMatch = INT_MAX;
   const Font* bestFont = nullptr;
   for (size_t i = 0; i < mFonts.size(); i++) {

--- a/third_party/txt/src/minikin/FontFamily.cpp
+++ b/third_party/txt/src/minikin/FontFamily.cpp
@@ -164,6 +164,35 @@ FakedFont FontFamily::getClosestMatch(FontStyle style) const {
   return FakedFont{nullptr, FontFakery()};
 }
 
+FakedFont FontFamily::getClosestMatchWithChar(FontStyle style,uint32_t codepoint) const {
+  const Font* bestFont = nullptr;
+  int bestMatch = 0;
+  for (size_t i = 0; i < mFonts.size(); i++) {
+    const Font& font = mFonts[i];
+    int match = computeMatch(font.style, style);
+    bool result = false;
+    {
+      hb_font_t* hb_font = getHbFontLocked(font.typeface.get());
+      uint32_t unusedGlyph;
+      result =
+          hb_font_get_glyph(hb_font, codepoint, 0, &unusedGlyph);
+      hb_font_destroy(hb_font);
+    }
+
+    if(result){
+      if (i == 0 || match < bestMatch || bestMatch==0) {
+        bestFont = &font;
+        bestMatch = match;
+      }
+    }
+  }
+  if (bestFont != nullptr) {
+    return FakedFont{bestFont->typeface.get(),
+                     computeFakery(style, bestFont->style)};
+  }
+  return FakedFont{nullptr, FontFakery()};
+}
+
 bool FontFamily::isColorEmojiFamily() const {
   const FontLanguages& languageList = FontLanguageListCache::getById(mLangId);
   for (size_t i = 0; i < languageList.size(); ++i) {

--- a/third_party/txt/src/minikin/FontFamily.cpp
+++ b/third_party/txt/src/minikin/FontFamily.cpp
@@ -146,58 +146,30 @@ static FontFakery computeFakery(FontStyle wanted, FontStyle actual) {
   return FontFakery(isFakeBold, isFakeItalic);
 }
 
-FakedFont FontFamily::getClosestMatch(FontStyle style) const {
-  const Font* bestFont = nullptr;
-  int bestMatch = 0;
-  for (size_t i = 0; i < mFonts.size(); i++) {
-    const Font& font = mFonts[i];
-    int match = computeMatch(font.style, style);
-    if (i == 0 || match < bestMatch) {
-      bestFont = &font;
-      bestMatch = match;
-    }
-  }
-  if (bestFont != nullptr) {
-    return FakedFont{bestFont->typeface.get(),
-                     computeFakery(style, bestFont->style)};
-  }
-  return FakedFont{nullptr, FontFakery()};
-}
-
-FakedFont FontFamily::getClosestMatchWithChar(FontStyle style,
-                                              uint32_t codepoint) {
+FakedFont FontFamily::getClosestMatch(FontStyle style,
+                                      uint32_t codepoint,
+                                      uint32_t variationSelector) const {
   int bestMatch = INT_MAX;
   const Font* bestFont = nullptr;
-  if (mLastMatchedCodePoint == codepoint && style == mLastMatchedFontStyle) {
-    if (mFonts.size() > mLastMatchedFontIndex) {
-      bestFont = &mFonts[mLastMatchedFontIndex];
-      return FakedFont{bestFont->typeface.get(),
-                       computeFakery(style, bestFont->style)};
-    }
-  }
-
   for (size_t i = 0; i < mFonts.size(); i++) {
     const Font& font = mFonts[i];
     int match = computeMatch(font.style, style);
     bool result = false;
-    {
+    if (codepoint != 0) {
       hb_font_t* hb_font = getHbFontLocked(font.typeface.get());
       uint32_t unusedGlyph;
-      result = hb_font_get_glyph(hb_font, codepoint, 0, &unusedGlyph);
+      result = hb_font_get_glyph(hb_font, codepoint, variationSelector,
+                                 &unusedGlyph);
       hb_font_destroy(hb_font);
     }
-
-    if (result) {
+    if (!codepoint || (codepoint && result)) {
       if (match < bestMatch) {
         bestFont = &font;
         bestMatch = match;
-        mLastMatchedFontIndex = i;
       }
     }
   }
   if (bestFont != nullptr) {
-    mLastMatchedFontStyle = style;
-    mLastMatchedCodePoint = codepoint;
     return FakedFont{bestFont->typeface.get(),
                      computeFakery(style, bestFont->style)};
   }

--- a/third_party/txt/src/minikin/FontFamily.cpp
+++ b/third_party/txt/src/minikin/FontFamily.cpp
@@ -150,20 +150,20 @@ FakedFont FontFamily::getClosestMatch(
     FontStyle style,
     uint32_t codepoint /* = 0 */,
     uint32_t variationSelector /* = 0 */) const {
-  int bestMatch = INT_MAX;
   const Font* bestFont = nullptr;
+  int bestMatch = INT_MAX;
   for (size_t i = 0; i < mFonts.size(); i++) {
     const Font& font = mFonts[i];
     int match = computeMatch(font.style, style);
     bool result = false;
     if (codepoint != 0) {
-      hb_font_t* hb_font = getHbFontLocked(font.typeface.get());
+      hb_font_t* hbFont = getHbFontLocked(font.typeface.get());
       uint32_t unusedGlyph = 0;
-      result = hb_font_get_glyph(hb_font, codepoint, variationSelector,
-                                 &unusedGlyph);
-      hb_font_destroy(hb_font);
+      result =
+          hb_font_get_glyph(hbFont, codepoint, variationSelector, &unusedGlyph);
+      hb_font_destroy(hbFont);
     }
-    if (!codepoint || (codepoint && result)) {
+    if (codepoint == 0 || (codepoint != 0 && result)) {
       if (match < bestMatch) {
         bestFont = &font;
         bestMatch = match;

--- a/third_party/txt/src/minikin/FontFamily.cpp
+++ b/third_party/txt/src/minikin/FontFamily.cpp
@@ -165,9 +165,17 @@ FakedFont FontFamily::getClosestMatch(FontStyle style) const {
 }
 
 FakedFont FontFamily::getClosestMatchWithChar(FontStyle style,
-                                              uint32_t codepoint) const {
+                                              uint32_t codepoint) {
+  int bestMatch = INT_MAX;
   const Font* bestFont = nullptr;
-  int bestMatch = 0;
+  if (mLastMatchedCodePoint == codepoint && style == mLastMatchedFontStyle) {
+    if (mFonts.size() > mLastMatchedFontIndex) {
+      bestFont = &mFonts[mLastMatchedFontIndex];
+      return FakedFont{bestFont->typeface.get(),
+                       computeFakery(style, bestFont->style)};
+    }
+  }
+
   for (size_t i = 0; i < mFonts.size(); i++) {
     const Font& font = mFonts[i];
     int match = computeMatch(font.style, style);
@@ -180,13 +188,16 @@ FakedFont FontFamily::getClosestMatchWithChar(FontStyle style,
     }
 
     if (result) {
-      if (i == 0 || match < bestMatch || bestMatch == 0) {
+      if (match < bestMatch) {
         bestFont = &font;
         bestMatch = match;
+        mLastMatchedFontIndex = i;
       }
     }
   }
   if (bestFont != nullptr) {
+    mLastMatchedFontStyle = style;
+    mLastMatchedCodePoint = codepoint;
     return FakedFont{bestFont->typeface.get(),
                      computeFakery(style, bestFont->style)};
   }

--- a/third_party/txt/src/minikin/FontFamily.cpp
+++ b/third_party/txt/src/minikin/FontFamily.cpp
@@ -147,8 +147,8 @@ static FontFakery computeFakery(FontStyle wanted, FontStyle actual) {
 }
 
 FakedFont FontFamily::getClosestMatch(FontStyle style,
-                                      uint32_t codepoint,
-                                      uint32_t variationSelector) const {
+                                      uint32_t codepoint /* = 0 */,
+                                      uint32_t variationSelector /* = 0 */) const {
   int bestMatch = INT_MAX;
   const Font* bestFont = nullptr;
   for (size_t i = 0; i < mFonts.size(); i++) {
@@ -157,7 +157,7 @@ FakedFont FontFamily::getClosestMatch(FontStyle style,
     bool result = false;
     if (codepoint != 0) {
       hb_font_t* hb_font = getHbFontLocked(font.typeface.get());
-      uint32_t unusedGlyph;
+      uint32_t unusedGlyph = 0;
       result = hb_font_get_glyph(hb_font, codepoint, variationSelector,
                                  &unusedGlyph);
       hb_font_destroy(hb_font);

--- a/third_party/txt/src/minikin/FontFamily.h
+++ b/third_party/txt/src/minikin/FontFamily.h
@@ -141,7 +141,7 @@ class FontFamily {
                            int* weight,
                            bool* italic);
   FakedFont getClosestMatch(FontStyle style) const;
-  FakedFont getClosestMatchWithChar(FontStyle style, uint32_t codepoint) const;
+  FakedFont getClosestMatchWithChar(FontStyle style, uint32_t codepoint);
 
   uint32_t langId() const { return mLangId; }
   int variant() const { return mVariant; }
@@ -174,6 +174,8 @@ class FontFamily {
   std::shared_ptr<FontFamily> createFamilyWithVariation(
       const std::vector<FontVariation>& variations) const;
 
+  uint32_t getLastMatchedCodePoint() { return mLastMatchedCodePoint; }
+
  private:
   void computeCoverage();
 
@@ -184,6 +186,10 @@ class FontFamily {
 
   SparseBitSet mCoverage;
   bool mHasVSTable;
+
+  uint mLastMatchedFontIndex;
+  uint32_t mLastMatchedCodePoint;
+  FontStyle mLastMatchedFontStyle;
 
   // Forbid copying and assignment.
   FontFamily(const FontFamily&) = delete;

--- a/third_party/txt/src/minikin/FontFamily.h
+++ b/third_party/txt/src/minikin/FontFamily.h
@@ -140,8 +140,9 @@ class FontFamily {
   static bool analyzeStyle(const std::shared_ptr<MinikinFont>& typeface,
                            int* weight,
                            bool* italic);
-  FakedFont getClosestMatch(FontStyle style) const;
-  FakedFont getClosestMatchWithChar(FontStyle style, uint32_t codepoint);
+  FakedFont getClosestMatch(FontStyle style,
+                            uint32_t codepoint = 0,
+                            uint32_t variationSelector = 0) const;
 
   uint32_t langId() const { return mLangId; }
   int variant() const { return mVariant; }
@@ -174,8 +175,6 @@ class FontFamily {
   std::shared_ptr<FontFamily> createFamilyWithVariation(
       const std::vector<FontVariation>& variations) const;
 
-  uint32_t getLastMatchedCodePoint() { return mLastMatchedCodePoint; }
-
  private:
   void computeCoverage();
 
@@ -186,10 +185,6 @@ class FontFamily {
 
   SparseBitSet mCoverage;
   bool mHasVSTable;
-
-  uint mLastMatchedFontIndex;
-  uint32_t mLastMatchedCodePoint;
-  FontStyle mLastMatchedFontStyle;
 
   // Forbid copying and assignment.
   FontFamily(const FontFamily&) = delete;

--- a/third_party/txt/src/minikin/FontFamily.h
+++ b/third_party/txt/src/minikin/FontFamily.h
@@ -141,6 +141,7 @@ class FontFamily {
                            int* weight,
                            bool* italic);
   FakedFont getClosestMatch(FontStyle style) const;
+  FakedFont getClosestMatchWithChar(FontStyle style, uint32_t codepoint) const;
 
   uint32_t langId() const { return mLangId; }
   int variant() const { return mVariant; }

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -250,6 +250,28 @@ void FontCollection::SortSkTypefaces(
         int a_delta = std::abs(a_style.width() - SkFontStyle::kNormal_Width);
         int b_delta = std::abs(b_style.width() - SkFontStyle::kNormal_Width);
 
+        {
+          // A workaround to prevent emoji fonts being selected for normal text
+          // when normal and emojis are mixed at same font family.
+
+          bool a_isContainEmoji = false;
+          bool b_isContainEmoji = false;
+          SkString postScriptName;
+          a->getPostScriptName(&postScriptName);
+          if (postScriptName.contains("Emoji")) {
+            a_isContainEmoji = true;
+          }
+          b->getPostScriptName(&postScriptName);
+          if (postScriptName.contains("Emoji")) {
+            b_isContainEmoji = true;
+          }
+          if (a_isContainEmoji && !b_isContainEmoji) {
+            return false;
+          } else if (!a_isContainEmoji && b_isContainEmoji) {
+            return true;
+          }
+        }
+
         if (a_delta != b_delta) {
           // If a family name query is so generic it ends up bringing in fonts
           // of multiple widths (e.g. condensed, expanded), opt to be

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -254,20 +254,20 @@ void FontCollection::SortSkTypefaces(
           // A workaround to prevent emoji fonts being selected for normal text
           // when normal and emojis are mixed at same font family.
 
-          bool a_isContainEmoji = false;
-          bool b_isContainEmoji = false;
+          bool a_isEmojiFont = false;
+          bool b_isEmojiFont = false;
           SkString postScriptName;
           a->getPostScriptName(&postScriptName);
           if (postScriptName.contains("Emoji")) {
-            a_isContainEmoji = true;
+            a_isEmojiFont = true;
           }
           b->getPostScriptName(&postScriptName);
           if (postScriptName.contains("Emoji")) {
-            b_isContainEmoji = true;
+            b_isEmojiFont = true;
           }
-          if (a_isContainEmoji && !b_isContainEmoji) {
+          if (a_isEmojiFont && !b_isEmojiFont) {
             return false;
-          } else if (!a_isContainEmoji && b_isContainEmoji) {
+          } else if (!a_isEmojiFont && b_isEmojiFont) {
             return true;
           }
         }

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -244,12 +244,6 @@ void FontCollection::SortSkTypefaces(
   std::sort(
       sk_typefaces.begin(), sk_typefaces.end(),
       [](const sk_sp<SkTypeface>& a, const sk_sp<SkTypeface>& b) {
-        SkFontStyle a_style = a->fontStyle();
-        SkFontStyle b_style = b->fontStyle();
-
-        int a_delta = std::abs(a_style.width() - SkFontStyle::kNormal_Width);
-        int b_delta = std::abs(b_style.width() - SkFontStyle::kNormal_Width);
-
         {
           // A workaround to prevent emoji fonts being selected for normal text
           // when normal and emojis are mixed at same font family.
@@ -271,6 +265,12 @@ void FontCollection::SortSkTypefaces(
             return true;
           }
         }
+
+        SkFontStyle a_style = a->fontStyle();
+        SkFontStyle b_style = b->fontStyle();
+
+        int a_delta = std::abs(a_style.width() - SkFontStyle::kNormal_Width);
+        int b_delta = std::abs(b_style.width() - SkFontStyle::kNormal_Width);
 
         if (a_delta != b_delta) {
           // If a family name query is so generic it ends up bringing in fonts

--- a/third_party/txt/src/txt/platform_linux.cc
+++ b/third_party/txt/src/txt/platform_linux.cc
@@ -13,6 +13,9 @@
 namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies() {
+#ifdef FLUTTER_USE_FONTCONFIG
+  return {"TizenDefaultFont"};
+#else
   return {
       "SamsungOneUI",
       "SamsungOneUIArabic",
@@ -72,11 +75,12 @@ std::vector<std::string> GetDefaultFontFamilies() {
       "BreezeSansFallback",
       "BreezeColorEmoji",
   };
+#endif
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager() {
 #ifdef FLUTTER_USE_FONTCONFIG
-  return SkFontMgr_New_FontConfig(nullptr);
+  return SkFontMgr::RefDefault();
 #else
   return SkFontMgr_New_Custom_Directory("/usr/share/fonts");
 #endif


### PR DESCRIPTION
PR due to default branch change
 - previous PR : https://github.com/flutter-tizen/engine/pull/106
----
This PR is to solve the font issue by re-enable ``font config`` and changing font selection logic(with workaround)
PR that uses the font config as the default and reverts our modification will be prepared separately.
Also, it contains the following minor change.
- Change fallback font name to ``TizenDefaultFont`` :  The font config setting in the Tizen device has an alias called ``TizenDefaultFont``, and it is connected to the actual font in device. So if we decide to use the font config we can use it as a fallback font family.
