### PR TITLE
[workflows] Add workflows for buliding and testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - 'flutter-*-tizen'
+      - "flutter-*-tizen"
   pull_request:
 
 jobs:
@@ -43,20 +43,17 @@ jobs:
       - name: setup variables for host
         if: matrix.os == 'host'
         run: |
-          echo "FETCH_DEPTH=0" >> $GITHUB_ENV
           echo "OUTPUT_NAME=host_${{ matrix.mode }}" >> $GITHUB_ENV
           echo "BUILD_TARGET_OPT=--build-target flutter_tizen_unittests" >> $GITHUB_ENV
 
       - name: setup variables for linux
         if: matrix.os == 'linux'
         run: |
-          echo "FETCH_DEPTH=1" >> $GITHUB_ENV
           echo "OUTPUT_NAME=linux_${{ matrix.mode }}_${{ matrix.arch }}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
         with:
           path: src/flutter
-          fetch-depth: ${{ env.FETCH_DEPTH }}
 
       - uses: actions/cache@v2
         with:
@@ -69,11 +66,6 @@ jobs:
         run: |
           gclient-prepare-sync.sh --reduce-deps --shallow-sync
           gclient sync -v --no-history --shallow
-
-      - name: check format
-        if: matrix.os == 'host'
-        run: |
-          src/flutter/ci/format.sh
 
       - name: build
         run: |
@@ -123,8 +115,11 @@ jobs:
         with:
           name: host-x64-debug
 
-      - name: run unittests
+      - name: prepare
         run: |
           /etc/init.d/dbus start
           chmod +x flutter_tizen_unittests
+
+      - name: run unittests
+        run: |
           ./flutter_tizen_unittests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,130 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - 'flutter-*-tizen'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flutter-tizen/build-engine:latest
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    strategy:
+      matrix:
+        arch: [arm, arm64, x86]
+        mode: [debug, release, profile]
+        include:
+          - arch: arm
+            os: linux
+            triple: armv7l-tizen-linux-gnueabi
+          - arch: arm64
+            os: linux
+            triple: aarch64-tizen-linux-gnu
+          - arch: x86
+            os: linux
+            triple: i586-tizen-linux-gnueabi
+          - arch: x64
+            os: host
+            triple: none
+            mode: debug
+        exclude:
+          - arch: x86
+            mode: release
+          - arch: x86
+            mode: profile
+
+    steps:
+      - name: setup variables for host
+        if: matrix.os == 'host'
+        run: |
+          echo "FETCH_DEPTH=0" >> $GITHUB_ENV
+          echo "OUTPUT_NAME=host_${{ matrix.mode }}" >> $GITHUB_ENV
+          echo "BUILD_TARGET_OPT=--build-target flutter_tizen_unittests" >> $GITHUB_ENV
+
+      - name: setup variables for linux
+        if: matrix.os == 'linux'
+        run: |
+          echo "FETCH_DEPTH=1" >> $GITHUB_ENV
+          echo "OUTPUT_NAME=linux_${{ matrix.mode }}_${{ matrix.arch }}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v2
+        with:
+          path: src/flutter
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+
+      - uses: actions/cache@v2
+        with:
+          path: src/out/${{ env.OUTPUT_NAME }}
+          key: out-build-${{ env.OUTPUT_NAME }}-${{ github.sha }}
+          restore-keys: |
+            out-build-${{ env.OUTPUT_NAME }}-
+
+      - name: gclient sync
+        run: |
+          gclient-prepare-sync.sh --reduce-deps --shallow-sync
+          gclient sync -v --no-history --shallow
+
+      - name: check format
+        if: matrix.os == 'host'
+        run: |
+          src/flutter/ci/format.sh
+
+      - name: build
+        run: |
+          cache-checksum.sh restore src/out/$OUTPUT_NAME
+          build-engine.sh \
+            --target-os ${{ matrix.os }} \
+            --target-arch ${{ matrix.arch }} \
+            --target-triple ${{ matrix.triple }} \
+            --runtime-mode ${{ matrix.mode }} $BUILD_TARGET_OPT
+          cache-checksum.sh save src/out/$OUTPUT_NAME
+
+      - uses: actions/upload-artifact@v2
+        if: matrix.os == 'host'
+        with:
+          name: host-${{ matrix.arch }}-${{ matrix.mode }}
+          path: |
+            src/out/${{ env.OUTPUT_NAME }}/libflutter_*.so
+            src/out/${{ env.OUTPUT_NAME }}/*_unittests
+
+      - uses: actions/upload-artifact@v2
+        if: matrix.os == 'linux'
+        with:
+          name: tizen-${{ matrix.arch }}-${{ matrix.mode }}
+          path: src/out/${{ env.OUTPUT_NAME }}/libflutter_*.so
+
+      - uses: actions/upload-artifact@v2
+        if: matrix.arch == 'arm' && matrix.mode == 'release'
+        with:
+          name: tizen-common
+          path: |
+            src/out/linux_release_arm/icu
+            src/out/linux_release_arm/public
+            src/out/linux_release_arm/cpp_client_wrapper
+            !src/out/linux_release_arm/cpp_client_wrapper/engine_method_result.cc
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flutter-tizen/build-engine:latest
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: host-x64-debug
+
+      - name: run unittests
+        run: |
+          /etc/init.d/dbus start
+          chmod +x flutter_tizen_unittests
+          ./flutter_tizen_unittests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,14 +82,14 @@ jobs:
         with:
           name: host-${{ matrix.arch }}-${{ matrix.mode }}
           path: |
-            src/out/${{ env.OUTPUT_NAME }}/libflutter_*.so
             src/out/${{ env.OUTPUT_NAME }}/*_unittests
 
       - uses: actions/upload-artifact@v2
         if: matrix.os == 'linux'
         with:
           name: tizen-${{ matrix.arch }}-${{ matrix.mode }}
-          path: src/out/${{ env.OUTPUT_NAME }}/libflutter_*.so
+          path: |
+            src/out/${{ env.OUTPUT_NAME }}/libflutter_*.so
 
       - uses: actions/upload-artifact@v2
         if: matrix.arch == 'arm' && matrix.mode == 'release'

--- a/.github/workflows/check-symbol.yml
+++ b/.github/workflows/check-symbol.yml
@@ -58,7 +58,6 @@ jobs:
           path: artifacts
 
       - name: check symbols
-        id: check
         env:
           ALLOWLIST: tizen_allowlist/4.0.0_native_whitelist_wearable_v12.txt
         run: |

--- a/.github/workflows/check-symbol.yml
+++ b/.github/workflows/check-symbol.yml
@@ -1,0 +1,104 @@
+name: Check Symbols
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - requested
+      - completed
+
+jobs:
+  pending:
+    if: |
+      github.event.action == 'requested' &&
+      github.event.workflow_run.event == 'pull_request'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: commit status
+        uses: actions/github-script@v5
+        with:
+          script: |
+            for (const pr of context.payload.workflow_run.pull_requests) {
+              if (pr.base.repo.url == context.payload.repository.url) {
+                github.rest.repos.createCommitStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha: pr.head.sha,
+                  context: 'Check Symbols',
+                  state: 'pending',
+                  description: 'Waiting for build finish'
+                });
+              }
+            }
+
+  check:
+    if: |
+      github.event.action == 'completed' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: flutter-tizen/tizen_allowlist
+          token: ${{ secrets.TIZENAPI_TOKEN }}
+          path: tizen_allowlist
+
+      - name: download artifacts
+        uses: TizenAPI/tizenfx-build-actions/download-workflow-artifacts@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: tizen-arm-release
+          path: artifacts
+
+      - name: check symbols
+        id: check
+        env:
+          ALLOWLIST: tizen_allowlist/4.0.0_native_whitelist_wearable_v12.txt
+        run: |
+          python ci/docker/tizen/tools/check-symbol.py --allowlist=$ALLOWLIST \
+            artifacts/libflutter_engine.so \
+            artifacts/libflutter_tizen_wearable.so
+
+      - name: commit success status
+        if: ${{ success() }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            for (const pr of context.payload.workflow_run.pull_requests) {
+              if (pr.base.repo.url == context.payload.repository.url) {
+                github.rest.repos.createCommitStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha: pr.head.sha,
+                  context: "Check Symbols",
+                  state: 'success',
+                  description: 'All symbols are valid'
+                });
+              }
+            }
+
+      - name: commit failure status
+        if: ${{ failure() }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            for (const pr of context.payload.workflow_run.pull_requests) {
+              if (pr.base.repo.url == context.payload.repository.url) {
+                github.rest.repos.createCommitStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha: pr.head.sha,
+                  context: "Check Symbols",
+                  state: 'failure',
+                  description: 'Failed in checking symbols',
+                  target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+                });
+              }
+            }

--- a/.github/workflows/check-symbol.yml
+++ b/.github/workflows/check-symbol.yml
@@ -8,48 +8,30 @@ on:
       - completed
 
 jobs:
-  pending:
-    if: |
-      github.event.action == 'requested' &&
-      github.event.workflow_run.event == 'pull_request'
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: commit status
-        uses: actions/github-script@v5
-        with:
-          script: |
-            for (const pr of context.payload.workflow_run.pull_requests) {
-              if (pr.base.repo.url == context.payload.repository.url) {
-                github.rest.repos.createCommitStatus({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  sha: pr.head.sha,
-                  context: 'Check Symbols',
-                  state: 'pending',
-                  description: 'Waiting for build finish'
-                });
-              }
-            }
-
   check:
-    if: |
-      github.event.action == 'completed' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
 
     runs-on: ubuntu-latest
 
     steps:
+      - uses: WonyoungChoi/workflow-run-status-action@v1
+        with:
+          context: '${{ github.workflow }}'
+          message_on_pending: "Waiting for build finish"
+          message_on_success: "All symbols are valid"
+
       - uses: actions/checkout@v2
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
       - uses: actions/checkout@v2
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         with:
           repository: flutter-tizen/tizen_allowlist
           token: ${{ secrets.TIZENAPI_TOKEN }}
           path: tizen_allowlist
 
       - name: download artifacts
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         uses: TizenAPI/tizenfx-build-actions/download-workflow-artifacts@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -58,46 +40,10 @@ jobs:
           path: artifacts
 
       - name: check symbols
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         env:
           ALLOWLIST: tizen_allowlist/4.0.0_native_whitelist_wearable_v12.txt
         run: |
           python ci/docker/tizen/tools/check-symbol.py --allowlist=$ALLOWLIST \
             artifacts/libflutter_engine.so \
             artifacts/libflutter_tizen_wearable.so
-
-      - name: commit success status
-        if: ${{ success() }}
-        uses: actions/github-script@v5
-        with:
-          script: |
-            for (const pr of context.payload.workflow_run.pull_requests) {
-              if (pr.base.repo.url == context.payload.repository.url) {
-                github.rest.repos.createCommitStatus({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  sha: pr.head.sha,
-                  context: "Check Symbols",
-                  state: 'success',
-                  description: 'All symbols are valid'
-                });
-              }
-            }
-
-      - name: commit failure status
-        if: ${{ failure() }}
-        uses: actions/github-script@v5
-        with:
-          script: |
-            for (const pr of context.payload.workflow_run.pull_requests) {
-              if (pr.base.repo.url == context.payload.repository.url) {
-                github.rest.repos.createCommitStatus({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  sha: pr.head.sha,
-                  context: "Check Symbols",
-                  state: 'failure',
-                  description: 'Failed in checking symbols',
-                  target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}',
-                });
-              }
-            }

--- a/.github/workflows/check-symbol.yml
+++ b/.github/workflows/check-symbol.yml
@@ -4,34 +4,25 @@ on:
   workflow_run:
     workflows: ["Build"]
     types:
-      - requested
       - completed
 
 jobs:
   check:
-    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: WonyoungChoi/workflow-run-status-action@v1
-        with:
-          context: '${{ github.workflow }}'
-          message_on_pending: "Waiting for build finish"
-          message_on_success: "All symbols are valid"
-
       - uses: actions/checkout@v2
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
       - uses: actions/checkout@v2
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         with:
           repository: flutter-tizen/tizen_allowlist
           token: ${{ secrets.TIZENAPI_TOKEN }}
           path: tizen_allowlist
 
       - name: download artifacts
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         uses: TizenAPI/tizenfx-build-actions/download-workflow-artifacts@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,10 +31,38 @@ jobs:
           path: artifacts
 
       - name: check symbols
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         env:
           ALLOWLIST: tizen_allowlist/4.0.0_native_whitelist_wearable_v12.txt
         run: |
           python ci/docker/tizen/tools/check-symbol.py --allowlist=$ALLOWLIST \
             artifacts/libflutter_engine.so \
             artifacts/libflutter_tizen_wearable.so
+
+      - name: commit success status
+        if: ${{ success() }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.workflow_run.head_sha,
+              context: "Check Symbols",
+              state: 'success',
+              description: 'All symbols are valid'
+            });
+
+      - name: commit failure status
+        if: ${{ failure() }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.workflow_run.head_sha,
+              context: "Check Symbols",
+              state: 'failure',
+              description: 'Failed in checking symbols',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+            });


### PR DESCRIPTION
This PR is to add github actions workflows for building the engine source and running unit-tests.

## `Build` workflow is :
- using GitHub's hosted runner.
- using `actions/cache` for incremental build, the cache size for each job is about 140~200MB. 
- using `strategy matrix ` to create multiple jobs in building task.
- using the docker image `build-engine`.

## `Check Symbols` workflow :
- checks symbols of the build artifacts with the allowlist. 
- is triggered by `workflow_run` event. (for security reason)

## tasks
- [x] Build engines for each target [arm-debug, arm-profile, arm-release, arm64-debug, arm64-profile, arm64-release, x86-debug]
- [x] Run unit tests
- [x] Verify symbol references.
- [x] Publish artifacts.