### PR TITLE
Revert shell/platform/common/BUILD.gn

### DIFF
--- a/shell/platform/common/BUILD.gn
+++ b/shell/platform/common/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//flutter/common/config.gni")
+import("//flutter/shell/platform/tizen/config.gni")
 import("//flutter/testing/testing.gni")
 
 config("desktop_library_implementation") {
@@ -110,8 +111,10 @@ source_set("common_cpp") {
   deps = [
     ":common_cpp_library_headers",
     "//flutter/shell/platform/common/client_wrapper:client_wrapper",
-    "//flutter/shell/platform/embedder:embedder_as_internal_library",
   ]
+  if (!build_tizen_shell) {
+    deps += [ "//flutter/shell/platform/embedder:embedder_as_internal_library" ]
+  }
 
   public_deps = [
     ":common_cpp_core",

--- a/shell/platform/common/BUILD.gn
+++ b/shell/platform/common/BUILD.gn
@@ -112,6 +112,7 @@ source_set("common_cpp") {
     ":common_cpp_library_headers",
     "//flutter/shell/platform/common/client_wrapper:client_wrapper",
   ]
+
   if (!build_tizen_shell) {
     deps += [ "//flutter/shell/platform/embedder:embedder_as_internal_library" ]
   }

--- a/shell/platform/common/BUILD.gn
+++ b/shell/platform/common/BUILD.gn
@@ -110,6 +110,7 @@ source_set("common_cpp") {
   deps = [
     ":common_cpp_library_headers",
     "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/embedder:embedder_as_internal_library",
   ]
 
   public_deps = [


### PR DESCRIPTION
For running embedder's unit test, I need x64 build.
(I am modifying the embedder API for the ``FlutterEngineGroup`` API, and I want to add a unit test.)
Unfortunately, modification of BUILD.gn are preventing that task.

This change came from [here](https://github.com/flutter-tizen/engine/commit/bb85756e045cac6aa8c3cdcafddb9dcf44fc8083), I couldn't find a reason. [previous_work](https://github.sec.samsung.net/f-project/engine/blob/flutter-1.22-candidate.12-tizen/shell/platform/common/cpp/BUILD.gn)

Does anyone know the history?
Can I reverse this?