### PR TITLE
Make an image for the environment to build engine source

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -6,6 +6,7 @@ on:
       - 'flutter-*'
     paths:
       - 'ci/docker/tizen/**'
+      - 'DEPS'
 
 jobs:
   build:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,37 @@
+name: Build Docker
+
+on:
+  push:
+    branches:
+      - 'flutter-*'
+    paths:
+      - 'ci/docker/tizen/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Extract branch name
+      id: branch
+      run: echo "##[set-output name=name;]$(echo ${GITHUB_REF#refs/heads/})"
+
+    - uses: actions/checkout@v2
+
+    - uses: docker/setup-buildx-action@v1
+
+    - uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: ci/docker/tizen
+        file: ci/docker/tizen/Dockerfile
+        push: true
+        build-args:
+          GIT_BRANCH=${{ steps.branch.outputs.name }}
+        tags: |
+          ghcr.io/${{ github.repository_owner }}/build-engine:latest

--- a/ci/docker/tizen/Dockerfile
+++ b/ci/docker/tizen/Dockerfile
@@ -1,0 +1,49 @@
+#################
+# Builder stage #
+#################
+
+FROM debian:buster-slim AS builder
+
+ARG GIT_BRANCH=master
+
+RUN apt-get update && \
+    apt-get install -y git curl ca-certificates python && \
+    apt-get clean
+
+# Install depot tools.
+ENV DEPOT_TOOLS_PATH=/usr/share/depot_tools
+ENV PATH=$PATH:${DEPOT_TOOLS_PATH}
+RUN git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git ${DEPOT_TOOLS_PATH}
+
+# Sync engine and dependencies.
+WORKDIR /engine
+RUN git clone --depth 1 -b $GIT_BRANCH https://github.com/flutter-tizen/engine src/flutter
+
+RUN gclient config --name="src/flutter" --deps-file="DEPS" --unmanaged https://github.com/flutter-tizen/engine.git
+RUN gclient setdep --var=download_android_deps=False --deps-file=src/flutter/DEPS
+RUN gclient sync -f -D --no-history --shallow
+
+# Copy selected .git directories.
+RUN mkdir -p cache
+RUN for x in $(find src/third_party/ -name .git -a \( -wholename "*/dart/*" -o -wholename "*/skia/*" \)); do \
+        mkdir -p cache/$x; \
+        cp -fr $x/* cache/$x; \
+    done
+
+
+#############################
+# build-engine docker image #
+#############################
+
+FROM ghcr.io/flutter-tizen/tizen-tools:latest
+
+RUN apt-get update && \
+    apt-get install -y git curl ca-certificates python xz-utils pkg-config \
+                       libncurses5 libfreetype6-dev && \
+    apt-get clean
+
+COPY --from=builder /usr/share/depot_tools /usr/share/depot_tools
+COPY --from=builder /engine/cache /engine/cache
+ADD prepare-sync.sh /engine/tools/
+
+ENV PATH=$PATH:/usr/share/depot_tools:/engine/tools

--- a/ci/docker/tizen/Dockerfile
+++ b/ci/docker/tizen/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM debian:buster-slim AS builder
 
-ARG GIT_BRANCH=master
+ARG GIT_BRANCH
 
 RUN apt-get update && \
     apt-get install -y git curl ca-certificates python && \
@@ -17,7 +17,11 @@ RUN git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_t
 
 # Sync engine and dependencies.
 WORKDIR /engine
-RUN git clone --depth 1 -b $GIT_BRANCH https://github.com/flutter-tizen/engine src/flutter
+RUN if [ -n "$GIT_BRANCH" ]; then \
+        git clone --depth 1 -b $GIT_BRANCH https://github.com/flutter-tizen/engine src/flutter; \
+    else \
+        git clone --depth 1 https://github.com/flutter-tizen/engine src/flutter; \
+    fi
 
 RUN gclient config --name="src/flutter" --deps-file="DEPS" --unmanaged https://github.com/flutter-tizen/engine.git
 RUN gclient setdep --var=download_android_deps=False --deps-file=src/flutter/DEPS

--- a/ci/docker/tizen/build-docker.sh
+++ b/ci/docker/tizen/build-docker.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+IMAGE_NAME=ghcr.io/flutter-tizen/build-engine
+IMAGE_TAG=latest
+GIT_BRANCH=flutter-2.2.1-tizen
+
+docker pull $IMAGE_NAME:$IMAGE_TAG
+docker build --build-arg GIT_BRANCH=$GIT_BRANCH --tag $IMAGE_NAME:$IMAGE_TAG .

--- a/ci/docker/tizen/build-docker.sh
+++ b/ci/docker/tizen/build-docker.sh
@@ -2,7 +2,6 @@
 
 IMAGE_NAME=ghcr.io/flutter-tizen/build-engine
 IMAGE_TAG=latest
-GIT_BRANCH=flutter-2.2.1-tizen
 
 docker pull $IMAGE_NAME:$IMAGE_TAG
-docker build --build-arg GIT_BRANCH=$GIT_BRANCH --tag $IMAGE_NAME:$IMAGE_TAG .
+docker build --tag $IMAGE_NAME:$IMAGE_TAG .

--- a/ci/docker/tizen/prepare-sync.sh
+++ b/ci/docker/tizen/prepare-sync.sh
@@ -13,9 +13,6 @@ solutions = [
     "url"         : 'https://github.com/flutter-tizen/engine.git',
     "deps_file"   : 'DEPS',
     "managed"     : False,
-    "custom_deps" : {
-    },
-    "custom_vars": {},
   },
 ]
 EOF

--- a/ci/docker/tizen/prepare-sync.sh
+++ b/ci/docker/tizen/prepare-sync.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -e
+
+DEPS=src/flutter/DEPS
+
+if [ ! -f $DEPS ]; then
+    echo "Could not find DEPS file."
+    exit 1
+fi
+
+cat > .gclient << EOF
+solutions = [
+  { "name"        : 'src/flutter',
+    "url"         : 'https://github.com/flutter-tizen/engine.git',
+    "deps_file"   : 'DEPS',
+    "managed"     : False,
+    "custom_deps" : {
+    },
+    "custom_vars": {},
+  },
+]
+EOF
+
+gclient setdep --var=download_android_deps=False --deps-file=$DEPS
+
+sed -i -e '/src\/ios_tools/,+2d' $DEPS
+sed -i -e '/src\/third_party\/vulkan/,+2d' $DEPS
+sed -i -e '/src\/third_party\/angle/,+2d' $DEPS
+sed -i -e '/src\/third_party\/abseil-cpp/,+2d' $DEPS
+sed -i -e '/src\/fuchsia\/sdk\/linux/,+9d' $DEPS
+
+if [ -d /engine/cache ]; then
+    cp -fr /engine/cache/* .
+fi


### PR DESCRIPTION
New docker image named "build-engine" contains the following:
- Additional ubuntu packages : git curl ca-certificates python xz-utils pkg-config libncurses5 libfreetype6-dev
- depot_tools
- some .git cached directories to reduce gclient sync time. (dart/**/.git, skia/.git)

After this docker image is registered, `prepare-sync.sh` script will be run before the `gclient sync` in the build workflow to remove unnecessary dependencies from `DEPS` file.


