### PR TITLE
Revert #78 #69

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,6 +73,7 @@ jobs:
         --target-sysroot $HOME/tizen_tools/sysroot/$(arch) \
         --target-triple $(targetTriple) \
         --runtime-mode $(mode) \
+        --enable-fontconfig \
         --embedder-for-target \
         --disable-desktop-embeddings \
         --build-tizen-shell

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -187,6 +187,7 @@ FontCollection::GetMinikinFontCollectionForFamilies(
           FindFontFamilyInManagers(family);
       if (minikin_family != nullptr) {
         minikin_families.push_back(minikin_family);
+        break;
       }
     }
   }

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -99,7 +99,6 @@ size_t FontCollection::GetFontManagersCount() const {
 
 void FontCollection::SetupDefaultFontManager() {
   default_font_manager_ = GetDefaultFontManager();
-  fallback_font_manager_ = GetFallbackFontManager();
 }
 
 void FontCollection::SetDefaultFontManager(sk_sp<SkFontMgr> font_manager) {
@@ -145,8 +144,6 @@ std::vector<sk_sp<SkFontMgr>> FontCollection::GetFontManagerOrder() const {
     order.push_back(test_font_manager_);
   if (default_font_manager_)
     order.push_back(default_font_manager_);
-  if (fallback_font_manager_)
-    order.push_back(fallback_font_manager_);
   return order;
 }
 

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -91,7 +91,6 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
   };
 
   sk_sp<SkFontMgr> default_font_manager_;
-  sk_sp<SkFontMgr> fallback_font_manager_;
   sk_sp<SkFontMgr> asset_font_manager_;
   sk_sp<SkFontMgr> dynamic_font_manager_;
   sk_sp<SkFontMgr> test_font_manager_;

--- a/third_party/txt/src/txt/platform.cc
+++ b/third_party/txt/src/txt/platform.cc
@@ -14,8 +14,4 @@ sk_sp<SkFontMgr> GetDefaultFontManager() {
   return SkFontMgr::RefDefault();
 }
 
-sk_sp<SkFontMgr> GetFallbackFontManager() {
-  return nullptr;
-}
-
 }  // namespace txt

--- a/third_party/txt/src/txt/platform.h
+++ b/third_party/txt/src/txt/platform.h
@@ -17,8 +17,6 @@ std::vector<std::string> GetDefaultFontFamilies();
 
 sk_sp<SkFontMgr> GetDefaultFontManager();
 
-sk_sp<SkFontMgr> GetFallbackFontManager();
-
 }  // namespace txt
 
 #endif  // TXT_PLATFORM_H_

--- a/third_party/txt/src/txt/platform_linux.cc
+++ b/third_party/txt/src/txt/platform_linux.cc
@@ -13,7 +13,7 @@
 namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies() {
-  return {"TizenDefaultFont"};
+  return {"TizenDefaultFont", "SamsungOneUI"};
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager() {

--- a/third_party/txt/src/txt/platform_linux.cc
+++ b/third_party/txt/src/txt/platform_linux.cc
@@ -82,15 +82,7 @@ sk_sp<SkFontMgr> GetDefaultFontManager() {
 #ifdef FLUTTER_USE_FONTCONFIG
   return SkFontMgr::RefDefault();
 #else
-  return SkFontMgr_New_Custom_Directory("/usr/share/fonts");
-#endif
-}
-
-sk_sp<SkFontMgr> GetFallbackFontManager() {
-#ifdef FLUTTER_USE_FONTCONFIG
-  return nullptr;
-#else
-  return SkFontMgr_New_Custom_Directory("/usr/share/fallback_fonts");
+  return SkFontMgr_New_Custom_Directory("/usr/share/");
 #endif
 }
 

--- a/third_party/txt/src/txt/platform_linux.cc
+++ b/third_party/txt/src/txt/platform_linux.cc
@@ -13,76 +13,14 @@
 namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies() {
-#ifdef FLUTTER_USE_FONTCONFIG
   return {"TizenDefaultFont"};
-#else
-  return {
-      "SamsungOneUI",
-      "SamsungOneUIArabic",
-      "SamsungOneUIArmenian",
-      "SamsungOneUIBangla",
-      "SamsungOneUIDevanagari",
-      "SamsungOneUIEthiopic",
-      "SamsungOneUIFallback",
-      "SamsungOneUIGeorgian",
-      "SamsungOneUIGujarati",
-      "SamsungOneUIGurmukhi",
-      "SamsungOneUIHebrew",
-      "SamsungOneUIJP",
-      "SamsungOneUIKannada",
-      "SamsungOneUIKhmer",
-      "SamsungOneUIKorean",
-      "SamsungOneUIKoreanH",
-      "SamsungOneUILao",
-      "SamsungOneUIMalayalam",
-      "SamsungOneUIMyanmar",
-      "SamsungOneUIOdia",
-      "SamsungOneUIOlChiki",
-      "SamsungOneUISCN",
-      "SamsungOneUISinhala",
-      "SamsungOneUITCN",
-      "SamsungOneUITagalog",
-      "SamsungOneUITamil",
-      "SamsungOneUITelugu",
-      "SamsungOneUIThai",
-      "SamsungOneFallback",
-      "SECEmoji",
-      "BreezeSans",
-      "BreezeSansArabic",
-      "BreezeSansArmenian",
-      "BreezeSansBengali",
-      "BreezeSansChinese",
-      "BreezeSansEthiopic",
-      "BreezeSansGeorgian",
-      "BreezeSansGujarathi",
-      "BreezeSansHebrew",
-      "BreezeSansHindi",
-      "BreezeSansJapanese",
-      "BreezeSansKannada",
-      "BreezeSansKhmer",
-      "BreezeSansKorean",
-      "BreezeSansLao",
-      "BreezeSansMalayalam",
-      "BreezeSansMeeteiMayek",
-      "BreezeSansMyanmar",
-      "BreezeSansOriya",
-      "BreezeSansPunjabi",
-      "BreezeSansSinhala",
-      "BreezeSansTamilBreezeSansTamil",
-      "BreezeSansTelugu",
-      "BreezeSansThai",
-      "BreezeSansTibetan",
-      "BreezeSansFallback",
-      "BreezeColorEmoji",
-  };
-#endif
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager() {
 #ifdef FLUTTER_USE_FONTCONFIG
   return SkFontMgr::RefDefault();
 #else
-  return SkFontMgr_New_Custom_Directory("/usr/share/");
+  return SkFontMgr_New_Custom_Directory("/usr/share/fonts/");
 #endif
 }
 


### PR DESCRIPTION
This PR includes :
* Revert "Create fallback font manager to solve performance drops (#78)"
* Revert "Fix font breaking issues (#69)"
* Add SamsungOneUI to DefaultFontFamilies

Now, re-enable fontconfig as default