### PR TITLE
Do not call std::locale::global() on startup

### DIFF
--- a/shell/platform/tizen/channels/settings_channel_linux.cc
+++ b/shell/platform/tizen/channels/settings_channel_linux.cc
@@ -4,13 +4,9 @@
 
 #include "settings_channel.h"
 
-#include <locale>
-
 namespace flutter {
 
-void SettingsChannel::Init() {
-  std::locale::global(std::locale(""));
-}
+void SettingsChannel::Init() {}
 
 void SettingsChannel::Dispose() {}
 


### PR DESCRIPTION
Calling `std::locale::global(std::locale(""))` results in a program crash when the locale is explicitly provided.

e.g.
```sh
$ LANG=ja_JP ./flutter_tizen_shell --width=1400 --height=800
Launching a Flutter application...
...
Aborted (core dumped)
```