### PR TITLE
Add FlutterDesktopWindowProperties to the public API

### DIFF
--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -32,6 +32,7 @@ _flutter_tizen_source = [
   "channels/navigation_channel.cc",
   "channels/platform_view_channel.cc",
   "channels/text_input_channel.cc",
+  "flutter_project_bundle.cc",
   "flutter_tizen.cc",
   "flutter_tizen_engine.cc",
   "flutter_tizen_texture_registrar.cc",
@@ -139,6 +140,7 @@ template("embedder_for_profile") {
       libs += [
         "base-utils-i18n",
         "capi-appfw-application",
+        "capi-appfw-app-common",
         "capi-base-common",
         "capi-system-info",
         "capi-system-system-settings",

--- a/shell/platform/tizen/external_texture.h
+++ b/shell/platform/tizen/external_texture.h
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <memory>
+
 #include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 

--- a/shell/platform/tizen/flutter_project_bundle.cc
+++ b/shell/platform/tizen/flutter_project_bundle.cc
@@ -7,7 +7,6 @@
 
 #include <filesystem>
 
-#include "flutter/shell/platform/common/path_utils.h"
 #include "flutter/shell/platform/tizen/tizen_log.h"
 
 namespace flutter {
@@ -18,24 +17,6 @@ FlutterProjectBundle::FlutterProjectBundle(
       icu_path_(properties.icu_data_path) {
   if (properties.aot_library_path != nullptr) {
     aot_library_path_ = std::filesystem::path(properties.aot_library_path);
-  }
-
-  // Resolve any relative paths.
-  if (assets_path_.is_relative() || icu_path_.is_relative() ||
-      (!aot_library_path_.empty() && aot_library_path_.is_relative())) {
-    std::filesystem::path executable_location = GetExecutableDirectory();
-    if (executable_location.empty()) {
-      FT_LOGE("Unable to find executable location to resolve resource paths.");
-      assets_path_ = std::filesystem::path();
-      icu_path_ = std::filesystem::path();
-    } else {
-      assets_path_ = std::filesystem::path(executable_location) / assets_path_;
-      icu_path_ = std::filesystem::path(executable_location) / icu_path_;
-      if (!aot_library_path_.empty()) {
-        aot_library_path_ =
-            std::filesystem::path(executable_location) / aot_library_path_;
-      }
-    }
   }
 
   switches_.insert(switches_.end(), properties.switches,

--- a/shell/platform/tizen/flutter_project_bundle.cc
+++ b/shell/platform/tizen/flutter_project_bundle.cc
@@ -5,7 +5,11 @@
 
 #include "flutter_project_bundle.h"
 
+#ifdef __X64_SHELL__
+#include "flutter/shell/platform/common/path_utils.h"
+#else
 #include <app_common.h>
+#endif
 
 #include <filesystem>
 
@@ -13,6 +17,7 @@
 
 namespace flutter {
 
+#ifndef __X64_SHELL__
 namespace {
 
 // Returns the path of the directory containing the app binary, or an empty
@@ -28,6 +33,7 @@ std::filesystem::path GetExecutableDirectory() {
 }
 
 }  // namespace
+#endif
 
 FlutterProjectBundle::FlutterProjectBundle(
     const FlutterDesktopEngineProperties& properties)

--- a/shell/platform/tizen/flutter_project_bundle.cc
+++ b/shell/platform/tizen/flutter_project_bundle.cc
@@ -1,0 +1,78 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter_project_bundle.h"
+
+#include <filesystem>
+
+#include "flutter/shell/platform/common/path_utils.h"
+#include "flutter/shell/platform/tizen/tizen_log.h"
+
+namespace flutter {
+
+FlutterProjectBundle::FlutterProjectBundle(
+    const FlutterDesktopEngineProperties& properties)
+    : assets_path_(properties.assets_path),
+      icu_path_(properties.icu_data_path) {
+  if (properties.aot_library_path != nullptr) {
+    aot_library_path_ = std::filesystem::path(properties.aot_library_path);
+  }
+
+  // Resolve any relative paths.
+  if (assets_path_.is_relative() || icu_path_.is_relative() ||
+      (!aot_library_path_.empty() && aot_library_path_.is_relative())) {
+    std::filesystem::path executable_location = GetExecutableDirectory();
+    if (executable_location.empty()) {
+      FT_LOGE("Unable to find executable location to resolve resource paths.");
+      assets_path_ = std::filesystem::path();
+      icu_path_ = std::filesystem::path();
+    } else {
+      assets_path_ = std::filesystem::path(executable_location) / assets_path_;
+      icu_path_ = std::filesystem::path(executable_location) / icu_path_;
+      if (!aot_library_path_.empty()) {
+        aot_library_path_ =
+            std::filesystem::path(executable_location) / aot_library_path_;
+      }
+    }
+  }
+
+  switches_.insert(switches_.end(), properties.switches,
+                   properties.switches + properties.switches_count);
+}
+
+bool FlutterProjectBundle::HasValidPaths() {
+  return !assets_path_.empty() && !icu_path_.empty();
+}
+
+// Attempts to load AOT data from the given path, which must be absolute and
+// non-empty. Logs and returns nullptr on failure.
+UniqueAotDataPtr FlutterProjectBundle::LoadAotData(
+    const FlutterEngineProcTable& engine_procs) {
+  if (aot_library_path_.empty()) {
+    FT_LOGE(
+        "Attempted to load AOT data, but no aot_library_path was provided.");
+    return UniqueAotDataPtr(nullptr, nullptr);
+  }
+  if (!std::filesystem::exists(aot_library_path_)) {
+    FT_LOGE("Can't load AOT data from %s; no such file.",
+            aot_library_path_.u8string().c_str());
+    return UniqueAotDataPtr(nullptr, nullptr);
+  }
+  std::string path_string = aot_library_path_.u8string();
+  FlutterEngineAOTDataSource source = {};
+  source.type = kFlutterEngineAOTDataSourceTypeElfPath;
+  source.elf_path = path_string.c_str();
+  FlutterEngineAOTData data = nullptr;
+  auto result = engine_procs.CreateAOTData(&source, &data);
+  if (result != kSuccess) {
+    FT_LOGE("Failed to load AOT data from: %s", path_string.c_str());
+    return UniqueAotDataPtr(nullptr, nullptr);
+  }
+  return UniqueAotDataPtr(data, engine_procs.CollectAOTData);
+}
+
+FlutterProjectBundle::~FlutterProjectBundle() {}
+
+}  // namespace flutter

--- a/shell/platform/tizen/flutter_project_bundle.h
+++ b/shell/platform/tizen/flutter_project_bundle.h
@@ -1,0 +1,62 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef EMBEDDER_FLUTTER_PROJECT_BUNDLE_H_
+#define EMBEDDER_FLUTTER_PROJECT_BUNDLE_H_
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/tizen/public/flutter_tizen.h"
+
+namespace flutter {
+
+using UniqueAotDataPtr =
+    std::unique_ptr<_FlutterEngineAOTData, FlutterEngineCollectAOTDataFnPtr>;
+
+// The data associated with a Flutter project needed to run it in an engine.
+class FlutterProjectBundle {
+ public:
+  // Creates a new project bundle from the given properties.
+  //
+  // Treats any relative paths as relative to the directory of this executable.
+  explicit FlutterProjectBundle(
+      const FlutterDesktopEngineProperties& properties);
+
+  ~FlutterProjectBundle();
+
+  // Whether or not the bundle is valid. This does not check that the paths
+  // exist, or contain valid data, just that paths were able to be constructed.
+  bool HasValidPaths();
+
+  // Returns the path to the assets directory.
+  const std::filesystem::path& assets_path() { return assets_path_; }
+
+  // Returns the path to the ICU data file.
+  const std::filesystem::path& icu_path() { return icu_path_; }
+
+  // Returns any switches that should be passed to the engine.
+  const std::vector<std::string> switches() { return switches_; }
+
+  // Attempts to load AOT data for this bundle. The returned data must be
+  // retained until any engine instance it is passed to has been shut down.
+  //
+  // Logs and returns nullptr on failure.
+  UniqueAotDataPtr LoadAotData(const FlutterEngineProcTable& engine_procs);
+
+ private:
+  std::filesystem::path assets_path_;
+  std::filesystem::path icu_path_;
+  std::vector<std::string> switches_;
+
+  // Path to the AOT library file, if any.
+  std::filesystem::path aot_library_path_;
+};
+
+}  // namespace flutter
+
+#endif  // EMBEDDER_FLUTTER_PROJECT_BUNDLE_H_

--- a/shell/platform/tizen/flutter_project_bundle.h
+++ b/shell/platform/tizen/flutter_project_bundle.h
@@ -22,6 +22,8 @@ using UniqueAotDataPtr =
 class FlutterProjectBundle {
  public:
   // Creates a new project bundle from the given properties.
+  //
+  // Treats any relative paths as relative to the directory of the app binary.
   explicit FlutterProjectBundle(
       const FlutterDesktopEngineProperties& properties);
 

--- a/shell/platform/tizen/flutter_project_bundle.h
+++ b/shell/platform/tizen/flutter_project_bundle.h
@@ -22,8 +22,6 @@ using UniqueAotDataPtr =
 class FlutterProjectBundle {
  public:
   // Creates a new project bundle from the given properties.
-  //
-  // Treats any relative paths as relative to the directory of this executable.
   explicit FlutterProjectBundle(
       const FlutterDesktopEngineProperties& properties);
 
@@ -51,7 +49,7 @@ class FlutterProjectBundle {
  private:
   std::filesystem::path assets_path_;
   std::filesystem::path icu_path_;
-  std::vector<std::string> switches_;
+  std::vector<std::string> switches_ = {};
 
   // Path to the AOT library file, if any.
   std::filesystem::path aot_library_path_;

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -26,12 +26,17 @@ static FlutterDesktopEngineRef HandleForEngine(
 }
 
 FlutterDesktopEngineRef FlutterDesktopRunEngine(
-    const FlutterDesktopEngineProperties& engine_properties,
-    bool headed) {
+    const FlutterDesktopWindowProperties& window_properties,
+    const FlutterDesktopEngineProperties& engine_properties) {
   flutter::StartLogging();
 
   flutter::FlutterProjectBundle project(engine_properties);
-  auto engine = std::make_unique<flutter::FlutterTizenEngine>(project, headed);
+  auto engine = std::make_unique<flutter::FlutterTizenEngine>(project);
+  if (window_properties.headed) {
+    engine->InitializeRenderer(window_properties.x, window_properties.y,
+                               window_properties.width,
+                               window_properties.height);
+  }
   if (!engine->RunEngine()) {
     FT_LOGE("Failed to run the Flutter engine.");
     return nullptr;

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -8,6 +8,7 @@
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
 #include "flutter/shell/platform/common/incoming_message_dispatcher.h"
+#include "flutter/shell/platform/tizen/flutter_project_bundle.h"
 #include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/public/flutter_platform_view.h"
 #include "flutter/shell/platform/tizen/tizen_log.h"
@@ -29,8 +30,9 @@ FlutterDesktopEngineRef FlutterDesktopRunEngine(
     bool headed) {
   flutter::StartLogging();
 
-  auto engine = std::make_unique<flutter::FlutterTizenEngine>(headed);
-  if (!engine->RunEngine(engine_properties)) {
+  flutter::FlutterProjectBundle project(engine_properties);
+  auto engine = std::make_unique<flutter::FlutterTizenEngine>(project, headed);
+  if (!engine->RunEngine()) {
     FT_LOGE("Failed to run the Flutter engine.");
     return nullptr;
   }

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -92,6 +92,10 @@ void FlutterTizenEngine::NotifyLowMemoryWarning() {
 }
 
 bool FlutterTizenEngine::RunEngine() {
+  if (engine_ != nullptr) {
+    FT_LOGE("The engine has already started.");
+    return false;
+  }
   if (IsHeaded() && !renderer->IsValid()) {
     FT_LOGE("The display was not valid.");
     return false;

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -51,7 +51,7 @@ namespace flutter {
 class FlutterTizenEngine : public TizenRenderer::Delegate {
  public:
   // Creates a new Flutter engine object configured to run |project|.
-  explicit FlutterTizenEngine(const FlutterProjectBundle& project, bool headed);
+  explicit FlutterTizenEngine(const FlutterProjectBundle& project);
 
   virtual ~FlutterTizenEngine();
 
@@ -60,7 +60,7 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
   FlutterTizenEngine& operator=(FlutterTizenEngine const&) = delete;
 
   // Sets up an instance of TizenRenderer.
-  void InitializeRenderer();
+  void InitializeRenderer(int32_t x, int32_t y, int32_t width, int32_t height);
 
   // Starts running the engine.
   bool RunEngine();

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -137,6 +137,7 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
   std::unique_ptr<PlatformViewChannel> platform_view_channel;
 
  private:
+  // Whether the engine is running in headed or headless mode.
   bool IsHeaded() { return renderer != nullptr; }
 
   FlutterDesktopMessage ConvertToDesktopMessage(

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -149,11 +149,13 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
   // FlutterTizenEngine.
   FlutterRendererConfig GetRendererConfig();
 
-  // The handle to the embedder.h engine instance.
+  // The Flutter engine instance.
   FLUTTER_API_SYMBOL(FlutterEngine) engine_ = nullptr;
 
+  // The proc table of the embedder APIs.
   FlutterEngineProcTable embedder_api_ = {};
 
+  // The data required for configuring a Flutter engine instance.
   std::unique_ptr<FlutterProjectBundle> project_;
 
   // AOT data for this engine instance, if applicable.

--- a/shell/platform/tizen/flutter_tizen_engine_unittest.cc
+++ b/shell/platform/tizen/flutter_tizen_engine_unittest.cc
@@ -1,5 +1,4 @@
-// Copyright 2020 Samsung Electronics Co., Ltd. All rights reserved.
-// Copyright 2013 The Flutter Authors. All rights reserved.
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -9,52 +8,22 @@
 namespace flutter {
 namespace testing {
 
-class FlutterTizenEngineTestSimple : public ::testing::Test {
- protected:
-  void SetUp() { ecore_init(); }
-};
-
-TEST_F(FlutterTizenEngineTestSimple, Create_Headless) {
-  flutter::FlutterTizenEngine* tizen_engine =
-      new flutter::FlutterTizenEngine(false);
-  EXPECT_TRUE(tizen_engine != nullptr);
-  delete tizen_engine;
-}
-
-// TODO
-TEST_F(FlutterTizenEngineTestSimple, DISABLED_Create_Headed) {
-  flutter::FlutterTizenEngine* tizen_engine =
-      new flutter::FlutterTizenEngine(true);
-  EXPECT_TRUE(tizen_engine != nullptr);
-  delete tizen_engine;
-}
-
 class FlutterTizenEngineTest : public ::testing::Test {
  public:
   FlutterTizenEngineTest() {
     ecore_init();
-
-    std::string tpk_root;
-    char path[256];
-    EXPECT_TRUE(getcwd(path, sizeof(path)) != NULL);
-    tpk_root = path + std::string("/tpkroot");
-
-    assets_path_ = tpk_root + "/res/flutter_assets";
-    icu_data_path_ = tpk_root + "/res/icudtl.dat";
-    aot_lib_path_ = tpk_root + "/lib/libapp.so";
-
-    switches_.push_back("--disable-observatory");
+    elm_init(0, nullptr);
   }
 
  protected:
   void SetUp() {
-    engine_prop_.assets_path = assets_path_.c_str();
-    engine_prop_.icu_data_path = icu_data_path_.c_str();
-    engine_prop_.aot_library_path = aot_lib_path_.c_str();
-    engine_prop_.switches = switches_.data();
-    engine_prop_.switches_count = switches_.size();
+    FlutterDesktopEngineProperties engine_prop = {};
+    engine_prop.assets_path = "foo/flutter_assets";
+    engine_prop.icu_data_path = "foo/icudtl.dat";
+    engine_prop.aot_library_path = "foo/libapp.so";
 
-    auto engine = std::make_unique<flutter::FlutterTizenEngine>(false);
+    FlutterProjectBundle project(engine_prop);
+    auto engine = std::make_unique<FlutterTizenEngine>(project);
     engine_ = engine.release();
   }
 
@@ -65,49 +34,53 @@ class FlutterTizenEngineTest : public ::testing::Test {
     engine_ = nullptr;
   }
 
-  std::string assets_path_;
-  std::string icu_data_path_;
-  std::string aot_lib_path_;
   flutter::FlutterTizenEngine* engine_;
-  FlutterDesktopEngineProperties engine_prop_ = {};
-  std::vector<const char*> switches_;
+};
+
+class FlutterTizenEngineTestHeaded : public FlutterTizenEngineTest {
+ protected:
+  void SetUp() {
+    FlutterTizenEngineTest::SetUp();
+    engine_->InitializeRenderer(0, 0, 800, 600);
+  }
 };
 
 TEST_F(FlutterTizenEngineTest, Run) {
   EXPECT_TRUE(engine_ != nullptr);
-  EXPECT_TRUE(engine_->RunEngine(engine_prop_));
+  EXPECT_TRUE(engine_->RunEngine());
   EXPECT_TRUE(true);
 }
 
 // TODO
 TEST_F(FlutterTizenEngineTest, DISABLED_Run_Twice) {
-  EXPECT_TRUE(engine_ != nullptr);
-  EXPECT_TRUE(engine_->RunEngine(engine_prop_));
-  EXPECT_FALSE(engine_->RunEngine(engine_prop_));
+  EXPECT_TRUE(engine_->RunEngine());
+  EXPECT_FALSE(engine_->RunEngine());
   EXPECT_TRUE(true);
 }
 
 TEST_F(FlutterTizenEngineTest, Stop) {
-  EXPECT_TRUE(engine_ != nullptr);
-  EXPECT_TRUE(engine_->RunEngine(engine_prop_));
+  EXPECT_TRUE(engine_->RunEngine());
   EXPECT_TRUE(engine_->StopEngine());
 }
 
 TEST_F(FlutterTizenEngineTest, Stop_Twice) {
-  EXPECT_TRUE(engine_ != nullptr);
-  EXPECT_TRUE(engine_->RunEngine(engine_prop_));
+  EXPECT_TRUE(engine_->RunEngine());
   EXPECT_TRUE(engine_->StopEngine());
   EXPECT_FALSE(engine_->StopEngine());
 }
 
 TEST_F(FlutterTizenEngineTest, GetPluginRegistrar) {
-  EXPECT_TRUE(engine_ != nullptr);
+  EXPECT_TRUE(engine_->RunEngine());
   EXPECT_TRUE(engine_->GetPluginRegistrar() != nullptr);
 }
 
-// TODO
-TEST_F(FlutterTizenEngineTest, DISABLED_GetTextureRegistrar) {
-  EXPECT_TRUE(engine_ != nullptr);
+TEST_F(FlutterTizenEngineTest, GetTextureRegistrar) {
+  EXPECT_TRUE(engine_->RunEngine());
+  EXPECT_TRUE(engine_->GetTextureRegistrar() == nullptr);
+}
+
+TEST_F(FlutterTizenEngineTestHeaded, GetTextureRegistrar) {
+  EXPECT_TRUE(engine_->RunEngine());
   EXPECT_TRUE(engine_->GetTextureRegistrar() != nullptr);
 }
 

--- a/shell/platform/tizen/flutter_tizen_engine_unittest.cc
+++ b/shell/platform/tizen/flutter_tizen_engine_unittest.cc
@@ -34,7 +34,7 @@ class FlutterTizenEngineTest : public ::testing::Test {
     engine_ = nullptr;
   }
 
-  flutter::FlutterTizenEngine* engine_;
+  FlutterTizenEngine* engine_;
 };
 
 class FlutterTizenEngineTestHeaded : public FlutterTizenEngineTest {
@@ -48,14 +48,11 @@ class FlutterTizenEngineTestHeaded : public FlutterTizenEngineTest {
 TEST_F(FlutterTizenEngineTest, Run) {
   EXPECT_TRUE(engine_ != nullptr);
   EXPECT_TRUE(engine_->RunEngine());
-  EXPECT_TRUE(true);
 }
 
-// TODO
-TEST_F(FlutterTizenEngineTest, DISABLED_Run_Twice) {
+TEST_F(FlutterTizenEngineTest, Run_Twice) {
   EXPECT_TRUE(engine_->RunEngine());
   EXPECT_FALSE(engine_->RunEngine());
-  EXPECT_TRUE(true);
 }
 
 TEST_F(FlutterTizenEngineTest, Stop) {

--- a/shell/platform/tizen/public/flutter_tizen.h
+++ b/shell/platform/tizen/public/flutter_tizen.h
@@ -77,21 +77,29 @@ FlutterDesktopGetPluginRegistrar(FlutterDesktopEngineRef engine,
 FLUTTER_EXPORT FlutterDesktopMessengerRef
 FlutterDesktopEngineGetMessenger(FlutterDesktopEngineRef engine);
 
+// Posts a locale change notification to the engine instance.
 FLUTTER_EXPORT void FlutterDesktopNotifyLocaleChange(
     FlutterDesktopEngineRef engine);
 
+// Posts a low memory notification to the engine instance.
 FLUTTER_EXPORT void FlutterDesktopNotifyLowMemoryWarning(
     FlutterDesktopEngineRef engine);
 
+// Notifies the engine that the app is in an inactive state and not receiving
+// user input.
 FLUTTER_EXPORT void FlutterDesktopNotifyAppIsInactive(
     FlutterDesktopEngineRef engine);
 
+// Notifies the engine that the app is visible and responding to user input.
 FLUTTER_EXPORT void FlutterDesktopNotifyAppIsResumed(
     FlutterDesktopEngineRef engine);
 
+// Notifies the engine that the app is not currently visible to the user, not
+// responding to user input, and running in the background.
 FLUTTER_EXPORT void FlutterDesktopNotifyAppIsPaused(
     FlutterDesktopEngineRef engine);
 
+// Notifies the engine that the engine is detached from any host views.
 FLUTTER_EXPORT void FlutterDesktopNotifyAppIsDetached(
     FlutterDesktopEngineRef engine);
 

--- a/shell/platform/tizen/public/flutter_tizen.h
+++ b/shell/platform/tizen/public/flutter_tizen.h
@@ -21,6 +21,21 @@ extern "C" {
 struct FlutterDesktopEngine;
 typedef struct FlutterDesktopEngine* FlutterDesktopEngineRef;
 
+// Properties for configuring the initial settings of a Flutter window.
+typedef struct {
+  // Whether the app is headed or headless. Other properties are ignored if
+  // this value is set to false.
+  bool headed;
+  // The x-coordinate of the top left corner of the window.
+  int32_t x;
+  // The y-coordinate of the top left corner of the window.
+  int32_t y;
+  // The width of the window, or the maximum width if the value is zero.
+  int32_t width;
+  // The height of the window, or the maximum height if the value is zero.
+  int32_t height;
+} FlutterDesktopWindowProperties;
+
 // Properties for configuring a Flutter engine instance.
 typedef struct {
   // The path to the flutter_assets folder for the application to be run.
@@ -41,9 +56,9 @@ typedef struct {
 // Runs an instance of a Flutter engine with the given properties.
 //
 // If |headed| is false, the engine is run in headless mode.
-FLUTTER_EXPORT FlutterDesktopEngineRef
-FlutterDesktopRunEngine(const FlutterDesktopEngineProperties& engine_properties,
-                        bool headed);
+FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopRunEngine(
+    const FlutterDesktopWindowProperties& window_properties,
+    const FlutterDesktopEngineProperties& engine_properties);
 
 // Shuts down the given engine instance.
 //

--- a/shell/platform/tizen/tizen_renderer.cc
+++ b/shell/platform/tizen/tizen_renderer.cc
@@ -6,8 +6,8 @@
 
 namespace flutter {
 
-TizenRenderer::TizenRenderer(TizenRenderer::Delegate& delegate)
-    : delegate_(delegate) {}
+TizenRenderer::TizenRenderer(WindowGeometry geometry, Delegate& delegate)
+    : initial_geometry_(geometry), delegate_(delegate) {}
 
 TizenRenderer::~TizenRenderer() = default;
 

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -12,7 +12,7 @@ namespace flutter {
 
 class TizenRenderer {
  public:
-  struct TizenWindowGeometry {
+  struct WindowGeometry {
     int32_t x{0}, y{0}, w{0}, h{0};
   };
 
@@ -32,7 +32,7 @@ class TizenRenderer {
   virtual uint32_t OnGetFBO() = 0;
   virtual void* OnProcResolver(const char* name) = 0;
 
-  virtual TizenWindowGeometry GetGeometry() = 0;
+  virtual WindowGeometry GetCurrentGeometry() = 0;
   virtual int32_t GetDpi() = 0;
   virtual uintptr_t GetWindowId() = 0;
 
@@ -45,12 +45,13 @@ class TizenRenderer {
   virtual void SetPreferredOrientations(const std::vector<int>& rotations) = 0;
 
  protected:
-  explicit TizenRenderer(TizenRenderer::Delegate& delegate);
+  explicit TizenRenderer(WindowGeometry geometry, Delegate& delegate);
+
+  WindowGeometry initial_geometry_;
+  Delegate& delegate_;
 
   bool is_valid_ = false;
-
-  bool received_rotation_{false};
-  TizenRenderer::Delegate& delegate_;
+  bool received_rotation_ = false;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -15,7 +15,7 @@ namespace flutter {
 
 class TizenRendererEcoreWl2 : public TizenRenderer {
  public:
-  explicit TizenRendererEcoreWl2(TizenRenderer::Delegate& delegate);
+  explicit TizenRendererEcoreWl2(WindowGeometry geometry, Delegate& delegate);
   virtual ~TizenRendererEcoreWl2();
 
   bool OnMakeCurrent() override;
@@ -25,7 +25,7 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   uint32_t OnGetFBO() override;
   void* OnProcResolver(const char* name) override;
 
-  TizenWindowGeometry GetGeometry() override;
+  WindowGeometry GetCurrentGeometry() override;
   int32_t GetDpi() override;
   uintptr_t GetWindowId() override;
 
@@ -42,7 +42,7 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   void Show();
   void DestroyRenderer();
 
-  bool SetupDisplay(int32_t& width, int32_t& height);
+  bool SetupDisplay(int32_t* width, int32_t* height);
   bool SetupEcoreWlWindow(int32_t width, int32_t height);
   bool SetupEglWindow(int32_t width, int32_t height);
   EGLDisplay GetEGLDisplay();

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -6,8 +6,6 @@
 
 #ifdef __X64_SHELL__
 #include "tizen_evas_gl_helper.h"
-int gApp_width = 800;
-int gApp_height = 600;
 #else
 #include <Evas_GL_GLES3_Helpers.h>
 #endif
@@ -667,10 +665,6 @@ Evas_Object* TizenRendererEvasGL::SetupEvasWindow(int32_t* width,
   int32_t x = initial_geometry_.x;
   int32_t y = initial_geometry_.y;
 
-#ifdef __X64_SHELL__
-  width = gApp_width;
-  height = gApp_height;
-#endif
   elm_win_alpha_set(evas_window_, EINA_FALSE);
   evas_object_move(evas_window_, x, y);
   evas_object_resize(evas_window_, *width, *height);

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -18,8 +18,9 @@ EVAS_GL_GLOBAL_GLES3_DEFINE();
 
 namespace flutter {
 
-TizenRendererEvasGL::TizenRendererEvasGL(TizenRenderer::Delegate& delegate)
-    : TizenRenderer(delegate) {
+TizenRendererEvasGL::TizenRendererEvasGL(WindowGeometry geometry,
+                                         Delegate& delegate)
+    : TizenRenderer(geometry, delegate) {
   InitializeRenderer();
 
   // Clear once to remove noise.
@@ -549,8 +550,8 @@ void* TizenRendererEvasGL::OnProcResolver(const char* name) {
   return nullptr;
 }
 
-TizenRenderer::TizenWindowGeometry TizenRendererEvasGL::GetGeometry() {
-  TizenWindowGeometry result;
+TizenRenderer::WindowGeometry TizenRendererEvasGL::GetCurrentGeometry() {
+  WindowGeometry result;
   evas_object_geometry_get(evas_window_, &result.x, &result.y, &result.w,
                            &result.h);
   return result;
@@ -595,9 +596,10 @@ void TizenRendererEvasGL::DestroyRenderer() {
 
 bool TizenRendererEvasGL::SetupEvasGL() {
   int32_t width, height;
-  evas_gl_ = evas_gl_new(evas_object_evas_get(SetupEvasWindow(width, height)));
+  evas_gl_ =
+      evas_gl_new(evas_object_evas_get(SetupEvasWindow(&width, &height)));
   if (!evas_gl_) {
-    FT_LOGE("SetupEvasWindow fail");
+    FT_LOGE("Could not set up an Evas window object.");
     return false;
   }
 
@@ -640,27 +642,38 @@ bool TizenRendererEvasGL::SetupEvasGL() {
   return true;
 }
 
-Evas_Object* TizenRendererEvasGL::SetupEvasWindow(int32_t& width,
-                                                  int32_t& height) {
+Evas_Object* TizenRendererEvasGL::SetupEvasWindow(int32_t* width,
+                                                  int32_t* height) {
   elm_config_accel_preference_set("hw:opengl");
 
   evas_window_ = elm_win_add(NULL, NULL, ELM_WIN_BASIC);
-  auto* ecore_evas =
-      ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_));
-  int32_t x, y;
-  ecore_evas_screen_geometry_get(ecore_evas, &x, &y, &width, &height);
-  if (width == 0 || height == 0) {
-    FT_LOGE("Invalid screen size: %d x %d", width, height);
+  if (!evas_window_) {
     return nullptr;
   }
+  auto* ecore_evas =
+      ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_));
+
+  ecore_evas_screen_geometry_get(ecore_evas, nullptr, nullptr, width, height);
+  if (*width == 0 || *height == 0) {
+    FT_LOGE("Invalid screen size: %d x %d", *width, *height);
+    return nullptr;
+  }
+  if (initial_geometry_.w > 0) {
+    *width = initial_geometry_.w;
+  }
+  if (initial_geometry_.h > 0) {
+    *height = initial_geometry_.h;
+  }
+  int32_t x = initial_geometry_.x;
+  int32_t y = initial_geometry_.y;
 
 #ifdef __X64_SHELL__
   width = gApp_width;
   height = gApp_height;
 #endif
   elm_win_alpha_set(evas_window_, EINA_FALSE);
-  evas_object_move(evas_window_, 0, 0);
-  evas_object_resize(evas_window_, width, height);
+  evas_object_move(evas_window_, x, y);
+  evas_object_resize(evas_window_, *width, *height);
   evas_object_raise(evas_window_);
 
   Evas_Object* bg = elm_bg_add(evas_window_);
@@ -671,9 +684,9 @@ Evas_Object* TizenRendererEvasGL::SetupEvasWindow(int32_t& width,
 
   graphics_adapter_ =
       evas_object_image_filled_add(evas_object_evas_get(evas_window_));
-  evas_object_resize(graphics_adapter_, width, height);
-  evas_object_move(graphics_adapter_, 0, 0);
-  evas_object_image_size_set(graphics_adapter_, width, height);
+  evas_object_resize(graphics_adapter_, *width, *height);
+  evas_object_move(graphics_adapter_, x, y);
+  evas_object_image_size_set(graphics_adapter_, *width, *height);
   evas_object_image_alpha_set(graphics_adapter_, EINA_TRUE);
   elm_win_resize_object_add(evas_window_, graphics_adapter_);
 

--- a/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -16,7 +16,7 @@ namespace flutter {
 
 class TizenRendererEvasGL : public TizenRenderer {
  public:
-  explicit TizenRendererEvasGL(TizenRenderer::Delegate& delegate);
+  explicit TizenRendererEvasGL(WindowGeometry geometry, Delegate& delegate);
   virtual ~TizenRendererEvasGL();
 
   bool OnMakeCurrent() override;
@@ -26,7 +26,7 @@ class TizenRendererEvasGL : public TizenRenderer {
   uint32_t OnGetFBO() override;
   void* OnProcResolver(const char* name) override;
 
-  TizenWindowGeometry GetGeometry() override;
+  WindowGeometry GetCurrentGeometry() override;
   int32_t GetDpi() override;
   uintptr_t GetWindowId() override;
 
@@ -48,7 +48,7 @@ class TizenRendererEvasGL : public TizenRenderer {
   void DestroyRenderer();
 
   bool SetupEvasGL();
-  Evas_Object* SetupEvasWindow(int32_t& width, int32_t& height);
+  Evas_Object* SetupEvasWindow(int32_t* width, int32_t* height);
   void DestroyEvasGL();
   void DestroyEvasWindow();
 

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -39,9 +39,9 @@ void TouchEventHandler::SendFlutterPointerEvent(FlutterPointerPhase phase,
                                                 size_t timestamp,
                                                 int device_id = 0) {
   // Correct errors caused by window rotation.
-  auto window_geometry = engine_->renderer->GetGeometry();
-  double width = window_geometry.w;
-  double height = window_geometry.h;
+  auto geometry = engine_->renderer->GetCurrentGeometry();
+  double width = geometry.w;
+  double height = geometry.h;
   double new_x = x, new_y = y;
 
   if (rotation == 90) {


### PR DESCRIPTION
- Add `FlutterProjectBundle` and refactor similarly to the Windows embedder.
- Allow relative paths as values of `assets_path`, `icu_data_path`, and `aot_library_path`.
- Add `FlutterDesktopWindowProperties` to flutter_tizen.h. This might be used in the future.

Caveats:
- If `width` or `height` in `FlutterDesktopWindowProperties` is set to non-zero, it is assumed that the screen is not resizable. Attempting to resize or rotate the screen is an undefined behavior.

This depends on #131 and should be rebased after #131 is merged.