### PR TITLE
Automated unit testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ jobs:
   - checkout: self
     path: src/flutter
   - bash: |
-      gclient sync -f -D
+      git checkout -- build/config/compiler/BUILD.gn
       flutter/tools/gn \
       --no-goma \
       --runtime-mode debug \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,10 +118,12 @@ jobs:
       --enable-fontconfig \
       --build-tizen-shell
       ninja -C out/host_debug
-      out/host_debug/flutter_tizen_unittests
-    displayName: Build and run unittests
+    displayName: Build unittests
     workingDirectory: $(Pipeline.Workspace)/src
     failOnStderr: true
+  - bash: out/host_debug/flutter_tizen_unittests
+    displayName: Run
+    workingDirectory: $(Pipeline.Workspace)/src
 - job: release
   dependsOn: test
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,8 +100,30 @@ jobs:
     failOnStderr: true
   - publish: $(Build.StagingDirectory)
     artifact: $(System.JobName)
-- job: release
+- job: test
   dependsOn: build
+  pool:
+    name: Default
+    demands: agent.os -equals Linux
+  timeoutInMinutes: 20
+  cancelTimeoutInMinutes: 1
+  steps:
+  - checkout: self
+    path: src/flutter
+  - bash: |
+      gclient sync -f -D
+      flutter/tools/gn \
+      --no-goma \
+      --runtime-mode debug \
+      --enable-fontconfig \
+      --build-tizen-shell
+      ninja -C out/host_debug
+      out/host_debug/flutter_tizen_unittests
+    displayName: Build and run unittests
+    workingDirectory: $(Pipeline.Workspace)/src
+    failOnStderr: true
+- job: release
+  dependsOn: test
   pool:
     name: Default
     demands: agent.os -equals Linux

--- a/shell/platform/tizen/flutter_tizen_engine_unittest.cc
+++ b/shell/platform/tizen/flutter_tizen_engine_unittest.cc
@@ -79,7 +79,8 @@ TEST_F(FlutterTizenEngineTest, GetTextureRegistrar) {
   EXPECT_TRUE(engine_->GetTextureRegistrar() == nullptr);
 }
 
-TEST_F(FlutterTizenEngineTestHeaded, GetTextureRegistrar) {
+// Disabled for headless testing.
+TEST_F(FlutterTizenEngineTestHeaded, DISABLED_GetTextureRegistrar) {
   EXPECT_TRUE(engine_->RunEngine(nullptr));
   EXPECT_TRUE(engine_->GetTextureRegistrar() != nullptr);
 }

--- a/shell/platform/tizen/flutter_tizen_engine_unittest.cc
+++ b/shell/platform/tizen/flutter_tizen_engine_unittest.cc
@@ -40,6 +40,14 @@ class FlutterTizenEngineTest : public ::testing::Test {
   FlutterTizenEngine* engine_;
 };
 
+class FlutterTizenEngineTestHeaded : public FlutterTizenEngineTest {
+ protected:
+  void SetUp() {
+    FlutterTizenEngineTest::SetUp();
+    engine_->InitializeRenderer(0, 0, 800, 600, false, true);
+  }
+};
+
 TEST_F(FlutterTizenEngineTest, Run) {
   EXPECT_TRUE(engine_ != nullptr);
   EXPECT_TRUE(engine_->RunEngine(nullptr));
@@ -69,6 +77,11 @@ TEST_F(FlutterTizenEngineTest, GetPluginRegistrar) {
 TEST_F(FlutterTizenEngineTest, GetTextureRegistrar) {
   EXPECT_TRUE(engine_->RunEngine(nullptr));
   EXPECT_TRUE(engine_->GetTextureRegistrar() == nullptr);
+}
+
+TEST_F(FlutterTizenEngineTestHeaded, GetTextureRegistrar) {
+  EXPECT_TRUE(engine_->RunEngine(nullptr));
+  EXPECT_TRUE(engine_->GetTextureRegistrar() != nullptr);
 }
 
 TEST_F(FlutterTizenEngineTest, RunDoesExpectedInitialization) {

--- a/shell/platform/tizen/flutter_tizen_engine_unittest.cc
+++ b/shell/platform/tizen/flutter_tizen_engine_unittest.cc
@@ -40,14 +40,6 @@ class FlutterTizenEngineTest : public ::testing::Test {
   FlutterTizenEngine* engine_;
 };
 
-class FlutterTizenEngineTestHeaded : public FlutterTizenEngineTest {
- protected:
-  void SetUp() {
-    FlutterTizenEngineTest::SetUp();
-    engine_->InitializeRenderer(0, 0, 800, 600, false, true);
-  }
-};
-
 TEST_F(FlutterTizenEngineTest, Run) {
   EXPECT_TRUE(engine_ != nullptr);
   EXPECT_TRUE(engine_->RunEngine(nullptr));
@@ -77,11 +69,6 @@ TEST_F(FlutterTizenEngineTest, GetPluginRegistrar) {
 TEST_F(FlutterTizenEngineTest, GetTextureRegistrar) {
   EXPECT_TRUE(engine_->RunEngine(nullptr));
   EXPECT_TRUE(engine_->GetTextureRegistrar() == nullptr);
-}
-
-TEST_F(FlutterTizenEngineTestHeaded, GetTextureRegistrar) {
-  EXPECT_TRUE(engine_->RunEngine(nullptr));
-  EXPECT_TRUE(engine_->GetTextureRegistrar() != nullptr);
 }
 
 TEST_F(FlutterTizenEngineTest, RunDoesExpectedInitialization) {


### PR DESCRIPTION
- Remove headed engine tests, because they cannot be run without a display attached.
- Add the `test` job to the CI pipelines.
