### PR TITLE
Check if the renderer's window is correct before processing the ecore…

### DIFF
--- a/shell/platform/tizen/key_event_handler.cc
+++ b/shell/platform/tizen/key_event_handler.cc
@@ -40,6 +40,10 @@ Eina_Bool KeyEventHandler::OnKey(void* data, int type, void* event) {
   auto* engine = self->engine_;
   auto is_down = type == ECORE_EVENT_KEY_DOWN;
 
+  if (self->engine_->renderer()->GetWindowId() != key->window) {
+    return ECORE_CALLBACK_PASS_ON;
+  }
+
   if (is_down) {
     FT_LOG(Info) << "Key pressed: " << key->key << "(" << key->keycode << ")";
   }

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -74,9 +74,9 @@ Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
   auto* self = reinterpret_cast<TouchEventHandler*>(data);
 
   if (type == ECORE_EVENT_MOUSE_BUTTON_DOWN) {
-    self->pointer_state_ = true;
     auto* button_event = reinterpret_cast<Ecore_Event_Mouse_Button*>(event);
     if (self->engine_->renderer()->GetWindowId() == button_event->window) {
+      self->pointer_state_ = true;
       self->SendFlutterPointerEvent(kDown, button_event->x, button_event->y, 0,
                                     0, button_event->timestamp,
                                     button_event->multi.device);
@@ -84,9 +84,9 @@ Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
     }
 
   } else if (type == ECORE_EVENT_MOUSE_BUTTON_UP) {
-    self->pointer_state_ = false;
     auto* button_event = reinterpret_cast<Ecore_Event_Mouse_Button*>(event);
     if (self->engine_->renderer()->GetWindowId() == button_event->window) {
+      self->pointer_state_ = false;
       self->SendFlutterPointerEvent(kUp, button_event->x, button_event->y, 0, 0,
                                     button_event->timestamp,
                                     button_event->multi.device);

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -21,6 +21,7 @@ TouchEventHandler::TouchEventHandler(FlutterTizenEngine* engine)
       ecore_event_handler_add(ECORE_EVENT_MOUSE_WHEEL, OnTouch, this));
   touch_event_handlers_.push_back(
       ecore_event_handler_add(ECORE_EVENT_MOUSE_MOVE, OnTouch, this));
+  window_id_ = engine_->renderer()->GetWindowId();
 }
 
 TouchEventHandler::~TouchEventHandler() {
@@ -75,7 +76,7 @@ Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
 
   if (type == ECORE_EVENT_MOUSE_BUTTON_DOWN) {
     auto* button_event = reinterpret_cast<Ecore_Event_Mouse_Button*>(event);
-    if (self->engine_->renderer()->GetWindowId() == button_event->window) {
+    if (self->window_id_ == button_event->window) {
       self->pointer_state_ = true;
       self->SendFlutterPointerEvent(kDown, button_event->x, button_event->y, 0,
                                     0, button_event->timestamp,
@@ -85,7 +86,7 @@ Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
 
   } else if (type == ECORE_EVENT_MOUSE_BUTTON_UP) {
     auto* button_event = reinterpret_cast<Ecore_Event_Mouse_Button*>(event);
-    if (self->engine_->renderer()->GetWindowId() == button_event->window) {
+    if (self->window_id_ == button_event->window) {
       self->pointer_state_ = false;
       self->SendFlutterPointerEvent(kUp, button_event->x, button_event->y, 0, 0,
                                     button_event->timestamp,
@@ -94,7 +95,7 @@ Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
     }
   } else if (type == ECORE_EVENT_MOUSE_MOVE) {
     auto* move_event = reinterpret_cast<Ecore_Event_Mouse_Move*>(event);
-    if (self->engine_->renderer()->GetWindowId() == move_event->window) {
+    if (self->window_id_ == move_event->window) {
       if (self->pointer_state_) {
         self->SendFlutterPointerEvent(kMove, move_event->x, move_event->y, 0, 0,
                                       move_event->timestamp,
@@ -104,7 +105,7 @@ Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
     }
   } else if (type == ECORE_EVENT_MOUSE_WHEEL) {
     auto* wheel_event = reinterpret_cast<Ecore_Event_Mouse_Wheel*>(event);
-    if (self->engine_->renderer()->GetWindowId() == wheel_event->window) {
+    if (self->window_id_ == wheel_event->window) {
       double scroll_delta_x = 0.0, scroll_delta_y = 0.0;
       if (wheel_event->direction == kScrollDirectionVertical) {
         scroll_delta_y += wheel_event->z;

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -76,36 +76,45 @@ Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
   if (type == ECORE_EVENT_MOUSE_BUTTON_DOWN) {
     self->pointer_state_ = true;
     auto* button_event = reinterpret_cast<Ecore_Event_Mouse_Button*>(event);
-    self->SendFlutterPointerEvent(kDown, button_event->x, button_event->y, 0, 0,
-                                  button_event->timestamp,
-                                  button_event->multi.device);
+    if (self->engine_->renderer()->GetWindowId() == button_event->window) {
+      self->SendFlutterPointerEvent(kDown, button_event->x, button_event->y, 0,
+                                    0, button_event->timestamp,
+                                    button_event->multi.device);
+    }
+
   } else if (type == ECORE_EVENT_MOUSE_BUTTON_UP) {
     self->pointer_state_ = false;
     auto* button_event = reinterpret_cast<Ecore_Event_Mouse_Button*>(event);
-    self->SendFlutterPointerEvent(kUp, button_event->x, button_event->y, 0, 0,
-                                  button_event->timestamp,
-                                  button_event->multi.device);
+    if (self->engine_->renderer()->GetWindowId() == button_event->window) {
+      self->SendFlutterPointerEvent(kUp, button_event->x, button_event->y, 0, 0,
+                                    button_event->timestamp,
+                                    button_event->multi.device);
+    }
   } else if (type == ECORE_EVENT_MOUSE_MOVE) {
     if (self->pointer_state_) {
       auto* move_event = reinterpret_cast<Ecore_Event_Mouse_Move*>(event);
-      self->SendFlutterPointerEvent(kMove, move_event->x, move_event->y, 0, 0,
-                                    move_event->timestamp,
-                                    move_event->multi.device);
+      if (self->engine_->renderer()->GetWindowId() == move_event->window) {
+        self->SendFlutterPointerEvent(kMove, move_event->x, move_event->y, 0, 0,
+                                      move_event->timestamp,
+                                      move_event->multi.device);
+      }
     }
   } else if (type == ECORE_EVENT_MOUSE_WHEEL) {
     auto* wheel_event = reinterpret_cast<Ecore_Event_Mouse_Wheel*>(event);
-    double scroll_delta_x = 0.0, scroll_delta_y = 0.0;
-    if (wheel_event->direction == kScrollDirectionVertical) {
-      scroll_delta_y += wheel_event->z;
-    } else if (wheel_event->direction == kScrollDirectionHorizontal) {
-      scroll_delta_x += wheel_event->z;
+    if (self->engine_->renderer()->GetWindowId() == wheel_event->window) {
+      double scroll_delta_x = 0.0, scroll_delta_y = 0.0;
+      if (wheel_event->direction == kScrollDirectionVertical) {
+        scroll_delta_y += wheel_event->z;
+      } else if (wheel_event->direction == kScrollDirectionHorizontal) {
+        scroll_delta_x += wheel_event->z;
+      }
+      const int kScrollOffsetMultiplier = 20;
+      scroll_delta_x *= kScrollOffsetMultiplier;
+      scroll_delta_y *= kScrollOffsetMultiplier;
+      self->SendFlutterPointerEvent(
+          self->pointer_state_ ? kMove : kHover, wheel_event->x, wheel_event->y,
+          scroll_delta_x, scroll_delta_y, wheel_event->timestamp);
     }
-    const int kScrollOffsetMultiplier = 20;
-    scroll_delta_x *= kScrollOffsetMultiplier;
-    scroll_delta_y *= kScrollOffsetMultiplier;
-    self->SendFlutterPointerEvent(
-        self->pointer_state_ ? kMove : kHover, wheel_event->x, wheel_event->y,
-        scroll_delta_x, scroll_delta_y, wheel_event->timestamp);
   }
   return ECORE_CALLBACK_PASS_ON;
 }

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -93,9 +93,9 @@ Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
       return ECORE_CALLBACK_DONE;
     }
   } else if (type == ECORE_EVENT_MOUSE_MOVE) {
-    if (self->pointer_state_) {
-      auto* move_event = reinterpret_cast<Ecore_Event_Mouse_Move*>(event);
-      if (self->engine_->renderer()->GetWindowId() == move_event->window) {
+    auto* move_event = reinterpret_cast<Ecore_Event_Mouse_Move*>(event);
+    if (self->engine_->renderer()->GetWindowId() == move_event->window) {
+      if (self->pointer_state_) {
         self->SendFlutterPointerEvent(kMove, move_event->x, move_event->y, 0, 0,
                                       move_event->timestamp,
                                       move_event->multi.device);

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -80,6 +80,7 @@ Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
       self->SendFlutterPointerEvent(kDown, button_event->x, button_event->y, 0,
                                     0, button_event->timestamp,
                                     button_event->multi.device);
+      return ECORE_CALLBACK_DONE;
     }
 
   } else if (type == ECORE_EVENT_MOUSE_BUTTON_UP) {
@@ -89,6 +90,7 @@ Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
       self->SendFlutterPointerEvent(kUp, button_event->x, button_event->y, 0, 0,
                                     button_event->timestamp,
                                     button_event->multi.device);
+      return ECORE_CALLBACK_DONE;
     }
   } else if (type == ECORE_EVENT_MOUSE_MOVE) {
     if (self->pointer_state_) {
@@ -97,6 +99,7 @@ Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
         self->SendFlutterPointerEvent(kMove, move_event->x, move_event->y, 0, 0,
                                       move_event->timestamp,
                                       move_event->multi.device);
+        return ECORE_CALLBACK_DONE;
       }
     }
   } else if (type == ECORE_EVENT_MOUSE_WHEEL) {
@@ -114,6 +117,7 @@ Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
       self->SendFlutterPointerEvent(
           self->pointer_state_ ? kMove : kHover, wheel_event->x, wheel_event->y,
           scroll_delta_x, scroll_delta_y, wheel_event->timestamp);
+      return ECORE_CALLBACK_DONE;
     }
   }
   return ECORE_CALLBACK_PASS_ON;

--- a/shell/platform/tizen/touch_event_handler.h
+++ b/shell/platform/tizen/touch_event_handler.h
@@ -29,6 +29,7 @@ class TouchEventHandler {
   FlutterTizenEngine* engine_;
   std::vector<Ecore_Event_Handler*> touch_event_handlers_;
   bool pointer_state_ = false;
+  uintptr_t window_id_ = 0;
 
   void SendFlutterPointerEvent(FlutterPointerPhase phase,
                                double x,


### PR DESCRIPTION
When there are multiple windows, it is necessary to check whether the window is correct before processing ecore event.
because ecore event handler is called as many times as the it is registered.