### PR TITLE
Remove device_profile

### DIFF
--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -110,7 +110,6 @@ template("embedder_for_profile") {
       "base-utils-i18n",
       "capi-appfw-application",
       "capi-base-common",
-      "capi-system-info",
       "capi-system-system-settings",
       "dlog",
       "ecore",

--- a/shell/platform/tizen/channels/key_event_channel.cc
+++ b/shell/platform/tizen/channels/key_event_channel.cc
@@ -257,8 +257,8 @@ void KeyEventChannel::SendKeyEvent(Ecore_Event_Key* key,
   channel_->Send(event, [callback = std::move(callback)](const uint8_t* reply,
                                                          size_t reply_size) {
     if (reply != nullptr) {
-      auto decoded = flutter::JsonMessageCodec::GetInstance().DecodeMessage(
-          reply, reply_size);
+      auto decoded =
+          JsonMessageCodec::GetInstance().DecodeMessage(reply, reply_size);
       bool handled = (*decoded)[kHandledKey].GetBool();
       callback(handled);
     }

--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -425,13 +425,13 @@ bool TextInputChannel::FilterEvent(Ecore_Event_Key* event) {
   imf_event.dev_name = is_ime ? "ime" : "";
   imf_event.keycode = event->keycode;
 
+#ifdef WEARABLE_PROFILE
+  // FIXME: Only for wearable.
   if (is_ime && strcmp(event->key, "Select") == 0) {
-    if (engine_->device_profile == DeviceProfile::kWearable) {
-      // FIXME: for wearable
-      in_select_mode_ = true;
-      FT_LOGI("Set select mode[true]");
-    }
+    in_select_mode_ = true;
+    FT_LOGI("Set select mode[true]");
   }
+#endif
 
   if (is_ime) {
     if (!strcmp(event->key, "Left") || !strcmp(event->key, "Right") ||
@@ -458,24 +458,26 @@ bool TextInputChannel::FilterEvent(Ecore_Event_Key* event) {
     last_handled_ecore_event_keyname_ = event->keyname;
   }
 
-  if (!handled && !strcmp(event->key, "Return") && in_select_mode_ &&
-      engine_->device_profile == DeviceProfile::kWearable) {
+#ifdef WEARABLE_PROFILE
+  if (!handled && !strcmp(event->key, "Return") && in_select_mode_) {
     in_select_mode_ = false;
     handled = true;
     FT_LOGI("Set select mode[false]");
   }
+#endif
 
   return handled;
 }
 
 void TextInputChannel::NonIMFFallback(Ecore_Event_Key* event) {
-  // For mobile, fix me!
-  if (engine_->device_profile == DeviceProfile::kMobile &&
-      edit_status_ == EditStatus::kPreeditEnd) {
+#ifdef MOBILE_PROFILE
+  // FIXME: Only for mobile.
+  if (edit_status_ == EditStatus::kPreeditEnd) {
     SetEditStatus(EditStatus::kNone);
     FT_LOGW("Ignore key-event[%s]!", event->keyname);
     return;
   }
+#endif
 
   bool select = !strcmp(event->key, "Select");
   bool is_filtered = true;

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -13,35 +13,29 @@
 
 #include "flutter/shell/platform/tizen/tizen_log.h"
 
-// Unique number associated with platform tasks.
-static constexpr size_t kPlatformTaskRunnerIdentifier = 1;
-#ifdef TIZEN_RENDERER_EVAS_GL
-static constexpr size_t kRenderTaskRunnerIdentifier = 2;
-#endif
-
 namespace flutter {
 
-static DeviceProfile GetDeviceProfile() {
-  char* feature_profile;
-  system_info_get_platform_string("http://tizen.org/feature/profile",
-                                  &feature_profile);
-  std::string profile(feature_profile);
-  free(feature_profile);
+namespace {
 
-  if (profile == "mobile") {
-    return DeviceProfile::kMobile;
-  } else if (profile == "wearable") {
-    return DeviceProfile::kWearable;
-  } else if (profile == "tv") {
-    return DeviceProfile::kTV;
-  } else if (profile == "common") {
-    return DeviceProfile::kCommon;
-  }
-  return DeviceProfile::kUnknown;
-}
+// Unique number associated with platform tasks.
+constexpr size_t kPlatformTaskRunnerIdentifier = 1;
+#ifdef TIZEN_RENDERER_EVAS_GL
+constexpr size_t kRenderTaskRunnerIdentifier = 2;
+#endif
 
-FlutterTizenEngine::FlutterTizenEngine(bool headed)
-    : device_profile(GetDeviceProfile()) {
+#if defined(MOBILE_PROFILE)
+constexpr double kProfileFactor = 0.7;
+#elif defined(WEARABLE_PROFILE)
+constexpr double kProfileFactor = 0.4;
+#elif defined(TV_PROFILE)
+constexpr double kProfileFactor = 2.0;
+#else
+constexpr double kProfileFactor = 1.0;
+#endif
+
+}  // namespace
+
+FlutterTizenEngine::FlutterTizenEngine(bool headed) {
   embedder_api_.struct_size = sizeof(FlutterEngineProcTable);
   FlutterEngineGetProcAddresses(&embedder_api_);
 
@@ -341,19 +335,12 @@ void FlutterTizenEngine::SendWindowMetrics(int32_t width,
     // The scale factor is computed based on the display DPI and the current
     // profile. A fixed DPI value (72) is used on TVs. See:
     // https://docs.tizen.org/application/native/guides/ui/efl/multiple-screens
+#ifdef TV_PROFILE
     double dpi = 72.0;
-    if (renderer && device_profile != DeviceProfile::kTV) {
-      dpi = static_cast<double>(renderer->GetDpi());
-    }
-    double profile_factor = 1.0;
-    if (device_profile == DeviceProfile::kWearable) {
-      profile_factor = 0.4;
-    } else if (device_profile == DeviceProfile::kMobile) {
-      profile_factor = 0.7;
-    } else if (device_profile == DeviceProfile::kTV) {
-      profile_factor = 2.0;
-    }
-    double scale_factor = dpi / 90.0 * profile_factor;
+#else
+    double dpi = static_cast<double>(renderer->GetDpi());
+#endif
+    double scale_factor = dpi / 90.0 * kProfileFactor;
     event.pixel_ratio = std::max(scale_factor, 1.0);
   } else {
     event.pixel_ratio = pixel_ratio;

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -5,8 +5,6 @@
 
 #include "flutter_tizen_engine.h"
 
-#include <system_info.h>
-
 #include <filesystem>
 #include <string>
 #include <vector>

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -56,8 +56,6 @@ struct AOTDataDeleter {
 
 using UniqueAotDataPtr = std::unique_ptr<_FlutterEngineAOTData, AOTDataDeleter>;
 
-enum DeviceProfile { kUnknown, kMobile, kWearable, kTV, kCommon };
-
 // Manages state associated with the underlying FlutterEngine.
 class FlutterTizenEngine : public TizenRenderer::Delegate {
  public:
@@ -139,8 +137,6 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
   std::unique_ptr<SettingsChannel> settings_channel;
   std::unique_ptr<TextInputChannel> text_input_channel;
   std::unique_ptr<PlatformViewChannel> platform_view_channel;
-
-  const DeviceProfile device_profile;
 
  private:
   bool IsHeaded() { return renderer != nullptr; }


### PR DESCRIPTION
It's unnecessary to read the current device profile at runtime.

The use of preprocessor macro is discouraged by the Google style guide, so it's

```cpp
constexpr double kProfileFactor = 0.7;
```

rather than

```cpp
#define PROFILE_FACTOR 0.7
```