### PR TITLE
Organize build steps in azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,21 +11,38 @@ jobs:
 - job: format
   pool:
     name: Default
+    demands: Agent.os -equals Linux
+  steps:
+  - checkout: self
+    path: src/flutter
+  - bash: ci/format.sh
+    displayName: Verify formatting
+- job: test
+  dependsOn: format
+  pool:
+    name: Default
     demands: agent.os -equals Linux
+  timeoutInMinutes: 20
+  cancelTimeoutInMinutes: 1
   steps:
   - checkout: self
     path: src/flutter
   - bash: |
       gclient sync -f -D
-      sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' build/config/compiler/BUILD.gn
-      sed -i 's/"-Wno-psabi",//g' build/config/compiler/BUILD.gn
-    displayName: Run gclient sync
+      flutter/tools/gn \
+      --no-goma \
+      --runtime-mode debug \
+      --enable-fontconfig \
+      --build-tizen-shell
+      ninja -C out/host_debug
+    displayName: Host build
     workingDirectory: $(Pipeline.Workspace)/src
     failOnStderr: true
-  - bash: ci/format.sh
-    displayName: Verify formatting
+  - bash: out/host_debug/flutter_tizen_unittests
+    displayName: Run tests
+    workingDirectory: $(Pipeline.Workspace)/src
 - job: build
-  dependsOn: format
+  dependsOn: test
   strategy:
     matrix:
       tizen-arm-release:
@@ -65,6 +82,13 @@ jobs:
   - checkout: self
     path: src/flutter
   - bash: |
+      gclient sync -f -D
+      sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' build/config/compiler/BUILD.gn
+      sed -i 's/"-Wno-psabi",//g' build/config/compiler/BUILD.gn
+    displayName: Disable build flags
+    workingDirectory: $(Pipeline.Workspace)/src
+    failOnStderr: true
+  - bash: |
       flutter/tools/gn \
         --target-os linux \
         --linux-cpu $(arch) \
@@ -100,40 +124,14 @@ jobs:
     failOnStderr: true
   - publish: $(Build.StagingDirectory)
     artifact: $(System.JobName)
-- job: test
-  dependsOn: build
-  pool:
-    name: Default
-    demands: agent.os -equals Linux
-  timeoutInMinutes: 20
-  cancelTimeoutInMinutes: 1
-  steps:
-  - checkout: self
-    path: src/flutter
-  - bash: |
-      git checkout -- build/config/compiler/BUILD.gn
-      flutter/tools/gn \
-      --no-goma \
-      --runtime-mode debug \
-      --enable-fontconfig \
-      --build-tizen-shell
-      ninja -C out/host_debug
-    displayName: Build unittests
-    workingDirectory: $(Pipeline.Workspace)/src
-    failOnStderr: true
-  - bash: out/host_debug/flutter_tizen_unittests
-    displayName: Run
-    workingDirectory: $(Pipeline.Workspace)/src
 - job: release
-  dependsOn: test
+  dependsOn: build
   pool:
     name: Default
     demands: agent.os -equals Linux
   workspace:
     clean: outputs
   steps:
-  - checkout: self
-    path: src/flutter
   - download: current
   - bash: |
       mv $(Pipeline.Workspace)/tizen-arm-release/tizen-common .


### PR DESCRIPTION
Build the x64 shell first and then build embedders for targets. This makes incremental builds much faster (37 min to 13 min) although I don't exactly know why.