### PR TITLE
Add Tizen implementation of fml logger

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -4,6 +4,7 @@
 
 import("//build/fuchsia/sdk.gni")
 import("//flutter/common/config.gni")
+import("//flutter/shell/platform/tizen/config.gni")
 import("//flutter/testing/testing.gni")
 
 source_set("fml") {
@@ -218,6 +219,10 @@ source_set("fml") {
       "platform/posix/paths_posix.cc",
       "platform/posix/posix_wrappers_posix.cc",
     ]
+  }
+
+  if (build_tizen_shell) {
+    defines = [ "OS_TIZEN" ]
   }
 }
 

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -183,9 +183,15 @@ bool FlutterTizenEngine::RunEngine() {
         engine->message_dispatcher->HandleMessage(message);
       };
   args.custom_task_runners = &custom_task_runners;
+  args.log_message_callback = [](const char* tag, const char* message,
+                                 void* user_data) {
+    // TODO: Do not use __LOG().
+    __LOG(DLOG_INFO, "%s: %s", tag, message);
+  };
+
 #ifndef TIZEN_RENDERER_EVAS_GL
   if (IsHeaded()) {
-    args.vsync_callback = [](void* user_data, intptr_t baton) -> void {
+    args.vsync_callback = [](void* user_data, intptr_t baton) {
       reinterpret_cast<FlutterTizenEngine*>(user_data)
           ->tizen_vsync_waiter_->AsyncWaitForVsync(baton);
     };


### PR DESCRIPTION
The implementation is not yet complete, but I want to hear opinions from @flutter-tizen/maintainers about this change.

In order to implement https://github.com/flutter-tizen/engine/issues/123, I need to

1. Redirect Dart message to dlog (this can be done by using the new `log_message_callback` API),
2. Redirect fml logs to dlog, to make sure all unhandled exceptions are logged to the console during `flutter-tizen run`,
3. Initiate logging threads (`StartLogging()`) only in debug mode (not implemented yet).

In order to apply 2, I need to modify the fml source code itself which is part of the engine. What makes things worse is that I have to dlopen libdlog.so at runtime, because the engine binary is common for all profiles (wearable and TV), and the engine code can't call the undocumented function `__dlog_print` statically due to the Galaxy Store API restrictions.

As a result, the 40 lines of change in this PR should be made to the engine source code, outside the Tizen embedder. (1) Do you think it's worth making this change to reduce possible logging overheads in release mode? (2) How about removing `StartLogging()` completely and applying the change to the debug mode as well? The downside is that standard output/errors from any other modules (not from the Flutter engine and the Tizen embedder) will not be generally available during debugging.
