### PR TITLE
Let the app handle the back key event first

### DIFF
--- a/shell/platform/tizen/channels/key_event_channel.h
+++ b/shell/platform/tizen/channels/key_event_channel.h
@@ -21,7 +21,9 @@ class KeyEventChannel {
   explicit KeyEventChannel(BinaryMessenger* messenger);
   virtual ~KeyEventChannel();
 
-  void SendKeyEvent(Ecore_Event_Key* key, bool is_down);
+  void SendKeyEvent(Ecore_Event_Key* key,
+                    bool is_down,
+                    std::function<void(bool)> callback);
 
  private:
   std::unique_ptr<BasicMessageChannel<rapidjson::Document>> channel_;

--- a/shell/platform/tizen/key_event_handler.cc
+++ b/shell/platform/tizen/key_event_handler.cc
@@ -4,11 +4,19 @@
 
 #include "key_event_handler.h"
 
-#include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
+#include <app.h>
 
-static constexpr char kPlatformBackButtonName[] = "XF86Back";
+#include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
+#include "flutter/shell/platform/tizen/tizen_log.h"
 
 namespace flutter {
+
+namespace {
+
+constexpr char kBackKey[] = "XF86Back";
+constexpr char kExitKey[] = "XF86Exit";
+
+}  // namespace
 
 KeyEventHandler::KeyEventHandler(FlutterTizenEngine* engine) : engine_(engine) {
   key_event_handlers_.push_back(
@@ -30,23 +38,33 @@ Eina_Bool KeyEventHandler::OnKey(void* data, int type, void* event) {
   auto* engine = self->engine_;
   auto is_down = type == ECORE_EVENT_KEY_DOWN;
 
-  if (strcmp(key->keyname, kPlatformBackButtonName) == 0) {
-    // The device back button was pressed.
-    if (engine->navigation_channel && !is_down) {
-      engine->navigation_channel->PopRoute();
+  FT_LOGI("Keycode: %d, name: %s, mods: %d, is_down: %d", key->keycode,
+          key->keyname, key->modifiers, is_down);
+
+  if (engine->text_input_channel) {
+    if (is_down) {
+      engine->text_input_channel->OnKeyDown(key);
     }
-  } else {
-    if (engine->text_input_channel) {
-      if (is_down) {
-        engine->text_input_channel->OnKeyDown(key);
-      }
-      if (engine->text_input_channel->IsSoftwareKeyboardShowing()) {
-        return ECORE_CALLBACK_PASS_ON;
-      }
+    if (engine->text_input_channel->IsSoftwareKeyboardShowing()) {
+      return ECORE_CALLBACK_PASS_ON;
     }
-    if (engine->key_event_channel) {
-      engine->key_event_channel->SendKeyEvent(key, is_down);
-    }
+  }
+
+  if (engine->key_event_channel) {
+    auto keyname = std::string(key->keyname);
+    engine->key_event_channel->SendKeyEvent(
+        key, is_down, [engine, keyname, is_down](bool handled) {
+          if (handled || is_down) {
+            return;
+          }
+          if (keyname == kBackKey) {
+            if (engine->navigation_channel) {
+              engine->navigation_channel->PopRoute();
+            }
+          } else if (keyname == kExitKey) {
+            ui_app_exit();
+          }
+        });
   }
   return ECORE_CALLBACK_PASS_ON;
 }

--- a/shell/platform/tizen/key_event_handler.cc
+++ b/shell/platform/tizen/key_event_handler.cc
@@ -51,17 +51,17 @@ Eina_Bool KeyEventHandler::OnKey(void* data, int type, void* event) {
   }
 
   if (engine->key_event_channel) {
-    auto keyname = std::string(key->keyname);
     engine->key_event_channel->SendKeyEvent(
-        key, is_down, [engine, keyname, is_down](bool handled) {
-          if (handled || is_down) {
+        key, is_down,
+        [engine, keyname = std::string(key->keyname), is_down](bool handled) {
+          if (handled) {
             return;
           }
-          if (keyname == kBackKey) {
+          if (keyname == kBackKey && !is_down) {
             if (engine->navigation_channel) {
               engine->navigation_channel->PopRoute();
             }
-          } else if (keyname == kExitKey) {
+          } else if (keyname == kExitKey && !is_down) {
             ui_app_exit();
           }
         });


### PR DESCRIPTION
Fixes https://github.com/flutter-tizen/flutter-tizen/issues/136.

Side note)
The new embedder API (`FlutterEngineSendKeyEvent`) has recently been added as part of https://github.com/flutter/flutter/issues/44918. I'll check if it's worth migrating from our platform channel-based implementation.

Edit)
I'm not going to implement https://github.com/flutter/flutter/issues/44918 right now because the work is still in progress and the framework side change isn't merged to the stable branch. (Actually I tried a bit: https://github.com/swift-kim/engine/commits/keyboard-hardware.) I'll revisit when the migration is almost done in the upstream and the method channel for key events becomes no longer available. Please take a look at https://flutter.dev/go/platform-based-key-events if interested.