### PR TITLE
Fix parsing bug for dispose method

### DIFF
--- a/shell/platform/tizen/channels/platform_view_channel.cc
+++ b/shell/platform/tizen/channels/platform_view_channel.cc
@@ -165,10 +165,8 @@ void PlatformViewChannel::HandleMethodCall(
     }
   } else if (method == "dispose") {
     int view_id = -1;
-    if (std::holds_alternative<int>(arguments)) {
-      view_id = std::get<int>(arguments);
-    };
-    if (view_id < 0 || view_instances_.find(view_id) == view_instances_.end()) {
+    if (!GetValueFromEncodableMap(arguments, "id", &view_id) ||
+        view_instances_.find(view_id) == view_instances_.end()) {
       result->Error("Can't find view id");
     } else {
       RemoveViewInstanceIfNeeded(view_id);


### PR DESCRIPTION
In PlatformViewChannel::HandleMethodCall, a argument for 'dispose' method includes a map.
Hence, to get a proper view_id value, it should be parsed by 'id' key.
