### PR TITLE
Check non-public API usage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
   pool:
     name: Default
     demands: agent.os -equals Linux
-  timeoutInMinutes: 60
+  timeoutInMinutes: 80
   cancelTimeoutInMinutes: 1
   steps:
   - checkout: self
@@ -80,6 +80,13 @@ jobs:
     displayName: Build
     workingDirectory: $(Pipeline.Workspace)/src
     failOnStderr: true
+  - bash: |
+      ../check_symbols.py out/linux_$(mode)_$(arch)/libflutter_engine.so
+      ../check_symbols.py out/linux_$(mode)_$(arch)/libflutter_tizen_wearable.so
+    displayName: Verify symbol references
+    workingDirectory: $(Pipeline.Workspace)/src
+    failOnStderr: true
+    condition: eq(variables['System.JobName'], 'tizen-arm-release')
   - bash: |
       OUTDIR=$(Build.StagingDirectory)
       cp out/linux_$(mode)_$(arch)/libflutter_*.so $OUTDIR


### PR DESCRIPTION
Check if any undocumented API is used by the engine or the embedder
binary (wearable only).

Contributes to https://github.com/flutter-tizen/engine/issues/89.

Related to https://github.com/flutter-tizen/flutter-tizen/issues/21.

The content of the `check_symbols.py` file pre-installed to the CI server is as follows:

```python
#!/usr/bin/env python3
import os
import subprocess
import sys

class Symbol:
  def __init__(self, line):
    self.text = line
    self.address = line[:8].strip()
    self.type = line[9] # See `man nm` for details.
    self.name = line[11:].strip()

  def __str__(self):
    return self.text

def main():
  if len(sys.argv) < 2:
    print('Insufficient arguments.')
    exit(1)
  sopath = sys.argv[1]

  allowlist = []
  scriptdir = os.path.dirname(__file__)
  with open(f'{scriptdir}/4.0.0_native_whitelist_wearable_v12.txt', 'r') as f:
    allowlist = [line.rstrip() for line in f]
  if not allowlist:
    print('The allowlist is empty.')
    exit(1)

  if not os.path.exists(sopath):
    print(f'File not found: {sopath}')
    exit(1)

  symbols_raw = subprocess.run(
    f'nm -gDC {sopath}', shell=True, encoding='utf-8', stdout=subprocess.PIPE).stdout
  symbols = []
  for line in symbols_raw.splitlines():
    symbols.append(Symbol(line))

  exit_code = 0
  for sym in symbols:
    if sym.address:
      continue
    if sym.name in allowlist or sym.name.startswith('FlutterEngine'):
      continue
    print(f'{sym.name}[{os.path.basename(sopath)}]')
    exit_code = 1
  
  exit(exit_code)

if __name__ == '__main__':
  main()
```