### PR TITLE
Temporarily disable weak symbols in third_party/boringssl

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,8 +16,7 @@ jobs:
   - checkout: self
     path: src/flutter
   - bash: |
-      git reset --hard HEAD
-      gclient sync -D
+      gclient sync -f -D
       sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' build/config/compiler/BUILD.gn
       sed -i 's/"-Wno-psabi",//g' build/config/compiler/BUILD.gn
       sed -i 's/defined(__ELF__) && defined(__GNUC__)/0/g' third_party/boringssl/src/crypto/mem.c
@@ -70,8 +69,8 @@ jobs:
       flutter/tools/gn \
         --target-os linux \
         --linux-cpu $(arch) \
-        --target-toolchain `pwd`/tizen_tools/toolchains \
-        --target-sysroot `pwd`/tizen_tools/sysroot/$(arch) \
+        --target-toolchain $HOME/tizen_tools/toolchains \
+        --target-sysroot $HOME/tizen_tools/sysroot/$(arch) \
         --target-triple $(targetTriple) \
         --runtime-mode $(mode) \
         --embedder-for-target \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ jobs:
       gclient sync -D
       sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' build/config/compiler/BUILD.gn
       sed -i 's/"-Wno-psabi",//g' build/config/compiler/BUILD.gn
+      sed -i 's/defined(__ELF__) && defined(__GNUC__)/0/g' third_party/boringssl/src/crypto/mem.c
     displayName: Run gclient sync
     workingDirectory: $(Pipeline.Workspace)/src
     failOnStderr: true


### PR DESCRIPTION
A temporary solution for https://github.com/flutter-tizen/flutter-tizen/issues/140.

Disables the following definition in `third_party/boringssl/src/crypto/mem.c`:

```cpp
#if defined(__ELF__) && defined(__GNUC__)
#define WEAK_SYMBOL_FUNC(rettype, name, args) \
  rettype name args __attribute__((weak));
...
#endif
```

and therefore makes the functions `OPENSSL_memory_*` and `sdallocx` local to the file as before.
