### PR TITLE
Remove engine dependency of LifecycleChannel

### DIFF
--- a/shell/platform/tizen/channels/key_event_channel.cc
+++ b/shell/platform/tizen/channels/key_event_channel.cc
@@ -6,6 +6,7 @@
 
 #include <map>
 
+#include "flutter/shell/platform/common/json_message_codec.h"
 #include "flutter/shell/platform/tizen/tizen_log.h"
 
 namespace flutter {

--- a/shell/platform/tizen/channels/key_event_channel.h
+++ b/shell/platform/tizen/channels/key_event_channel.h
@@ -11,7 +11,6 @@
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
-#include "flutter/shell/platform/common/json_message_codec.h"
 #include "rapidjson/document.h"
 
 namespace flutter {

--- a/shell/platform/tizen/channels/lifecycle_channel.cc
+++ b/shell/platform/tizen/channels/lifecycle_channel.cc
@@ -4,9 +4,7 @@
 
 #include "lifecycle_channel.h"
 
-#include <variant>
-
-#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
+#include "flutter/shell/platform/tizen/channels/string_codec.h"
 #include "flutter/shell/platform/tizen/tizen_log.h"
 
 namespace flutter {
@@ -20,38 +18,13 @@ constexpr char kResumed[] = "AppLifecycleState.resumed";
 constexpr char kPaused[] = "AppLifecycleState.paused";
 constexpr char kDetached[] = "AppLifecycleState.detached";
 
-// Codec extension for UTF-8 strings.
-class StringSerializer : public StandardCodecSerializer {
- public:
-  StringSerializer() = default;
-  virtual ~StringSerializer() = default;
-
-  // Returns the shared serializer instance.
-  static const StringSerializer& GetInstance() {
-    static StringSerializer sInstance;
-    return sInstance;
-  }
-
-  virtual void WriteValue(const EncodableValue& value,
-                          ByteStreamWriter* stream) const override {
-    if (auto string_value = std::get_if<std::string>(&value)) {
-      size_t size = string_value->size();
-      if (size > 0) {
-        stream->WriteBytes(
-            reinterpret_cast<const uint8_t*>(string_value->data()), size);
-      }
-    }
-  }
-};
-
 }  // namespace
 
 LifecycleChannel::LifecycleChannel(BinaryMessenger* messenger)
     : channel_(std::make_unique<BasicMessageChannel<EncodableValue>>(
           messenger,
           kChannelName,
-          &StandardMessageCodec::GetInstance(
-              &StringSerializer::GetInstance()))) {}
+          &StringCodec::GetInstance())) {}
 
 LifecycleChannel::~LifecycleChannel() {}
 

--- a/shell/platform/tizen/channels/lifecycle_channel.cc
+++ b/shell/platform/tizen/channels/lifecycle_channel.cc
@@ -4,8 +4,9 @@
 
 #include "lifecycle_channel.h"
 
+#include <variant>
+
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
-#include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/tizen_log.h"
 
 namespace flutter {
@@ -19,13 +20,38 @@ constexpr char kResumed[] = "AppLifecycleState.resumed";
 constexpr char kPaused[] = "AppLifecycleState.paused";
 constexpr char kDetached[] = "AppLifecycleState.detached";
 
+// Codec extension for UTF-8 strings.
+class StringSerializer : public StandardCodecSerializer {
+ public:
+  StringSerializer() = default;
+  virtual ~StringSerializer() = default;
+
+  // Returns the shared serializer instance.
+  static const StringSerializer& GetInstance() {
+    static StringSerializer sInstance;
+    return sInstance;
+  }
+
+  virtual void WriteValue(const EncodableValue& value,
+                          ByteStreamWriter* stream) const override {
+    if (auto string_value = std::get_if<std::string>(&value)) {
+      size_t size = string_value->size();
+      if (size > 0) {
+        stream->WriteBytes(
+            reinterpret_cast<const uint8_t*>(string_value->data()), size);
+      }
+    }
+  }
+};
+
 }  // namespace
 
 LifecycleChannel::LifecycleChannel(BinaryMessenger* messenger)
     : channel_(std::make_unique<BasicMessageChannel<EncodableValue>>(
           messenger,
           kChannelName,
-          &StandardMessageCodec::GetInstance())) {}
+          &StandardMessageCodec::GetInstance(
+              &StringSerializer::GetInstance()))) {}
 
 LifecycleChannel::~LifecycleChannel() {}
 

--- a/shell/platform/tizen/channels/lifecycle_channel.cc
+++ b/shell/platform/tizen/channels/lifecycle_channel.cc
@@ -4,6 +4,7 @@
 
 #include "lifecycle_channel.h"
 
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
 #include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/tizen_log.h"
 
@@ -20,35 +21,32 @@ constexpr char kDetached[] = "AppLifecycleState.detached";
 
 }  // namespace
 
-LifecycleChannel::LifecycleChannel(FlutterTizenEngine* engine)
-    : engine_(engine) {}
+LifecycleChannel::LifecycleChannel(BinaryMessenger* messenger)
+    : channel_(std::make_unique<BasicMessageChannel<EncodableValue>>(
+          messenger,
+          kChannelName,
+          &StandardMessageCodec::GetInstance())) {}
 
 LifecycleChannel::~LifecycleChannel() {}
 
-void LifecycleChannel::SendLifecycleMessage(const char message[]) {
-  engine_->SendPlatformMessage(kChannelName,
-                               reinterpret_cast<const uint8_t*>(message),
-                               strlen(message), nullptr, nullptr);
-}
-
 void LifecycleChannel::AppIsInactive() {
-  FT_LOGI("send app lifecycle state inactive.");
-  SendLifecycleMessage(kInactive);
+  FT_LOGI("Sending %s message.", kInactive);
+  channel_->Send(EncodableValue(kInactive));
 }
 
 void LifecycleChannel::AppIsResumed() {
-  FT_LOGI("send app lifecycle state resumed.");
-  SendLifecycleMessage(kResumed);
+  FT_LOGI("Sending %s message.", kResumed);
+  channel_->Send(EncodableValue(kResumed));
 }
 
 void LifecycleChannel::AppIsPaused() {
-  FT_LOGI("send app lifecycle state paused.");
-  SendLifecycleMessage(kPaused);
+  FT_LOGI("Sending %s message.", kPaused);
+  channel_->Send(EncodableValue(kPaused));
 }
 
 void LifecycleChannel::AppIsDetached() {
-  FT_LOGI("send app lifecycle state detached.");
-  SendLifecycleMessage(kDetached);
+  FT_LOGI("Sending %s message.", kDetached);
+  channel_->Send(EncodableValue(kDetached));
 }
 
 }  // namespace flutter

--- a/shell/platform/tizen/channels/lifecycle_channel.h
+++ b/shell/platform/tizen/channels/lifecycle_channel.h
@@ -5,23 +5,25 @@
 #ifndef EMBEDDER_LIFECYCLE_CHANNEL_H_
 #define EMBEDDER_LIFECYCLE_CHANNEL_H_
 
-namespace flutter {
+#include <memory>
 
-class FlutterTizenEngine;
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
+
+namespace flutter {
 
 class LifecycleChannel {
  public:
-  explicit LifecycleChannel(FlutterTizenEngine* engine);
+  explicit LifecycleChannel(BinaryMessenger* messenger);
   virtual ~LifecycleChannel();
 
   void AppIsInactive();
   void AppIsResumed();
   void AppIsPaused();
   void AppIsDetached();
-  void SendLifecycleMessage(const char message[]);
 
  private:
-  FlutterTizenEngine* engine_{nullptr};
+  std::unique_ptr<BasicMessageChannel<EncodableValue>> channel_;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/channels/string_codec.h
+++ b/shell/platform/tizen/channels/string_codec.h
@@ -1,0 +1,58 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef EMBEDDER_STRING_CODEC_H_
+#define EMBEDDER_STRING_CODEC_H_
+
+#include <memory>
+#include <string>
+#include <variant>
+
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/message_codec.h"
+
+namespace flutter {
+
+// A string message encoding/decoding mechanism for communications to/from the
+// Flutter engine via message channels.
+class StringCodec : public MessageCodec<EncodableValue> {
+ public:
+  ~StringCodec() = default;
+
+  // Returns an instance of the codec.
+  static const StringCodec& GetInstance() {
+    static StringCodec sInstance;
+    return sInstance;
+  }
+
+  // Prevent copying.
+  StringCodec(StringCodec const&) = delete;
+  StringCodec& operator=(StringCodec const&) = delete;
+
+ protected:
+  // |flutter::MessageCodec|
+  std::unique_ptr<EncodableValue> DecodeMessageInternal(
+      const uint8_t* binary_message,
+      const size_t message_size) const override {
+    return std::make_unique<EncodableValue>(std::string(
+        reinterpret_cast<const char*>(binary_message), message_size));
+  }
+
+  // |flutter::MessageCodec|
+  std::unique_ptr<std::vector<uint8_t>> EncodeMessageInternal(
+      const EncodableValue& message) const override {
+    auto string_value = std::get<std::string>(message);
+    return std::make_unique<std::vector<uint8_t>>(string_value.begin(),
+                                                  string_value.end());
+  }
+
+ private:
+  // Instances should be obtained via GetInstance.
+  explicit StringCodec() = default;
+};
+
+}  // namespace flutter
+
+#endif  // EMBEDDER_STRING_CODEC_H_

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -236,7 +236,8 @@ bool FlutterTizenEngine::RunEngine(
       internal_plugin_registrar_->messenger());
   localization_channel = std::make_unique<LocalizationChannel>(this);
   localization_channel->SendLocales();
-  lifecycle_channel = std::make_unique<LifecycleChannel>(this);
+  lifecycle_channel = std::make_unique<LifecycleChannel>(
+      internal_plugin_registrar_->messenger());
 
   if (IsHeaded()) {
     texture_registrar_ = std::make_unique<FlutterTizenTextureRegistrar>(this);


### PR DESCRIPTION
Sends lifecycle messages through a BasicMessageChannel instead of using `FlutterTizenEngine::SendPlatformMessage`.

I implemented `StringCodec` from scratch because there was no equivalent of the framework's `StringCodec` in cpp_client_wrapper. `StandardCodecSerializer` already has support for the string data type but its serialization format is slightly different from `StringCodec`'s.

@flutter-tizen/maintainers How do you feel about this change? I can discard this change if it doesn't make very much sense.
