### PR TITLE
Support partial window

### DIFF
--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -29,7 +29,8 @@ FlutterDesktopEngineRef FlutterDesktopRunEngine(
     bool headed) {
   StartLogging();
 
-  auto engine = std::make_unique<FlutterTizenEngine>(headed);
+  auto engine = std::make_unique<FlutterTizenEngine>(
+      headed, engine_properties.custom_win);
   if (!engine->RunEngine(engine_properties)) {
     FT_LOGE("Failed to run the Flutter engine.");
     return nullptr;

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -38,8 +38,8 @@ static DeviceProfile GetDeviceProfile() {
   return DeviceProfile::kUnknown;
 }
 
-FlutterTizenEngine::FlutterTizenEngine(bool headed)
-    : device_profile(GetDeviceProfile()) {
+FlutterTizenEngine::FlutterTizenEngine(bool headed, void* win)
+    : device_profile(GetDeviceProfile()), custom_window_(win) {
   embedder_api_.struct_size = sizeof(FlutterEngineProcTable);
   FlutterEngineGetProcAddresses(&embedder_api_);
 
@@ -420,6 +420,13 @@ bool FlutterTizenEngine::UnregisterExternalTexture(int64_t texture_id) {
 bool FlutterTizenEngine::MarkExternalTextureFrameAvailable(int64_t texture_id) {
   return (embedder_api_.MarkExternalTextureFrameAvailable(
               engine_, texture_id) == kSuccess);
+}
+
+bool FlutterTizenEngine::hasCustomWindow() {
+  return custom_window_ != nullptr;
+}
+void* FlutterTizenEngine::CustomWindow() {
+  return custom_window_;
 }
 
 // The Flutter Engine calls out to this function when new platform messages are

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -59,7 +59,7 @@ enum DeviceProfile { kUnknown, kMobile, kWearable, kTV, kCommon };
 // Manages state associated with the underlying FlutterEngine.
 class FlutterTizenEngine : public TizenRenderer::Delegate {
  public:
-  explicit FlutterTizenEngine(bool headed);
+  explicit FlutterTizenEngine(bool headed, void* win = nullptr);
   virtual ~FlutterTizenEngine();
 
   // Prevent copying.
@@ -118,6 +118,10 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
   // Notifies the engine about a new frame being available for the
   // given |texture_id|.
   bool MarkExternalTextureFrameAvailable(int64_t texture_id);
+
+  // This is an experimental feature to support partial window.
+  bool hasCustomWindow() override;
+  void* CustomWindow() override;
 
   // The plugin messenger handle given to API clients.
   std::unique_ptr<FlutterDesktopMessenger> messenger;
@@ -187,6 +191,8 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
 
   // The current renderer transformation.
   FlutterTransformation transformation_;
+
+  void* custom_window_;
 };
 
 #endif  // EMBEDDER_FLUTTER_TIZEN_ENGINE_H_

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -59,7 +59,7 @@ enum DeviceProfile { kUnknown, kMobile, kWearable, kTV, kCommon };
 // Manages state associated with the underlying FlutterEngine.
 class FlutterTizenEngine : public TizenRenderer::Delegate {
  public:
-  explicit FlutterTizenEngine(bool headed, void* win = nullptr);
+  explicit FlutterTizenEngine(bool headed, void* win );
   virtual ~FlutterTizenEngine();
 
   // Prevent copying.

--- a/shell/platform/tizen/public/flutter_tizen.h
+++ b/shell/platform/tizen/public/flutter_tizen.h
@@ -36,6 +36,8 @@ typedef struct {
   const char** switches;
   // The number of elements in |switches|.
   size_t switches_count;
+  // This is an experimental feature to support partial window.
+  void* custom_win;
 } FlutterDesktopEngineProperties;
 
 // Runs an instance of a Flutter engine with the given properties.

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -17,6 +17,9 @@ class TizenRenderer {
   class Delegate {
    public:
     virtual void OnOrientationChange(int32_t degree) = 0;
+    // This is an experimental feature to support partial window.
+    virtual bool hasCustomWindow() = 0;
+    virtual void* CustomWindow() = 0;
   };
 
   virtual ~TizenRenderer();

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -285,13 +285,19 @@ bool TizenRendererEcoreWl2::SetupEcoreWlWindow(int32_t width, int32_t height) {
     FT_LOGE("Invalid screen size: %d x %d", width, height);
     return false;
   }
-  ecore_wl2_window_ =
-      ecore_wl2_window_new(ecore_wl2_display_, nullptr, 0, 0, width, height);
-  ecore_wl2_window_type_set(ecore_wl2_window_, ECORE_WL2_WINDOW_TYPE_TOPLEVEL);
-  ecore_wl2_window_alpha_set(ecore_wl2_window_, EINA_FALSE);
-  ecore_wl2_window_position_set(ecore_wl2_window_, 0, 0);
-  ecore_wl2_window_aux_hint_add(ecore_wl2_window_, 0,
-                                "wm.policy.win.user.geometry", "1");
+  if (delegate_.hasCustomWindow()) {
+    ecore_wl2_window_ =
+        reinterpret_cast<Ecore_Wl2_Window*>(delegate_.CustomWindow());
+  } else {
+    ecore_wl2_window_ =
+        ecore_wl2_window_new(ecore_wl2_display_, nullptr, 0, 0, width, height);
+    ecore_wl2_window_type_set(ecore_wl2_window_,
+                              ECORE_WL2_WINDOW_TYPE_TOPLEVEL);
+    ecore_wl2_window_alpha_set(ecore_wl2_window_, EINA_FALSE);
+    ecore_wl2_window_position_set(ecore_wl2_window_, 0, 0);
+    ecore_wl2_window_aux_hint_add(ecore_wl2_window_, 0,
+                                  "wm.policy.win.user.geometry", "1");
+  }
   int rotations[4] = {0, 90, 180, 270};
   ecore_wl2_window_available_rotations_set(ecore_wl2_window_, rotations,
                                            sizeof(rotations) / sizeof(int));

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -642,7 +642,7 @@ Evas_Object* TizenRendererEvasGL::SetupEvasWindow(int32_t& width,
     evas_window_ = elm_win_add(NULL, NULL, ELM_WIN_BASIC);
     auto* ecore_evas =
         ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_));
-    int32_t x, y;
+    int32_t x = 0, y = 0;
     ecore_evas_screen_geometry_get(ecore_evas, &x, &y, &width, &height);
     if (width == 0 || height == 0) {
       FT_LOGE("Invalid screen size: %d x %d", width, height);

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -636,20 +636,24 @@ Evas_Object* TizenRendererEvasGL::SetupEvasWindow(int32_t& width,
                                                   int32_t& height) {
   elm_config_accel_preference_set("hw:opengl");
 
-  evas_window_ = elm_win_add(NULL, NULL, ELM_WIN_BASIC);
-  auto* ecore_evas =
-      ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_));
-  int32_t x, y;
-  ecore_evas_screen_geometry_get(ecore_evas, &x, &y, &width, &height);
-  if (width == 0 || height == 0) {
-    FT_LOGE("Invalid screen size: %d x %d", width, height);
-    return nullptr;
-  }
+  if (delegate_.hasCustomWindow()) {
+    evas_window_ = reinterpret_cast<Evas_Object*>(delegate_.CustomWindow());
+  } else {
+    evas_window_ = elm_win_add(NULL, NULL, ELM_WIN_BASIC);
+    auto* ecore_evas =
+        ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_));
+    int32_t x, y;
+    ecore_evas_screen_geometry_get(ecore_evas, &x, &y, &width, &height);
+    if (width == 0 || height == 0) {
+      FT_LOGE("Invalid screen size: %d x %d", width, height);
+      return nullptr;
+    }
 
-  elm_win_alpha_set(evas_window_, EINA_FALSE);
-  evas_object_move(evas_window_, 0, 0);
-  evas_object_resize(evas_window_, width, height);
-  evas_object_raise(evas_window_);
+    elm_win_alpha_set(evas_window_, EINA_FALSE);
+    evas_object_move(evas_window_, 0, 0);
+    evas_object_resize(evas_window_, width, height);
+    evas_object_raise(evas_window_);
+  }
 
   Evas_Object* bg = elm_bg_add(evas_window_);
   evas_object_color_set(bg, 0x00, 0x00, 0x00, 0x00);


### PR DESCRIPTION
Preparation work for https://github.com/flutter-tizen/engine/issues/94

- Now it is possible to create a partial app instead of a full screen as follows:
```C++
  Ecore_Wl2_Display* ecore_wl2_display_ = nullptr;
  ecore_wl2_init();
  ecore_wl2_display_ = ecore_wl2_display_connect(nullptr);
  ecore_wl2_sync();
  Ecore_Wl2_Window* ecore_wl2_window_ =
      ecore_wl2_window_new(ecore_wl2_display_, nullptr, 100, 100, 500, 600);
  ecore_wl2_window_type_set(ecore_wl2_window_,
                            ECORE_WL2_WINDOW_TYPE_TOPLEVEL);
  ecore_wl2_window_alpha_set(ecore_wl2_window_, false);
  ecore_wl2_window_position_set(ecore_wl2_window_, 0, 0);
  ecore_wl2_window_aux_hint_add(ecore_wl2_window_, 0,
                                "wm.policy.win.user.geometry", "1");
  
  FlutterDesktopEngineProperties engine_prop = {};
  engine_prop.assets_path = assets_path.c_str();
  engine_prop.icu_data_path = icu_data_path.c_str();
  engine_prop.aot_library_path = aot_lib_path.c_str();
  engine_prop.switches = switches.data();
  engine_prop.switches_count = switches.size();
  engine_prop.custom_win = ecore_wl2_window_;
```
