### PR TITLE
Use `EXT_image_dma_buf_import` when making EGLImage with tbm_surface

### DIFF
--- a/shell/platform/tizen/external_texture.h
+++ b/shell/platform/tizen/external_texture.h
@@ -20,7 +20,6 @@
 
 namespace flutter {
 
-// TODO
 typedef enum {
   ExternalTextureGLExtention_None,
   ExternalTextureGLExtention_EGL_TIZEN_image_native_surface,

--- a/shell/platform/tizen/external_texture.h
+++ b/shell/platform/tizen/external_texture.h
@@ -21,14 +21,14 @@
 namespace flutter {
 
 typedef enum {
-  ExternalTextureGLExtention_None,
-  ExternalTextureGLExtention_EGL_TIZEN_image_native_surface,
-  ExternalTextureGLExtention_EGL_EXT_image_dma_buf_import
-} ExternalTextureGLExtention;
+  kExternalTextureExtensionTypeNone,
+  kExternalTextureExtensionTypeNativeSurface,
+  kExternalTextureExtensionTypeDmaBuffer
+} ExternalTextureExtensionType;
 
 struct ExternalTextureGLState {
   GLuint gl_texture;
-  ExternalTextureGLExtention gl_extention;
+  ExternalTextureExtensionType gl_extention;
 };
 
 static std::atomic_long next_texture_id = {1};
@@ -36,8 +36,8 @@ static std::atomic_long next_texture_id = {1};
 // An adaptation class of flutter engine and external texture interface.
 class ExternalTexture : public std::enable_shared_from_this<ExternalTexture> {
  public:
-  ExternalTexture(
-      ExternalTextureGLExtention gl_extention = ExternalTextureGLExtention_None)
+  ExternalTexture(ExternalTextureExtensionType gl_extention =
+                      kExternalTextureExtensionTypeNone)
       : state_(std::make_unique<ExternalTextureGLState>()),
         texture_id_(next_texture_id++) {
     state_->gl_extention = gl_extention;

--- a/shell/platform/tizen/external_texture.h
+++ b/shell/platform/tizen/external_texture.h
@@ -20,11 +20,7 @@
 
 namespace flutter {
 
-enum ExternalTextureExtensionType {
-  kExternalTextureExtensionTypeNone,
-  kExternalTextureExtensionTypeNativeSurface,
-  kExternalTextureExtensionTypeDmaBuffer
-};
+enum class ExternalTextureExtensionType { kNone, kNativeSurface, kDmaBuffer };
 
 struct ExternalTextureGLState {
   GLuint gl_texture;
@@ -37,7 +33,7 @@ static std::atomic_long next_texture_id = {1};
 class ExternalTexture : public std::enable_shared_from_this<ExternalTexture> {
  public:
   ExternalTexture(ExternalTextureExtensionType gl_extention =
-                      kExternalTextureExtensionTypeNone)
+                      ExternalTextureExtensionType::kNone)
       : state_(std::make_unique<ExternalTextureGLState>()),
         texture_id_(next_texture_id++) {
     state_->gl_extention = gl_extention;

--- a/shell/platform/tizen/external_texture.h
+++ b/shell/platform/tizen/external_texture.h
@@ -20,11 +20,11 @@
 
 namespace flutter {
 
-typedef enum {
+enum ExternalTextureExtensionType {
   kExternalTextureExtensionTypeNone,
   kExternalTextureExtensionTypeNativeSurface,
   kExternalTextureExtensionTypeDmaBuffer
-} ExternalTextureExtensionType;
+};
 
 struct ExternalTextureGLState {
   GLuint gl_texture;

--- a/shell/platform/tizen/external_texture.h
+++ b/shell/platform/tizen/external_texture.h
@@ -20,8 +20,16 @@
 
 namespace flutter {
 
+// TODO
+typedef enum {
+  ExternalTextureGLExtention_None,
+  ExternalTextureGLExtention_EGL_TIZEN_image_native_surface,
+  ExternalTextureGLExtention_EGL_EXT_image_dma_buf_import
+} ExternalTextureGLExtention;
+
 struct ExternalTextureGLState {
   GLuint gl_texture;
+  ExternalTextureGLExtention gl_extention;
 };
 
 static std::atomic_long next_texture_id = {1};
@@ -29,9 +37,12 @@ static std::atomic_long next_texture_id = {1};
 // An adaptation class of flutter engine and external texture interface.
 class ExternalTexture : public std::enable_shared_from_this<ExternalTexture> {
  public:
-  ExternalTexture()
+  ExternalTexture(
+      ExternalTextureGLExtention gl_extention = ExternalTextureGLExtention_None)
       : state_(std::make_unique<ExternalTextureGLState>()),
-        texture_id_(next_texture_id++) {}
+        texture_id_(next_texture_id++) {
+    state_->gl_extention = gl_extention;
+  }
   virtual ~ExternalTexture() = default;
 
   /**

--- a/shell/platform/tizen/external_texture_surface_gl.h
+++ b/shell/platform/tizen/external_texture_surface_gl.h
@@ -15,7 +15,7 @@ namespace flutter {
 class ExternalTextureSurfaceGL : public ExternalTexture {
  public:
   ExternalTextureSurfaceGL(
-      ExternalTextureGLExtention gl_extention,
+      ExternalTextureExtensionType gl_extention,
       FlutterDesktopGpuBufferTextureCallback texture_callback,
       FlutterDesktopGpuBufferDestructionCallback destruction_callback,
       void* user_data);

--- a/shell/platform/tizen/external_texture_surface_gl.h
+++ b/shell/platform/tizen/external_texture_surface_gl.h
@@ -15,6 +15,7 @@ namespace flutter {
 class ExternalTextureSurfaceGL : public ExternalTexture {
  public:
   ExternalTextureSurfaceGL(
+      ExternalTextureGLExtention gl_extention,
       FlutterDesktopGpuBufferTextureCallback texture_callback,
       FlutterDesktopGpuBufferDestructionCallback destruction_callback,
       void* user_data);

--- a/shell/platform/tizen/external_texture_surface_gl_linux.cc
+++ b/shell/platform/tizen/external_texture_surface_gl_linux.cc
@@ -12,10 +12,11 @@
 namespace flutter {
 
 ExternalTextureSurfaceGL::ExternalTextureSurfaceGL(
+    ExternalTextureGLExtention gl_extention,
     FlutterDesktopGpuBufferTextureCallback texture_callback,
     FlutterDesktopGpuBufferDestructionCallback destruction_callback,
     void* user_data)
-    : ExternalTexture(),
+    : ExternalTexture(gl_extention),
       texture_callback_(texture_callback),
       destruction_callback_(destruction_callback),
       user_data_(user_data) {}

--- a/shell/platform/tizen/external_texture_surface_gl_linux.cc
+++ b/shell/platform/tizen/external_texture_surface_gl_linux.cc
@@ -12,7 +12,7 @@
 namespace flutter {
 
 ExternalTextureSurfaceGL::ExternalTextureSurfaceGL(
-    ExternalTextureGLExtention gl_extention,
+    ExternalTextureExtensionType gl_extention,
     FlutterDesktopGpuBufferTextureCallback texture_callback,
     FlutterDesktopGpuBufferDestructionCallback destruction_callback,
     void* user_data)

--- a/shell/platform/tizen/external_texture_surface_gl_tizen.cc
+++ b/shell/platform/tizen/external_texture_surface_gl_tizen.cc
@@ -4,6 +4,8 @@
 
 #include "external_texture_surface_gl.h"
 
+#include <tbm_surface.h>
+
 #ifdef TIZEN_RENDERER_EVAS_GL
 #undef EFL_BETA_API_SUPPORT
 #include "tizen_evas_gl_helper.h"
@@ -14,11 +16,7 @@ EVAS_GL_GLOBAL_GLES3_DECLARE();
 #include <EGL/eglext.h>
 #include <GLES2/gl2ext.h>
 #include <GLES3/gl32.h>
-#endif
 
-#include <tbm_surface.h>
-
-// TODO
 #include <tbm_bufmgr.h>
 #include <tbm_surface_internal.h>
 #ifndef EGL_DMA_BUF_PLANE3_FD_EXT
@@ -29,6 +27,7 @@ EVAS_GL_GLOBAL_GLES3_DECLARE();
 #endif
 #ifndef EGL_DMA_BUF_PLANE3_PITCH_EXT
 #define EGL_DMA_BUF_PLANE3_PITCH_EXT 0x3442
+#endif
 #endif
 
 #include "flutter/shell/platform/tizen/logger.h"
@@ -99,7 +98,6 @@ bool ExternalTextureSurfaceGL::PopulateTexture(
         EVAS_GL_NATIVE_SURFACE_TIZEN, tbm_surface, attribs);
   } else if (state_->gl_extention ==
              ExternalTextureGLExtention_EGL_EXT_image_dma_buf_import) {
-    // TODO
     FT_LOG(Error)
         << "EGL_EXT_image_dma_buf_import is not supported this renderer.";
     return false;
@@ -140,7 +138,6 @@ bool ExternalTextureSurfaceGL::PopulateTexture(
                             EGL_NATIVE_SURFACE_TIZEN, tbm_surface, attribs);
   } else if (state_->gl_extention ==
              ExternalTextureGLExtention_EGL_EXT_image_dma_buf_import) {
-    // TODO
     {
       EGLint attribs[50];
       int atti = 0;

--- a/shell/platform/tizen/external_texture_surface_gl_tizen.cc
+++ b/shell/platform/tizen/external_texture_surface_gl_tizen.cc
@@ -45,7 +45,7 @@ static void OnCollectTexture(void* textureGL) {
 }
 
 ExternalTextureSurfaceGL::ExternalTextureSurfaceGL(
-    ExternalTextureGLExtention gl_extention,
+    ExternalTextureExtensionType gl_extention,
     FlutterDesktopGpuBufferTextureCallback texture_callback,
     FlutterDesktopGpuBufferDestructionCallback destruction_callback,
     void* user_data)
@@ -90,14 +90,12 @@ bool ExternalTextureSurfaceGL::PopulateTexture(
 
 #ifdef TIZEN_RENDERER_EVAS_GL
   EvasGLImage egl_src_image = nullptr;
-  if (state_->gl_extention ==
-      ExternalTextureGLExtention_EGL_TIZEN_image_native_surface) {
+  if (state_->gl_extention == kExternalTextureExtensionTypeNativeSurface) {
     int attribs[] = {EVAS_GL_IMAGE_PRESERVED, GL_TRUE, 0};
     egl_src_image = evasglCreateImageForContext(
         g_evas_gl, evas_gl_current_context_get(g_evas_gl),
         EVAS_GL_NATIVE_SURFACE_TIZEN, tbm_surface, attribs);
-  } else if (state_->gl_extention ==
-             ExternalTextureGLExtention_EGL_EXT_image_dma_buf_import) {
+  } else if (state_->gl_extention == kExternalTextureExtensionTypeDmaBuffer) {
     FT_LOG(Error)
         << "EGL_EXT_image_dma_buf_import is not supported this renderer.";
     return false;
@@ -129,59 +127,57 @@ bool ExternalTextureSurfaceGL::PopulateTexture(
           eglGetProcAddress("eglCreateImageKHR"));
   EGLImageKHR egl_src_image = nullptr;
 
-  if (state_->gl_extention ==
-      ExternalTextureGLExtention_EGL_TIZEN_image_native_surface) {
+  if (state_->gl_extention == kExternalTextureExtensionTypeNativeSurface) {
     const EGLint attribs[] = {EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE,
                               EGL_NONE};
     egl_src_image =
         n_eglCreateImageKHR(eglGetCurrentDisplay(), EGL_NO_CONTEXT,
                             EGL_NATIVE_SURFACE_TIZEN, tbm_surface, attribs);
-  } else if (state_->gl_extention ==
-             ExternalTextureGLExtention_EGL_EXT_image_dma_buf_import) {
-    {
-      EGLint attribs[50];
-      int atti = 0;
-      tbm_bo tbo = NULL;
-      int bo_idx, num_planes, i;
-      int plane_fd_ext[4] = {
-          EGL_DMA_BUF_PLANE0_FD_EXT, EGL_DMA_BUF_PLANE1_FD_EXT,
-          EGL_DMA_BUF_PLANE2_FD_EXT, EGL_DMA_BUF_PLANE3_FD_EXT};
-      int plane_offset_ext[4] = {
-          EGL_DMA_BUF_PLANE0_OFFSET_EXT, EGL_DMA_BUF_PLANE1_OFFSET_EXT,
-          EGL_DMA_BUF_PLANE2_OFFSET_EXT, EGL_DMA_BUF_PLANE3_OFFSET_EXT};
-      int plane_pitch_ext[4] = {
-          EGL_DMA_BUF_PLANE0_PITCH_EXT, EGL_DMA_BUF_PLANE1_PITCH_EXT,
-          EGL_DMA_BUF_PLANE2_PITCH_EXT, EGL_DMA_BUF_PLANE3_PITCH_EXT};
+  } else if (state_->gl_extention == kExternalTextureExtensionTypeDmaBuffer) {
+    EGLint attribs[50];
+    int atti = 0;
+    int plane_fd_ext[4] = {EGL_DMA_BUF_PLANE0_FD_EXT, EGL_DMA_BUF_PLANE1_FD_EXT,
+                           EGL_DMA_BUF_PLANE2_FD_EXT,
+                           EGL_DMA_BUF_PLANE3_FD_EXT};
+    int plane_offset_ext[4] = {
+        EGL_DMA_BUF_PLANE0_OFFSET_EXT, EGL_DMA_BUF_PLANE1_OFFSET_EXT,
+        EGL_DMA_BUF_PLANE2_OFFSET_EXT, EGL_DMA_BUF_PLANE3_OFFSET_EXT};
+    int plane_pitch_ext[4] = {
+        EGL_DMA_BUF_PLANE0_PITCH_EXT, EGL_DMA_BUF_PLANE1_PITCH_EXT,
+        EGL_DMA_BUF_PLANE2_PITCH_EXT, EGL_DMA_BUF_PLANE3_PITCH_EXT};
 
-      attribs[atti++] = EGL_WIDTH;
-      attribs[atti++] = info.width;
-      attribs[atti++] = EGL_HEIGHT;
-      attribs[atti++] = info.height;
-      attribs[atti++] = EGL_LINUX_DRM_FOURCC_EXT;
-      attribs[atti++] = info.format;
+    attribs[atti++] = EGL_WIDTH;
+    attribs[atti++] = info.width;
+    attribs[atti++] = EGL_HEIGHT;
+    attribs[atti++] = info.height;
+    attribs[atti++] = EGL_LINUX_DRM_FOURCC_EXT;
+    attribs[atti++] = info.format;
 
-      num_planes = tbm_surface_internal_get_num_planes(info.format);
-      for (i = 0; i < num_planes; i++) {
-        bo_idx = tbm_surface_internal_get_plane_bo_idx(tbm_surface, i);
-        tbo = tbm_surface_internal_get_bo(tbm_surface, bo_idx);
-        attribs[atti++] = plane_fd_ext[i];
-        attribs[atti++] =
-            (int)(size_t)tbm_bo_get_handle(tbo, TBM_DEVICE_3D).ptr;
-        attribs[atti++] = plane_offset_ext[i];
-        attribs[atti++] = info.planes[i].offset;
-        attribs[atti++] = plane_pitch_ext[i];
-        attribs[atti++] = info.planes[i].stride;
-      }
-      attribs[atti++] = EGL_NONE;
-      egl_src_image =
-          n_eglCreateImageKHR(eglGetCurrentDisplay(), EGL_NO_CONTEXT,
-                              EGL_LINUX_DMA_BUF_EXT, NULL, attribs);
+    int num_planes = tbm_surface_internal_get_num_planes(info.format);
+    for (int i = 0; i < num_planes; i++) {
+      int bo_idx = tbm_surface_internal_get_plane_bo_idx(tbm_surface, i);
+      tbm_bo tbo = tbm_surface_internal_get_bo(tbm_surface, bo_idx);
+      attribs[atti++] = plane_fd_ext[i];
+      attribs[atti++] = static_cast<int>(
+          reinterpret_cast<size_t>(tbm_bo_get_handle(tbo, TBM_DEVICE_3D).ptr));
+      attribs[atti++] = plane_offset_ext[i];
+      attribs[atti++] = info.planes[i].offset;
+      attribs[atti++] = plane_pitch_ext[i];
+      attribs[atti++] = info.planes[i].stride;
     }
+    attribs[atti++] = EGL_NONE;
+    egl_src_image = n_eglCreateImageKHR(eglGetCurrentDisplay(), EGL_NO_CONTEXT,
+                                        EGL_LINUX_DMA_BUF_EXT, NULL, attribs);
   }
 
   if (!egl_src_image) {
-    FT_LOG(Error) << "eglCreateImageKHR failed with an error " << eglGetError()
-                  << " for texture ID: " << texture_id_;
+    if (state_->gl_extention != kExternalTextureExtensionTypeNone) {
+      FT_LOG(Error) << "eglCreateImageKHR failed with an error "
+                    << eglGetError() << " for texture ID: " << texture_id_;
+    } else {
+      FT_LOG(Error) << "Either EGL_TIZEN_image_native_surface or "
+                       "EGL_EXT_image_dma_buf_import shoule be supported "
+    }
     return false;
   }
   if (state_->gl_texture == 0) {

--- a/shell/platform/tizen/external_texture_surface_gl_tizen.cc
+++ b/shell/platform/tizen/external_texture_surface_gl_tizen.cc
@@ -166,8 +166,9 @@ bool ExternalTextureSurfaceGL::PopulateTexture(
       attribs[atti++] = info.planes[i].stride;
     }
     attribs[atti++] = EGL_NONE;
-    egl_src_image = n_eglCreateImageKHR(eglGetCurrentDisplay(), EGL_NO_CONTEXT,
-                                        EGL_LINUX_DMA_BUF_EXT, NULL, attribs);
+    egl_src_image =
+        n_eglCreateImageKHR(eglGetCurrentDisplay(), EGL_NO_CONTEXT,
+                            EGL_LINUX_DMA_BUF_EXT, nullptr, attribs);
   }
 
   if (!egl_src_image) {
@@ -176,7 +177,7 @@ bool ExternalTextureSurfaceGL::PopulateTexture(
                     << eglGetError() << " for texture ID: " << texture_id_;
     } else {
       FT_LOG(Error) << "Either EGL_TIZEN_image_native_surface or "
-                       "EGL_EXT_image_dma_buf_import shoule be supported "
+                       "EGL_EXT_image_dma_buf_import shoule be supported ";
     }
     return false;
   }

--- a/shell/platform/tizen/external_texture_surface_gl_tizen.cc
+++ b/shell/platform/tizen/external_texture_surface_gl_tizen.cc
@@ -177,7 +177,7 @@ bool ExternalTextureSurfaceGL::PopulateTexture(
                     << eglGetError() << " for texture ID: " << texture_id_;
     } else {
       FT_LOG(Error) << "Either EGL_TIZEN_image_native_surface or "
-                       "EGL_EXT_image_dma_buf_import shoule be supported ";
+                       "EGL_EXT_image_dma_buf_import shoule be supported.";
     }
     return false;
   }

--- a/shell/platform/tizen/external_texture_surface_gl_tizen.cc
+++ b/shell/platform/tizen/external_texture_surface_gl_tizen.cc
@@ -18,6 +18,19 @@ EVAS_GL_GLOBAL_GLES3_DECLARE();
 
 #include <tbm_surface.h>
 
+// TODO
+#include <tbm_bufmgr.h>
+#include <tbm_surface_internal.h>
+#ifndef EGL_DMA_BUF_PLANE3_FD_EXT
+#define EGL_DMA_BUF_PLANE3_FD_EXT 0x3440
+#endif
+#ifndef EGL_DMA_BUF_PLANE3_OFFSET_EXT
+#define EGL_DMA_BUF_PLANE3_OFFSET_EXT 0x3441
+#endif
+#ifndef EGL_DMA_BUF_PLANE3_PITCH_EXT
+#define EGL_DMA_BUF_PLANE3_PITCH_EXT 0x3442
+#endif
+
 #include "flutter/shell/platform/tizen/logger.h"
 
 namespace flutter {
@@ -33,10 +46,11 @@ static void OnCollectTexture(void* textureGL) {
 }
 
 ExternalTextureSurfaceGL::ExternalTextureSurfaceGL(
+    ExternalTextureGLExtention gl_extention,
     FlutterDesktopGpuBufferTextureCallback texture_callback,
     FlutterDesktopGpuBufferDestructionCallback destruction_callback,
     void* user_data)
-    : ExternalTexture(),
+    : ExternalTexture(gl_extention),
       texture_callback_(texture_callback),
       destruction_callback_(destruction_callback),
       user_data_(user_data) {}
@@ -76,10 +90,20 @@ bool ExternalTextureSurfaceGL::PopulateTexture(
   }
 
 #ifdef TIZEN_RENDERER_EVAS_GL
-  int attribs[] = {EVAS_GL_IMAGE_PRESERVED, GL_TRUE, 0};
-  EvasGLImage egl_src_image = evasglCreateImageForContext(
-      g_evas_gl, evas_gl_current_context_get(g_evas_gl),
-      EVAS_GL_NATIVE_SURFACE_TIZEN, tbm_surface, attribs);
+  EvasGLImage egl_src_image = nullptr;
+  if (state_->gl_extention ==
+      ExternalTextureGLExtention_EGL_TIZEN_image_native_surface) {
+    int attribs[] = {EVAS_GL_IMAGE_PRESERVED, GL_TRUE, 0};
+    egl_src_image = evasglCreateImageForContext(
+        g_evas_gl, evas_gl_current_context_get(g_evas_gl),
+        EVAS_GL_NATIVE_SURFACE_TIZEN, tbm_surface, attribs);
+  } else if (state_->gl_extention ==
+             ExternalTextureGLExtention_EGL_EXT_image_dma_buf_import) {
+    // TODO
+    FT_LOG(Error)
+        << "EGL_EXT_image_dma_buf_import is not supported this renderer.";
+    return false;
+  }
   if (!egl_src_image) {
     return false;
   }
@@ -105,11 +129,58 @@ bool ExternalTextureSurfaceGL::PopulateTexture(
   PFNEGLCREATEIMAGEKHRPROC n_eglCreateImageKHR =
       reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(
           eglGetProcAddress("eglCreateImageKHR"));
-  const EGLint attribs[] = {EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE,
-                            EGL_NONE};
-  EGLImageKHR egl_src_image =
-      n_eglCreateImageKHR(eglGetCurrentDisplay(), EGL_NO_CONTEXT,
-                          EGL_NATIVE_SURFACE_TIZEN, tbm_surface, attribs);
+  EGLImageKHR egl_src_image = nullptr;
+
+  if (state_->gl_extention ==
+      ExternalTextureGLExtention_EGL_TIZEN_image_native_surface) {
+    const EGLint attribs[] = {EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE,
+                              EGL_NONE};
+    egl_src_image =
+        n_eglCreateImageKHR(eglGetCurrentDisplay(), EGL_NO_CONTEXT,
+                            EGL_NATIVE_SURFACE_TIZEN, tbm_surface, attribs);
+  } else if (state_->gl_extention ==
+             ExternalTextureGLExtention_EGL_EXT_image_dma_buf_import) {
+    // TODO
+    {
+      EGLint attribs[50];
+      int atti = 0;
+      tbm_bo tbo = NULL;
+      int bo_idx, num_planes, i;
+      int plane_fd_ext[4] = {
+          EGL_DMA_BUF_PLANE0_FD_EXT, EGL_DMA_BUF_PLANE1_FD_EXT,
+          EGL_DMA_BUF_PLANE2_FD_EXT, EGL_DMA_BUF_PLANE3_FD_EXT};
+      int plane_offset_ext[4] = {
+          EGL_DMA_BUF_PLANE0_OFFSET_EXT, EGL_DMA_BUF_PLANE1_OFFSET_EXT,
+          EGL_DMA_BUF_PLANE2_OFFSET_EXT, EGL_DMA_BUF_PLANE3_OFFSET_EXT};
+      int plane_pitch_ext[4] = {
+          EGL_DMA_BUF_PLANE0_PITCH_EXT, EGL_DMA_BUF_PLANE1_PITCH_EXT,
+          EGL_DMA_BUF_PLANE2_PITCH_EXT, EGL_DMA_BUF_PLANE3_PITCH_EXT};
+
+      attribs[atti++] = EGL_WIDTH;
+      attribs[atti++] = info.width;
+      attribs[atti++] = EGL_HEIGHT;
+      attribs[atti++] = info.height;
+      attribs[atti++] = EGL_LINUX_DRM_FOURCC_EXT;
+      attribs[atti++] = info.format;
+
+      num_planes = tbm_surface_internal_get_num_planes(info.format);
+      for (i = 0; i < num_planes; i++) {
+        bo_idx = tbm_surface_internal_get_plane_bo_idx(tbm_surface, i);
+        tbo = tbm_surface_internal_get_bo(tbm_surface, bo_idx);
+        attribs[atti++] = plane_fd_ext[i];
+        attribs[atti++] =
+            (int)(size_t)tbm_bo_get_handle(tbo, TBM_DEVICE_3D).ptr;
+        attribs[atti++] = plane_offset_ext[i];
+        attribs[atti++] = info.planes[i].offset;
+        attribs[atti++] = plane_pitch_ext[i];
+        attribs[atti++] = info.planes[i].stride;
+      }
+      attribs[atti++] = EGL_NONE;
+      egl_src_image =
+          n_eglCreateImageKHR(eglGetCurrentDisplay(), EGL_NO_CONTEXT,
+                              EGL_LINUX_DMA_BUF_EXT, NULL, attribs);
+    }
+  }
 
   if (!egl_src_image) {
     FT_LOG(Error) << "eglCreateImageKHR failed with an error " << eglGetError()

--- a/shell/platform/tizen/external_texture_surface_gl_tizen.cc
+++ b/shell/platform/tizen/external_texture_surface_gl_tizen.cc
@@ -90,12 +90,12 @@ bool ExternalTextureSurfaceGL::PopulateTexture(
 
 #ifdef TIZEN_RENDERER_EVAS_GL
   EvasGLImage egl_src_image = nullptr;
-  if (state_->gl_extention == kExternalTextureExtensionTypeNativeSurface) {
+  if (state_->gl_extention == ExternalTextureExtensionType::kNativeSurface) {
     int attribs[] = {EVAS_GL_IMAGE_PRESERVED, GL_TRUE, 0};
     egl_src_image = evasglCreateImageForContext(
         g_evas_gl, evas_gl_current_context_get(g_evas_gl),
         EVAS_GL_NATIVE_SURFACE_TIZEN, tbm_surface, attribs);
-  } else if (state_->gl_extention == kExternalTextureExtensionTypeDmaBuffer) {
+  } else if (state_->gl_extention == ExternalTextureExtensionType::kDmaBuffer) {
     FT_LOG(Error)
         << "EGL_EXT_image_dma_buf_import is not supported this renderer.";
     return false;
@@ -127,13 +127,13 @@ bool ExternalTextureSurfaceGL::PopulateTexture(
           eglGetProcAddress("eglCreateImageKHR"));
   EGLImageKHR egl_src_image = nullptr;
 
-  if (state_->gl_extention == kExternalTextureExtensionTypeNativeSurface) {
+  if (state_->gl_extention == ExternalTextureExtensionType::kNativeSurface) {
     const EGLint attribs[] = {EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE,
                               EGL_NONE};
     egl_src_image =
         n_eglCreateImageKHR(eglGetCurrentDisplay(), EGL_NO_CONTEXT,
                             EGL_NATIVE_SURFACE_TIZEN, tbm_surface, attribs);
-  } else if (state_->gl_extention == kExternalTextureExtensionTypeDmaBuffer) {
+  } else if (state_->gl_extention == ExternalTextureExtensionType::kDmaBuffer) {
     EGLint attribs[50];
     int atti = 0;
     int plane_fd_ext[4] = {EGL_DMA_BUF_PLANE0_FD_EXT, EGL_DMA_BUF_PLANE1_FD_EXT,
@@ -172,7 +172,7 @@ bool ExternalTextureSurfaceGL::PopulateTexture(
   }
 
   if (!egl_src_image) {
-    if (state_->gl_extention != kExternalTextureExtensionTypeNone) {
+    if (state_->gl_extention != ExternalTextureExtensionType::kNone) {
       FT_LOG(Error) << "eglCreateImageKHR failed with an error "
                     << eglGetError() << " for texture ID: " << texture_id_;
     } else {

--- a/shell/platform/tizen/flutter_tizen_texture_registrar.cc
+++ b/shell/platform/tizen/flutter_tizen_texture_registrar.cc
@@ -95,7 +95,14 @@ FlutterTizenTextureRegistrar::CreateExternalTexture(
           texture_info->pixel_buffer_config.user_data);
       break;
     case kFlutterDesktopGpuBufferTexture:
-      // TODO: need to check EGL extention
+      if (engine_->renderer()->IsSupportedExtention(
+              "EGL_TIZEN_image_native_surface")) {
+        return std::make_unique<ExternalTextureSurfaceGL>(
+            ExternalTextureGLExtention_EGL_TIZEN_image_native_surface,
+            texture_info->gpu_buffer_config.callback,
+            texture_info->gpu_buffer_config.destruction_callback,
+            texture_info->gpu_buffer_config.user_data);
+      }
       return std::make_unique<ExternalTextureSurfaceGL>(
           ExternalTextureGLExtention_EGL_EXT_image_dma_buf_import,
           texture_info->gpu_buffer_config.callback,

--- a/shell/platform/tizen/flutter_tizen_texture_registrar.cc
+++ b/shell/platform/tizen/flutter_tizen_texture_registrar.cc
@@ -95,7 +95,9 @@ FlutterTizenTextureRegistrar::CreateExternalTexture(
           texture_info->pixel_buffer_config.user_data);
       break;
     case kFlutterDesktopGpuBufferTexture:
+      // TODO: need to check EGL extention
       return std::make_unique<ExternalTextureSurfaceGL>(
+          ExternalTextureGLExtention_EGL_EXT_image_dma_buf_import,
           texture_info->gpu_buffer_config.callback,
           texture_info->gpu_buffer_config.destruction_callback,
           texture_info->gpu_buffer_config.user_data);

--- a/shell/platform/tizen/flutter_tizen_texture_registrar.cc
+++ b/shell/platform/tizen/flutter_tizen_texture_registrar.cc
@@ -95,23 +95,20 @@ FlutterTizenTextureRegistrar::CreateExternalTexture(
           texture_info->pixel_buffer_config.user_data);
       break;
     case kFlutterDesktopGpuBufferTexture:
+      ExternalTextureExtensionType gl_extension =
+          kExternalTextureExtensionTypeNone;
       if (engine_->renderer()->IsSupportedExtention(
               "EGL_TIZEN_image_native_surface")) {
-        return std::make_unique<ExternalTextureSurfaceGL>(
-            ExternalTextureGLExtention_EGL_TIZEN_image_native_surface,
-            texture_info->gpu_buffer_config.callback,
-            texture_info->gpu_buffer_config.destruction_callback,
-            texture_info->gpu_buffer_config.user_data);
+        gl_extension = kExternalTextureExtensionTypeNativeSurface;
+      } else if (engine_->renderer()->IsSupportedExtention(
+                     "EGL_EXT_image_dma_buf_import")) {
+        gl_extension = kExternalTextureExtensionTypeDmaBuffer;
       }
       return std::make_unique<ExternalTextureSurfaceGL>(
-          ExternalTextureGLExtention_EGL_EXT_image_dma_buf_import,
-          texture_info->gpu_buffer_config.callback,
+          gl_extension, texture_info->gpu_buffer_config.callback,
           texture_info->gpu_buffer_config.destruction_callback,
           texture_info->gpu_buffer_config.user_data);
       break;
-    default:
-      FT_LOG(Error) << "Invalid texture type.";
-      return nullptr;
   }
 }
 

--- a/shell/platform/tizen/flutter_tizen_texture_registrar.cc
+++ b/shell/platform/tizen/flutter_tizen_texture_registrar.cc
@@ -96,13 +96,13 @@ FlutterTizenTextureRegistrar::CreateExternalTexture(
       break;
     case kFlutterDesktopGpuBufferTexture:
       ExternalTextureExtensionType gl_extension =
-          kExternalTextureExtensionTypeNone;
+          ExternalTextureExtensionType::kNone;
       if (engine_->renderer()->IsSupportedExtention(
               "EGL_TIZEN_image_native_surface")) {
-        gl_extension = kExternalTextureExtensionTypeNativeSurface;
+        gl_extension = ExternalTextureExtensionType::kNativeSurface;
       } else if (engine_->renderer()->IsSupportedExtention(
                      "EGL_EXT_image_dma_buf_import")) {
-        gl_extension = kExternalTextureExtensionTypeDmaBuffer;
+        gl_extension = ExternalTextureExtensionType::kDmaBuffer;
       }
       return std::make_unique<ExternalTextureSurfaceGL>(
           gl_extension, texture_info->gpu_buffer_config.callback,

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -44,6 +44,7 @@ class TizenRenderer {
                                   int32_t height,
                                   int32_t degree) = 0;
   virtual void SetPreferredOrientations(const std::vector<int>& rotations) = 0;
+  virtual bool IsSupportedExtention(const char* name) = 0;
 
  protected:
   explicit TizenRenderer(WindowGeometry geometry,

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -359,6 +359,7 @@ bool TizenRendererEcoreWl2::SetupEglSurface() {
     FT_LOG(Error) << "ChooseEGLConfiguration() failed.";
     return false;
   }
+  egl_extention_str_ = eglQueryString(egl_display_, EGL_EXTENSIONS);
 
   const EGLint context_attribs[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
   egl_context_ = eglCreateContext(egl_display_, egl_config_, EGL_NO_CONTEXT,
@@ -554,6 +555,13 @@ void TizenRendererEcoreWl2::SetPreferredOrientations(
     const std::vector<int>& rotations) {
   ecore_wl2_window_available_rotations_set(ecore_wl2_window_, rotations.data(),
                                            rotations.size());
+}
+
+bool TizenRendererEcoreWl2::IsSupportedExtention(const char* name) {
+  if (strstr(egl_extention_str_.c_str(), name)) {
+    return true;
+  }
+  return false;
 }
 
 }  // namespace flutter

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -8,6 +8,7 @@
 #define EFL_BETA_API_SUPPORT
 #include <EGL/egl.h>
 #include <Ecore_Wl2.h>
+#include <string>
 
 #include "flutter/shell/platform/tizen/tizen_renderer.h"
 
@@ -40,6 +41,7 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
                           int32_t angle) override;
   void SetRotate(int angle) override;
   void SetPreferredOrientations(const std::vector<int>& rotations) override;
+  bool IsSupportedExtention(const char* name) override;
 
  private:
   bool InitializeRenderer();
@@ -73,6 +75,8 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   EGLSurface egl_surface_ = EGL_NO_SURFACE;
   EGLContext egl_resource_context_ = EGL_NO_CONTEXT;
   EGLSurface egl_resource_surface_ = EGL_NO_SURFACE;
+
+  std::string egl_extention_str_;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -737,7 +737,6 @@ void TizenRendererEvasGL::SetPreferredOrientations(
 }
 
 bool TizenRendererEvasGL::IsSupportedExtention(const char* name) {
-  // TODO
   if (strcmp(name, "EGL_TIZEN_image_native_surface") == 0) {
     return true;
   }

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -739,4 +739,5 @@ void TizenRendererEvasGL::SetPreferredOrientations(
 bool TizenRendererEvasGL::IsSupportedExtention(const char* name) {
   return strcmp(name, "EGL_TIZEN_image_native_surface") == 0;
 }
+
 }  // namespace flutter

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -737,10 +737,6 @@ void TizenRendererEvasGL::SetPreferredOrientations(
 }
 
 bool TizenRendererEvasGL::IsSupportedExtention(const char* name) {
-  if (strcmp(name, "EGL_TIZEN_image_native_surface") == 0) {
-    return true;
-  }
-  return false;
+  return strcmp(name, "EGL_TIZEN_image_native_surface") == 0;
 }
-
 }  // namespace flutter

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -736,4 +736,12 @@ void TizenRendererEvasGL::SetPreferredOrientations(
       rotations.size());
 }
 
+bool TizenRendererEvasGL::IsSupportedExtention(const char* name) {
+  // TODO
+  if (strcmp(name, "EGL_TIZEN_image_native_surface") == 0) {
+    return true;
+  }
+  return false;
+}
+
 }  // namespace flutter

--- a/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -41,6 +41,7 @@ class TizenRendererEvasGL : public TizenRenderer {
                           int32_t angle) override;
   void SetRotate(int angle) override;
   void SetPreferredOrientations(const std::vector<int>& rotations) override;
+  bool IsSupportedExtention(const char* name) override;
 
   Evas_Object* GetImageHandle();
 


### PR DESCRIPTION
This is a patch that uses ``EGL_EXT_image_dma_buf_import`` extention for device that do not support ``EGL_TIZEN_image_native_surface``.