### PR TITLE
[docker] Support host build

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -9,7 +9,6 @@ on:
       - 'DEPS'
   workflow_dispatch:
 
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/ci/docker/tizen/Dockerfile
+++ b/ci/docker/tizen/Dockerfile
@@ -1,8 +1,20 @@
 FROM ghcr.io/flutter-tizen/tizen-tools:latest
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
-    apt-get install -y git curl ca-certificates python python3 xz-utils pkg-config \
-                       libncurses5 libfreetype6-dev && \
+    apt-get install -y git curl pkg-config ca-certificates xz-utils python python3 && \
+    apt-get install -y libncurses5 libfreetype6-dev && \
+    apt-get install -y build-essential check meson ninja-build && \
+    apt-get install -y libssl-dev libsystemd-dev libjpeg-dev libglib2.0-dev libgstreamer1.0-dev \
+                       liblua5.2-dev libfreetype6-dev libfontconfig1-dev libfribidi-dev libavahi-client-dev \
+                       libharfbuzz-dev libibus-1.0-dev libx11-dev libxext-dev libxrender-dev libgl1-mesa-dev \
+                       libgif-dev libtiff5-dev libpoppler-dev libpoppler-cpp-dev libspectre-dev libraw-dev \
+                       librsvg2-dev libudev-dev libmount-dev libdbus-1-dev libpulse-dev libsndfile1-dev \
+                       libxcursor-dev libxcomposite-dev libxinerama-dev libxrandr-dev libxtst-dev libxss-dev \
+                       libgstreamer-plugins-base1.0-dev doxygen libopenjp2-7-dev libscim-dev libxdamage-dev \
+                       libwebp-dev libunwind-dev libheif-dev libinput-dev libluajit-5.1-dev && \
+    apt-get install -y xvfb && \
     apt-get clean
 
 # Install depot tools.
@@ -13,3 +25,14 @@ RUN git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_t
 # Add engine building tools.
 ADD tools/* /engine/tools/
 ENV PATH=$PATH:/engine/tools
+
+# Build and install EFL.
+RUN git clone --depth 1 https://git.enlightenment.org/core/efl.git -b -v1.25.1 /tmp/efl && \
+    meson /tmp/efl /tmp/efl/build && \
+    ninja -C /tmp/efl/build && \
+    ninja -C /tmp/efl/build install && \
+    rm -fr /tmp/efl
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/x86_64-linux-gnu/
+
+# Start dbus service when running this container.
+ENTRYPOINT /etc/init.d/dbus start && /bin/bash

--- a/ci/docker/tizen/Dockerfile
+++ b/ci/docker/tizen/Dockerfile
@@ -1,20 +1,12 @@
-FROM ghcr.io/flutter-tizen/tizen-tools:latest
+#
+# Stage for build-engine-base
+#
+FROM ghcr.io/flutter-tizen/tizen-tools:latest AS build-engine-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get install -y git curl pkg-config ca-certificates xz-utils python python3 && \
-    apt-get install -y libncurses5 libfreetype6-dev && \
-    apt-get install -y build-essential check meson ninja-build && \
-    apt-get install -y libssl-dev libsystemd-dev libjpeg-dev libglib2.0-dev libgstreamer1.0-dev \
-                       liblua5.2-dev libfreetype6-dev libfontconfig1-dev libfribidi-dev libavahi-client-dev \
-                       libharfbuzz-dev libibus-1.0-dev libx11-dev libxext-dev libxrender-dev libgl1-mesa-dev \
-                       libgif-dev libtiff5-dev libpoppler-dev libpoppler-cpp-dev libspectre-dev libraw-dev \
-                       librsvg2-dev libudev-dev libmount-dev libdbus-1-dev libpulse-dev libsndfile1-dev \
-                       libxcursor-dev libxcomposite-dev libxinerama-dev libxrandr-dev libxtst-dev libxss-dev \
-                       libgstreamer-plugins-base1.0-dev doxygen libopenjp2-7-dev libscim-dev libxdamage-dev \
-                       libwebp-dev libunwind-dev libheif-dev libinput-dev libluajit-5.1-dev && \
-    apt-get install -y xvfb && \
+RUN apt-get update
+RUN apt-get install -y git curl pkg-config ca-certificates xz-utils python python3 libncurses5 && \
     apt-get clean
 
 # Install depot tools.
@@ -26,13 +18,32 @@ RUN git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_t
 ADD tools/* /engine/tools/
 ENV PATH=$PATH:/engine/tools
 
-# Build and install EFL.
-RUN git clone --depth 1 https://git.enlightenment.org/core/efl.git -b -v1.25.1 /tmp/efl && \
-    meson /tmp/efl /tmp/efl/build && \
+
+#
+# Stage for build-engine-with-efl
+#
+FROM build-engine-base AS build-engine-with-efl
+
+# Install dependencies for building EFL.
+RUN apt-get install -y build-essential check meson ninja-build && \
+    apt-get clean
+RUN apt-get install -y libssl-dev libsystemd-dev libglib2.0-dev libudev-dev libmount-dev libdbus-1-dev libunwind-dev && \
+    apt-get clean
+RUN apt-get install -y libjpeg-dev libopenjp2-7-dev libgif-dev libtiff5-dev librsvg2-dev libheif-dev libwebp-dev libraw-dev \
+                       libpoppler-dev libpoppler-cpp-dev libspectre-dev libfreetype6-dev libfontconfig1-dev libharfbuzz-dev \
+                       libpulse-dev libsndfile1-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+                       libibus-1.0-dev libscim-dev libfribidi-dev libinput-dev liblua5.2-dev libluajit-5.1-dev \
+                       libx11-dev libxext-dev libxrender-dev libxcursor-dev libxcomposite-dev libxinerama-dev libxrandr-dev \
+                       libxtst-dev libxss-dev libxdamage-dev libgl1-mesa-dev xvfb && \
+    apt-get clean
+
+# Build and install EFL for host build.
+RUN git clone --depth 1 https://git.enlightenment.org/core/efl.git -b efl-1.25 /tmp/efl && \
+    meson -Dbuild-examples=false -Dbuild-tests=false /tmp/efl /tmp/efl/build && \
     ninja -C /tmp/efl/build && \
     ninja -C /tmp/efl/build install && \
     rm -fr /tmp/efl
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/x86_64-linux-gnu/
+RUN ldconfig
 
 # Start dbus service when running this container.
 ENTRYPOINT /etc/init.d/dbus start && /bin/bash

--- a/ci/docker/tizen/build-docker.sh
+++ b/ci/docker/tizen/build-docker.sh
@@ -3,5 +3,4 @@
 IMAGE_NAME=ghcr.io/flutter-tizen/build-engine
 IMAGE_TAG=latest
 
-docker pull $IMAGE_NAME:$IMAGE_TAG
 docker build --tag $IMAGE_NAME:$IMAGE_TAG .


### PR DESCRIPTION
- Install EFL 1.25.1 and dependencies. (including xvfb)
- Fix build-engine.sh for buliding host build.
- Total uncompressed size of the docker will be 2.77GB including the `tizen-tools` image.

```
ghcr.io/flutter-tizen/build-engine   latest    a252ea0a8445   23 minutes ago   2.77GB
ghcr.io/flutter-tizen/tizen-tools    latest    12442f867f85   17 hours ago     1.86GB
```

The build workflows will be:

### build.yml
```yaml
      - name: gclient sync
        run: |
          gclient-prepare-sync.sh --reduce-deps --shallow-sync
          gclient sync -v --no-history --shallow

      - name: build
        run: |
          cache-checksum.sh restore $CACHE_PATH
          build-engine.sh \
            --target-os linux \
            --target-arch ${{ matrix.arch }} \
            --target-triple ${{ matrix.triple }} \
            --runtime-mode ${{ matrix.mode }}          
          cache-checksum.sh save $CACHE_PATH
```

### test.yml
```yaml
      - name: gclient sync
        run: |
          gclient-prepare-sync.sh --reduce-deps --shallow-sync
          gclient sync -v --no-history --shallow

      - name: check format
        run: |
          src/flutter/ci/format.sh

      - name: host build for test
        run: |
          cache-checksum.sh restore $CACHE_PATH
          build-engine.sh --build-target flutter_tizen_unittests
          cache-checksum.sh save $CACHE_PATH

      - name: run unit tests
        run: |
          $CACHE_PATH/flutter_tizen_unittests
```