### PR TITLE
Revert "Temporarily disable weak symbols in third_party/boringssl (#120)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,6 @@ jobs:
       gclient sync -f -D
       sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' build/config/compiler/BUILD.gn
       sed -i 's/"-Wno-psabi",//g' build/config/compiler/BUILD.gn
-      sed -i 's/defined(__ELF__) && defined(__GNUC__)/0/g' third_party/boringssl/src/crypto/mem.c
     displayName: Run gclient sync
     workingDirectory: $(Pipeline.Workspace)/src
     failOnStderr: true


### PR DESCRIPTION
This partially reverts commit a67e79d07db0563bc5ac2f8e76456c221c08e984.

Closes https://github.com/flutter-tizen/flutter-tizen/issues/140.