### PR TITLE
Remove TextInputChannel's dependency on FlutterTizenEngine

### DIFF
--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -49,13 +49,14 @@ bool IsASCIIPrintableKey(char c) {
 
 }  // namespace
 
-TextInputChannel::TextInputChannel(BinaryMessenger* messenger,
-                                   FlutterTizenEngine* engine)
+TextInputChannel::TextInputChannel(
+    BinaryMessenger* messenger,
+    std::unique_ptr<TizenInputMethodContext> input_method_context)
     : channel_(std::make_unique<MethodChannel<rapidjson::Document>>(
           messenger,
           kChannelName,
           &JsonMethodCodec::GetInstance())),
-      input_method_context_(std::make_unique<TizenInputMethodContext>(engine)) {
+      input_method_context_(std::move(input_method_context)) {
   channel_->SetMethodCallHandler(
       [this](const MethodCall<rapidjson::Document>& call,
              std::unique_ptr<MethodResult<rapidjson::Document>> result) {

--- a/shell/platform/tizen/channels/text_input_channel.h
+++ b/shell/platform/tizen/channels/text_input_channel.h
@@ -21,8 +21,6 @@
 
 namespace flutter {
 
-class FlutterTizenEngine;
-
 enum class EditStatus { kNone, kPreeditStart, kPreeditEnd, kCommit };
 
 struct TextEditingContext {
@@ -36,8 +34,9 @@ struct TextEditingContext {
 
 class TextInputChannel {
  public:
-  explicit TextInputChannel(BinaryMessenger* messenger,
-                            FlutterTizenEngine* engine);
+  explicit TextInputChannel(
+      BinaryMessenger* messenger,
+      std::unique_ptr<TizenInputMethodContext> input_method_context);
   virtual ~TextInputChannel();
 
   bool IsSoftwareKeyboardShowing() { return is_software_keyboard_showing_; }

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -11,6 +11,7 @@
 
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/system_utils.h"
+#include "flutter/shell/platform/tizen/tizen_input_method_context.h"
 
 namespace flutter {
 
@@ -257,7 +258,8 @@ bool FlutterTizenEngine::RunEngine(const char* entrypoint) {
     navigation_channel = std::make_unique<NavigationChannel>(
         internal_plugin_registrar_->messenger());
     text_input_channel = std::make_unique<TextInputChannel>(
-        internal_plugin_registrar_->messenger(), this);
+        internal_plugin_registrar_->messenger(),
+        std::make_unique<TizenInputMethodContext>(this));
     platform_view_channel = std::make_unique<PlatformViewChannel>(
         internal_plugin_registrar_->messenger());
     key_event_handler_ = std::make_unique<KeyEventHandler>(this);


### PR DESCRIPTION
This looses coupling between the two classes.