### PR TITLE
Remove the app_control reply channel

### DIFF
--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -211,6 +211,7 @@ template("embedder") {
       "//flutter/shell/platform/common:common_cpp_input",
       "//flutter/shell/platform/common:common_cpp_library_headers",
       "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+      "//third_party/dart/runtime:dart_api",
       "//third_party/rapidjson",
     ]
   }

--- a/shell/platform/tizen/channels/app_control.cc
+++ b/shell/platform/tizen/channels/app_control.cc
@@ -4,16 +4,14 @@
 
 #include "app_control.h"
 
-#include "flutter/shell/platform/common/public/flutter_export.h"
 #include "flutter/shell/platform/tizen/channels/app_control_channel.h"
 #include "flutter/shell/platform/tizen/logger.h"
-#include "third_party/dart/runtime/include/dart_api_dl.h"
 
-DART_EXPORT FLUTTER_EXPORT intptr_t NativeInitializeDartApi(void* data) {
+intptr_t NativeInitializeDartApi(void* data) {
   return Dart_InitializeApiDL(data);
 }
 
-DART_EXPORT FLUTTER_EXPORT uint32_t NativeCreateAppControl(Dart_Handle handle) {
+int32_t NativeCreateAppControl(Dart_Handle handle) {
   auto app_control = std::make_unique<flutter::AppControl>();
   if (!app_control->handle()) {
     return -1;
@@ -27,6 +25,19 @@ DART_EXPORT FLUTTER_EXPORT uint32_t NativeCreateAppControl(Dart_Handle handle) {
       });
   flutter::AppControlManager::GetInstance().Insert(std::move(app_control));
   return id;
+}
+
+bool NativeAttachAppControl(int32_t id, Dart_Handle handle) {
+  auto app_control = flutter::AppControlManager::GetInstance().FindById(id);
+  if (!app_control || !app_control->handle()) {
+    return false;
+  }
+  Dart_NewFinalizableHandle_DL(
+      handle, app_control, 64, [](void* isolate_callback_data, void* peer) {
+        auto app_control = reinterpret_cast<flutter::AppControl*>(peer);
+        flutter::AppControlManager::GetInstance().Remove(app_control->id());
+      });
+  return true;
 }
 
 namespace flutter {

--- a/shell/platform/tizen/channels/app_control.cc
+++ b/shell/platform/tizen/channels/app_control.cc
@@ -14,7 +14,7 @@ DART_EXPORT FLUTTER_EXPORT intptr_t NativeInitializeDartApi(void* data) {
 }
 
 DART_EXPORT FLUTTER_EXPORT uint32_t NativeCreateAppControl(Dart_Handle handle) {
-  auto app_control = std::make_shared<flutter::AppControl>();
+  auto app_control = std::make_unique<flutter::AppControl>();
   if (!app_control->handle()) {
     return -1;
   }
@@ -264,17 +264,8 @@ AppControlResult AppControl::SendLaunchRequestWithReply(
   auto reply_callback = [](app_control_h request, app_control_h reply,
                            app_control_result_e result, void* user_data) {
     AppControl* app_control = static_cast<AppControl*>(user_data);
-    app_control_h clone = nullptr;
-    AppControlResult ret = app_control_clone(&clone, reply);
-    if (!ret) {
-      FT_LOG(Error) << "Could not clone app_control: " << ret.message();
-      return;
-    }
-
-    std::shared_ptr<AppControl> app_control_reply =
-        std::make_shared<AppControl>(clone);
+    auto app_control_reply = std::make_unique<AppControl>(reply);
     EncodableMap map;
-    map[EncodableValue("id")] = EncodableValue(app_control->id());
     map[EncodableValue("reply")] =
         app_control_reply->SerializeAppControlToMap();
     if (result == APP_CONTROL_RESULT_APP_STARTED) {
@@ -286,7 +277,6 @@ AppControlResult AppControl::SendLaunchRequestWithReply(
     } else if (result == APP_CONTROL_RESULT_CANCELED) {
       map[EncodableValue("result")] = EncodableValue("canceled");
     }
-
     app_control->on_reply_(EncodableValue(map));
     app_control->on_reply_ = nullptr;
     AppControlManager::GetInstance().Insert(std::move(app_control_reply));
@@ -300,7 +290,7 @@ AppControlResult AppControl::SendTerminateRequest() {
   return ret;
 }
 
-AppControlResult AppControl::Reply(std::shared_ptr<AppControl> reply,
+AppControlResult AppControl::Reply(AppControl* reply,
                                    const std::string& result) {
   app_control_result_e result_e;
   if (result == "appStarted") {

--- a/shell/platform/tizen/channels/app_control.cc
+++ b/shell/platform/tizen/channels/app_control.cc
@@ -4,18 +4,59 @@
 
 #include "app_control.h"
 
+#include "flutter/shell/platform/common/public/flutter_export.h"
 #include "flutter/shell/platform/tizen/channels/app_control_channel.h"
+#include "flutter/shell/platform/tizen/logger.h"
+#include "third_party/dart/runtime/include/dart_api_dl.h"
+
+DART_EXPORT FLUTTER_EXPORT intptr_t NativeInitializeDartApi(void* data) {
+  return Dart_InitializeApiDL(data);
+}
+
+DART_EXPORT FLUTTER_EXPORT uint32_t NativeCreateAppControl(Dart_Handle handle) {
+  auto app_control = std::make_shared<flutter::AppControl>();
+  if (!app_control->handle()) {
+    return -1;
+  }
+  auto id = app_control->id();
+  Dart_NewFinalizableHandle_DL(
+      handle, app_control.get(), 64,
+      [](void* isolate_callback_data, void* peer) {
+        auto app_control = reinterpret_cast<flutter::AppControl*>(peer);
+        flutter::AppControlManager::GetInstance().Remove(app_control->id());
+      });
+  flutter::AppControlManager::GetInstance().Insert(std::move(app_control));
+  return id;
+}
 
 namespace flutter {
 
-int AppControl::next_id_ = 0;
+int32_t AppControl::next_id_ = 0;
 
-AppControl::AppControl(app_control_h app_control) : id_(next_id_++) {
-  handle_ = app_control;
+AppControl::AppControl() : id_(next_id_++) {
+  app_control_h handle = nullptr;
+  AppControlResult ret = app_control_create(&handle);
+  if (!ret) {
+    FT_LOG(Error) << "app_control_create() failed: " << ret.message();
+    return;
+  }
+  handle_ = handle;
+}
+
+AppControl::AppControl(app_control_h handle) : id_(next_id_++) {
+  app_control_h clone = nullptr;
+  AppControlResult ret = app_control_clone(&clone, handle);
+  if (!ret) {
+    FT_LOG(Error) << "app_control_clone() failed: " << ret.message();
+    return;
+  }
+  handle_ = clone;
 }
 
 AppControl::~AppControl() {
-  app_control_destroy(handle_);
+  if (handle_) {
+    app_control_destroy(handle_);
+  }
 }
 
 AppControlResult AppControl::GetString(std::string& str,
@@ -109,14 +150,6 @@ AppControlResult AppControl::SetExtraData(const EncodableMap& map) {
   return AppControlResult();
 }
 
-void AppControl::SetManager(AppControlChannel* manager) {
-  manager_ = manager;
-}
-
-AppControlChannel* AppControl::GetManager() {
-  return manager_;
-}
-
 AppControlResult AppControl::GetOperation(std::string& operation) {
   return GetString(operation, app_control_get_operation);
 }
@@ -183,6 +216,12 @@ AppControlResult AppControl::SetLaunchMode(const std::string& launch_mode) {
   return AppControlResult(ret);
 }
 
+bool AppControl::IsReplyRequested() {
+  bool requested = false;
+  app_control_is_reply_requested(handle_, &requested);
+  return requested;
+}
+
 EncodableValue AppControl::SerializeAppControlToMap() {
   std::string app_id, operation, mime, category, uri, caller_id, launch_mode;
   AppControlResult results[7];
@@ -202,31 +241,28 @@ EncodableValue AppControl::SerializeAppControlToMap() {
     }
   }
   EncodableMap map;
-  map[EncodableValue("id")] = EncodableValue(GetId());
+  map[EncodableValue("id")] = EncodableValue(id());
   map[EncodableValue("appId")] = EncodableValue(app_id);
   map[EncodableValue("operation")] = EncodableValue(operation);
   map[EncodableValue("mime")] = EncodableValue(mime);
   map[EncodableValue("category")] = EncodableValue(category);
   map[EncodableValue("uri")] = EncodableValue(uri);
-  map[EncodableValue("callerId")] = EncodableValue(caller_id);
+  map[EncodableValue("callerAppId")] = EncodableValue(caller_id);
   map[EncodableValue("launchMode")] = EncodableValue(launch_mode);
   map[EncodableValue("extraData")] = EncodableValue(extra_data);
+  map[EncodableValue("shouldReply")] = EncodableValue(IsReplyRequested());
 
   return EncodableValue(map);
 }
 
 AppControlResult AppControl::SendLaunchRequest() {
-  AppControlResult ret =
-      app_control_send_launch_request(handle_, nullptr, nullptr);
-  return ret;
+  return app_control_send_launch_request(handle_, nullptr, nullptr);
 }
 
 AppControlResult AppControl::SendLaunchRequestWithReply(
-    std::shared_ptr<EventSink<EncodableValue>> reply_sink,
-    AppControlChannel* manager) {
-  SetManager(manager);
-  auto on_reply = [](app_control_h request, app_control_h reply,
-                     app_control_result_e result, void* user_data) {
+    ReplyCallback on_reply) {
+  auto reply_callback = [](app_control_h request, app_control_h reply,
+                           app_control_result_e result, void* user_data) {
     AppControl* app_control = static_cast<AppControl*>(user_data);
     app_control_h clone = nullptr;
     AppControlResult ret = app_control_clone(&clone, reply);
@@ -238,7 +274,7 @@ AppControlResult AppControl::SendLaunchRequestWithReply(
     std::shared_ptr<AppControl> app_control_reply =
         std::make_shared<AppControl>(clone);
     EncodableMap map;
-    map[EncodableValue("id")] = EncodableValue(app_control->GetId());
+    map[EncodableValue("id")] = EncodableValue(app_control->id());
     map[EncodableValue("reply")] =
         app_control_reply->SerializeAppControlToMap();
     if (result == APP_CONTROL_RESULT_APP_STARTED) {
@@ -251,14 +287,12 @@ AppControlResult AppControl::SendLaunchRequestWithReply(
       map[EncodableValue("result")] = EncodableValue("canceled");
     }
 
-    app_control->reply_sink_->Success(EncodableValue(map));
-    app_control->GetManager()->AddExistingAppControl(
-        std::move(app_control_reply));
+    app_control->on_reply_(EncodableValue(map));
+    app_control->on_reply_ = nullptr;
+    AppControlManager::GetInstance().Insert(std::move(app_control_reply));
   };
-  reply_sink_ = std::move(reply_sink);
-  AppControlResult ret =
-      app_control_send_launch_request(handle_, on_reply, this);
-  return ret;
+  on_reply_ = on_reply;
+  return app_control_send_launch_request(handle_, reply_callback, this);
 }
 
 AppControlResult AppControl::SendTerminateRequest() {
@@ -281,7 +315,7 @@ AppControlResult AppControl::Reply(std::shared_ptr<AppControl> reply,
     return AppControlResult(APP_CONTROL_ERROR_INVALID_PARAMETER);
   }
   AppControlResult ret = app_control_reply_to_launch_request(
-      reply->Handle(), this->handle_, result_e);
+      reply->handle(), this->handle_, result_e);
   return ret;
 }
 

--- a/shell/platform/tizen/channels/app_control.h
+++ b/shell/platform/tizen/channels/app_control.h
@@ -7,9 +7,10 @@
 
 #include <app.h>
 
+#include <unordered_map>
+
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/event_channel.h"
-#include "flutter/shell/platform/tizen/logger.h"
 
 namespace flutter {
 
@@ -29,11 +30,14 @@ class AppControlChannel;
 
 class AppControl {
  public:
-  AppControl(app_control_h app_control);
-  ~AppControl();
+  using ReplyCallback = std::function<void(const EncodableValue& response)>;
 
-  int GetId() { return id_; }
-  app_control_h Handle() { return handle_; }
+  explicit AppControl();
+  explicit AppControl(app_control_h handle);
+  virtual ~AppControl();
+
+  int32_t id() { return id_; }
+  app_control_h handle() { return handle_; }
 
   AppControlResult GetOperation(std::string& operation);
   AppControlResult SetOperation(const std::string& operation);
@@ -48,13 +52,12 @@ class AppControl {
   AppControlResult GetCaller(std::string& caller);
   AppControlResult GetLaunchMode(std::string& launch_mode);
   AppControlResult SetLaunchMode(const std::string& launch_mode);
+  bool IsReplyRequested();
 
   EncodableValue SerializeAppControlToMap();
 
   AppControlResult SendLaunchRequest();
-  AppControlResult SendLaunchRequestWithReply(
-      std::shared_ptr<EventSink<EncodableValue>> reply_sink,
-      AppControlChannel* manager);
+  AppControlResult SendLaunchRequestWithReply(ReplyCallback on_reply);
   AppControlResult SendTerminateRequest();
 
   AppControlResult Reply(std::shared_ptr<AppControl> reply,
@@ -62,9 +65,6 @@ class AppControl {
 
   AppControlResult GetExtraData(EncodableMap& value);
   AppControlResult SetExtraData(const EncodableMap& value);
-
-  void SetManager(AppControlChannel* manager);
-  AppControlChannel* GetManager();
 
  private:
   AppControlResult GetString(std::string& str, int func(app_control_h, char**));
@@ -74,12 +74,38 @@ class AppControl {
   AppControlResult AddExtraData(std::string key, EncodableValue value);
   AppControlResult AddExtraDataList(std::string& key, EncodableList& list);
 
-  app_control_h handle_;
-  int id_;
-  static int next_id_;
-  std::shared_ptr<EventSink<EncodableValue>> reply_sink_;
+  app_control_h handle_ = nullptr;
+  int32_t id_;
+  static int32_t next_id_;
+  ReplyCallback on_reply_ = nullptr;
+};
 
-  AppControlChannel* manager_;
+class AppControlManager {
+ public:
+  // Returns an instance of this class.
+  static AppControlManager& GetInstance() {
+    static AppControlManager instance;
+    return instance;
+  }
+
+  void Insert(std::shared_ptr<AppControl> app_control) {
+    map_.insert({app_control->id(), std::move(app_control)});
+  }
+
+  void Remove(int32_t id) { map_.erase(id); }
+
+  std::shared_ptr<AppControl> FindById(const int32_t id) {
+    if (map_.find(id) == map_.end()) {
+      return nullptr;
+    }
+    return map_[id];
+  }
+
+ private:
+  explicit AppControlManager() {}
+  ~AppControlManager() {}
+
+  std::unordered_map<int32_t, std::shared_ptr<AppControl>> map_;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/channels/app_control.h
+++ b/shell/platform/tizen/channels/app_control.h
@@ -11,6 +11,30 @@
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/event_channel.h"
+#include "flutter/shell/platform/common/public/flutter_export.h"
+#include "third_party/dart/runtime/include/dart_api_dl.h"
+
+// Called by Dart code through FFI to initialize dart_api_dl.h.
+DART_EXPORT FLUTTER_EXPORT intptr_t NativeInitializeDartApi(void* data);
+
+// Creates an internally managed instance of AppControl and associates with
+// |handle|.
+//
+// A finalizer is attached to the created instance and invoked when the
+// associated |handle| is disposed by GC.
+//
+// Returns a unique AppControl ID on success, otherwise -1.
+DART_EXPORT FLUTTER_EXPORT int32_t NativeCreateAppControl(Dart_Handle handle);
+
+// Finds an instance of AppControl with |id| and associates with |handle|.
+//
+// A finalizer is attached to the instance and invoked when the associated
+// |handle| is disposed by GC.
+//
+// Returns false if an instance of AppControl with the given |id| could not
+// be found, otherwise true.
+DART_EXPORT FLUTTER_EXPORT bool NativeAttachAppControl(int32_t id,
+                                                       Dart_Handle handle);
 
 namespace flutter {
 

--- a/shell/platform/tizen/channels/app_control.h
+++ b/shell/platform/tizen/channels/app_control.h
@@ -26,8 +26,6 @@ struct AppControlResult {
   int error_code;
 };
 
-class AppControlChannel;
-
 class AppControl {
  public:
   using ReplyCallback = std::function<void(const EncodableValue& response)>;
@@ -60,8 +58,7 @@ class AppControl {
   AppControlResult SendLaunchRequestWithReply(ReplyCallback on_reply);
   AppControlResult SendTerminateRequest();
 
-  AppControlResult Reply(std::shared_ptr<AppControl> reply,
-                         const std::string& result);
+  AppControlResult Reply(AppControl* reply, const std::string& result);
 
   AppControlResult GetExtraData(EncodableMap& value);
   AppControlResult SetExtraData(const EncodableMap& value);
@@ -88,24 +85,24 @@ class AppControlManager {
     return instance;
   }
 
-  void Insert(std::shared_ptr<AppControl> app_control) {
+  void Insert(std::unique_ptr<AppControl> app_control) {
     map_.insert({app_control->id(), std::move(app_control)});
   }
 
   void Remove(int32_t id) { map_.erase(id); }
 
-  std::shared_ptr<AppControl> FindById(const int32_t id) {
+  AppControl* FindById(const int32_t id) {
     if (map_.find(id) == map_.end()) {
       return nullptr;
     }
-    return map_[id];
+    return map_[id].get();
   }
 
  private:
   explicit AppControlManager() {}
   ~AppControlManager() {}
 
-  std::unordered_map<int32_t, std::shared_ptr<AppControl>> map_;
+  std::unordered_map<int32_t, std::unique_ptr<AppControl>> map_;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -51,7 +51,7 @@ void AppControlChannel::NotifyAppControl(void* handle) {
   auto app_control =
       std::make_unique<AppControl>(static_cast<app_control_h>(handle));
   if (!app_control->handle()) {
-    FT_LOG(Error) << "Could not clone AppControl.";
+    FT_LOG(Error) << "Could not create an instance of AppControl.";
     return;
   }
   if (!event_sink_) {

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -47,18 +47,18 @@ AppControlChannel::AppControlChannel(BinaryMessenger* messenger) {
 
 AppControlChannel::~AppControlChannel() {}
 
-void AppControlChannel::NotifyAppControl(void* h) {
-  auto handle = static_cast<app_control_h>(h);
-  auto app_control = std::make_shared<AppControl>(handle);
+void AppControlChannel::NotifyAppControl(void* handle) {
+  auto app_control =
+      std::make_unique<AppControl>(static_cast<app_control_h>(handle));
   if (!app_control->handle()) {
     FT_LOG(Error) << "Could not clone AppControl.";
     return;
   }
   if (!event_sink_) {
     FT_LOG(Info) << "EventChannel not set yet.";
-    queue_.push(app_control);
+    queue_.push(app_control.get());
   } else {
-    SendAppControlDataEvent(app_control);
+    SendAppControlDataEvent(app_control.get());
   }
   AppControlManager::GetInstance().Insert(std::move(app_control));
 }
@@ -114,8 +114,7 @@ void AppControlChannel::SendAlreadyQueuedEvents() {
   }
 }
 
-std::shared_ptr<AppControl> AppControlChannel::GetAppControl(
-    const EncodableValue* arguments) {
+AppControl* AppControlChannel::GetAppControl(const EncodableValue* arguments) {
   auto map_ptr = std::get_if<EncodableMap>(arguments);
   if (!map_ptr) {
     FT_LOG(Error) << "Invalid arguments.";
@@ -148,14 +147,14 @@ void AppControlChannel::CreateAppControl(
 }
 
 void AppControlChannel::Dispose(
-    std::shared_ptr<AppControl> app_control,
+    AppControl* app_control,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
   AppControlManager::GetInstance().Remove(app_control->id());
   result->Success();
 }
 
 void AppControlChannel::Reply(
-    std::shared_ptr<AppControl> app_control,
+    AppControl* app_control,
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
   auto map_ptr = std::get_if<EncodableMap>(arguments);
@@ -191,7 +190,7 @@ void AppControlChannel::Reply(
 }
 
 void AppControlChannel::SendLaunchRequest(
-    std::shared_ptr<AppControl> app_control,
+    AppControl* app_control,
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
   auto map_ptr = std::get_if<EncodableMap>(arguments);
@@ -223,7 +222,7 @@ void AppControlChannel::SendLaunchRequest(
 }
 
 void AppControlChannel::SendTerminateRequest(
-    std::shared_ptr<AppControl> app_control,
+    AppControl* app_control,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
   AppControlResult ret = app_control->SendTerminateRequest();
   if (ret) {
@@ -234,7 +233,7 @@ void AppControlChannel::SendTerminateRequest(
 }
 
 void AppControlChannel::SetAppControlData(
-    std::shared_ptr<AppControl> app_control,
+    AppControl* app_control,
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
   auto map_ptr = std::get_if<EncodableMap>(arguments);
@@ -283,8 +282,7 @@ void AppControlChannel::SetAppControlData(
   result->Success();
 }
 
-void AppControlChannel::SendAppControlDataEvent(
-    std::shared_ptr<AppControl> app_control) {
+void AppControlChannel::SendAppControlDataEvent(AppControl* app_control) {
   EncodableValue map = app_control->SerializeAppControlToMap();
   if (!map.IsNull()) {
     event_sink_->Success(map);

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -7,6 +7,7 @@
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/event_stream_handler_functions.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
 #include "flutter/shell/platform/tizen/channels/encodable_value_holder.h"
+#include "flutter/shell/platform/tizen/logger.h"
 
 namespace flutter {
 
@@ -14,7 +15,6 @@ namespace {
 
 constexpr char kChannelName[] = "tizen/internal/app_control_method";
 constexpr char kEventChannelName[] = "tizen/internal/app_control_event";
-constexpr char kReplyChannelName[] = "tizen/internal/app_control_reply";
 
 }  // namespace
 
@@ -43,44 +43,24 @@ AppControlChannel::AppControlChannel(BinaryMessenger* messenger) {
       });
 
   event_channel_->SetStreamHandler(std::move(event_channel_handler));
-
-  reply_channel_ = std::make_unique<EventChannel<EncodableValue>>(
-      messenger, kReplyChannelName, &StandardMethodCodec::GetInstance());
-
-  auto reply_channel_handler = std::make_unique<StreamHandlerFunctions<>>(
-      [this](const EncodableValue* arguments,
-             std::unique_ptr<EventSink<>>&& events)
-          -> std::unique_ptr<StreamHandlerError<>> {
-        RegisterReplyHandler(std::move(events));
-        return nullptr;
-      },
-      [this](const EncodableValue* arguments)
-          -> std::unique_ptr<StreamHandlerError<>> {
-        UnregisterReplyHandler();
-        return nullptr;
-      });
-
-  reply_channel_->SetStreamHandler(std::move(reply_channel_handler));
 }
 
 AppControlChannel::~AppControlChannel() {}
 
-void AppControlChannel::NotifyAppControl(void* app_control) {
-  app_control_h clone = nullptr;
-  app_control_h handle = static_cast<app_control_h>(app_control);
-  AppControlResult ret = app_control_clone(&clone, handle);
-  if (!ret) {
-    FT_LOG(Error) << "Could not clone app control: " << ret.message();
+void AppControlChannel::NotifyAppControl(void* h) {
+  auto handle = static_cast<app_control_h>(h);
+  auto app_control = std::make_shared<AppControl>(handle);
+  if (!app_control->handle()) {
+    FT_LOG(Error) << "Could not clone AppControl.";
     return;
   }
-  auto app = std::make_shared<AppControl>(clone);
   if (!event_sink_) {
-    queue_.push(app);
     FT_LOG(Info) << "EventChannel not set yet.";
+    queue_.push(app_control);
   } else {
-    SendAppControlDataEvent(app);
+    SendAppControlDataEvent(app_control);
   }
-  map_.insert({app->GetId(), app});
+  AppControlManager::GetInstance().Insert(std::move(app_control));
 }
 
 void AppControlChannel::HandleMethodCall(
@@ -134,15 +114,6 @@ void AppControlChannel::SendAlreadyQueuedEvents() {
   }
 }
 
-void AppControlChannel::RegisterReplyHandler(
-    std::unique_ptr<EventSink<EncodableValue>> events) {
-  reply_sink_ = std::move(events);
-}
-
-void AppControlChannel::UnregisterReplyHandler() {
-  reply_sink_.reset();
-}
-
 std::shared_ptr<AppControl> AppControlChannel::GetAppControl(
     const EncodableValue* arguments) {
   auto map_ptr = std::get_if<EncodableMap>(arguments);
@@ -151,36 +122,35 @@ std::shared_ptr<AppControl> AppControlChannel::GetAppControl(
     return nullptr;
   }
 
-  EncodableValueHolder<int> id(map_ptr, "id");
+  EncodableValueHolder<int32_t> id(map_ptr, "id");
   if (!id) {
     FT_LOG(Error) << "Could not get proper id from arguments.";
     return nullptr;
   }
 
-  if (map_.find(*id) == map_.end()) {
+  auto app_control = AppControlManager::GetInstance().FindById(*id);
+  if (!app_control) {
     FT_LOG(Error) << "Could not find AppControl with id " << *id;
     return nullptr;
   }
-  return map_[*id];
+  return app_control;
 }
 
 void AppControlChannel::CreateAppControl(
     std::unique_ptr<MethodResult<EncodableValue>> result) {
-  app_control_h app_control = nullptr;
-  AppControlResult ret = app_control_create(&app_control);
-  if (!ret) {
-    result->Error("Could not create AppControl", ret.message());
+  auto app_control = std::make_unique<AppControl>();
+  if (app_control->handle()) {
+    result->Success(EncodableValue(app_control->id()));
+    AppControlManager::GetInstance().Insert(std::move(app_control));
+  } else {
+    result->Error("Internal error", "Could not create AppControl.");
   }
-  auto app = std::make_unique<AppControl>(app_control);
-  int id = app->GetId();
-  map_.insert({id, std::move(app)});
-  result->Success(EncodableValue(id));
 }
 
 void AppControlChannel::Dispose(
     std::shared_ptr<AppControl> app_control,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
-  map_.erase(app_control->GetId());
+  AppControlManager::GetInstance().Remove(app_control->id());
   result->Success();
 }
 
@@ -194,13 +164,19 @@ void AppControlChannel::Reply(
     return;
   }
 
-  EncodableValueHolder<int> request_id(map_ptr, "requestId");
-  if (!request_id || map_.find(*request_id) == map_.end()) {
-    result->Error("Could not reply", "Invalid request app control");
+  EncodableValueHolder<int32_t> request_id(map_ptr, "requestId");
+  if (!request_id) {
+    result->Error("Invalid arguments", "Invalid requestId parameter");
+    return;
+  }
+  auto request_app_control =
+      AppControlManager::GetInstance().FindById(*request_id);
+  if (!request_app_control) {
+    result->Error("Invalid arguments",
+                  "Could not find AppControl with the given ID.");
     return;
   }
 
-  auto request_app_control = map_[*request_id];
   EncodableValueHolder<std::string> result_str(map_ptr, "result");
   if (!result_str) {
     result->Error("Could not reply", "Invalid result parameter");
@@ -225,18 +201,24 @@ void AppControlChannel::SendLaunchRequest(
   }
 
   EncodableValueHolder<bool> wait_for_reply(map_ptr, "waitForReply");
-
-  AppControlResult ret;
   if (wait_for_reply && *wait_for_reply) {
-    ret = app_control->SendLaunchRequestWithReply(std::move(reply_sink_), this);
+    auto result_ptr = result.release();
+    auto on_reply = [result_ptr](const EncodableValue& response) {
+      result_ptr->Success(response);
+      delete result_ptr;
+    };
+    AppControlResult ret = app_control->SendLaunchRequestWithReply(on_reply);
+    if (!ret) {
+      result_ptr->Error(ret.message());
+      delete result_ptr;
+    }
   } else {
-    ret = app_control->SendLaunchRequest();
-  }
-
-  if (ret) {
-    result->Success();
-  } else {
-    result->Error(ret.message());
+    AppControlResult ret = app_control->SendLaunchRequest();
+    if (ret) {
+      result->Success();
+    } else {
+      result->Error(ret.message());
+    }
   }
 }
 

--- a/shell/platform/tizen/channels/app_control_channel.h
+++ b/shell/platform/tizen/channels/app_control_channel.h
@@ -30,26 +30,26 @@ class AppControlChannel {
   void UnregisterEventHandler();
   void SendAlreadyQueuedEvents();
 
-  std::shared_ptr<AppControl> GetAppControl(const EncodableValue* arguments);
+  AppControl* GetAppControl(const EncodableValue* arguments);
 
   void CreateAppControl(std::unique_ptr<MethodResult<EncodableValue>> result);
 
-  void Dispose(std::shared_ptr<AppControl> app_control,
+  void Dispose(AppControl* app_control,
                std::unique_ptr<MethodResult<EncodableValue>> result);
-  void Reply(std::shared_ptr<AppControl> app_control,
+  void Reply(AppControl* app_control,
              const EncodableValue* arguments,
              std::unique_ptr<MethodResult<EncodableValue>> result);
-  void SendLaunchRequest(std::shared_ptr<AppControl> app_control,
+  void SendLaunchRequest(AppControl* app_control,
                          const EncodableValue* arguments,
                          std::unique_ptr<MethodResult<EncodableValue>> result);
   void SendTerminateRequest(
-      std::shared_ptr<AppControl> app_control,
+      AppControl* app_control,
       std::unique_ptr<MethodResult<EncodableValue>> result);
 
-  void SetAppControlData(std::shared_ptr<AppControl> app_control,
+  void SetAppControlData(AppControl* app_control,
                          const EncodableValue* arguments,
                          std::unique_ptr<MethodResult<EncodableValue>> result);
-  void SendAppControlDataEvent(std::shared_ptr<AppControl> app_control);
+  void SendAppControlDataEvent(AppControl* app_control);
 
   std::unique_ptr<MethodChannel<EncodableValue>> method_channel_;
   std::unique_ptr<EventChannel<EncodableValue>> event_channel_;
@@ -58,7 +58,7 @@ class AppControlChannel {
   // We need this queue, because there is no quarantee
   // that EventChannel on Dart side will be registered
   // before native OnAppControl event
-  std::queue<std::shared_ptr<AppControl>> queue_;
+  std::queue<AppControl*> queue_;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/channels/app_control_channel.h
+++ b/shell/platform/tizen/channels/app_control_channel.h
@@ -7,14 +7,12 @@
 
 #include <memory>
 #include <queue>
-#include <unordered_map>
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/event_channel.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
 #include "flutter/shell/platform/tizen/channels/app_control.h"
-#include "flutter/shell/platform/tizen/logger.h"
 
 namespace flutter {
 
@@ -25,19 +23,12 @@ class AppControlChannel {
 
   void NotifyAppControl(void* app_control);
 
-  void AddExistingAppControl(std::shared_ptr<AppControl> app_control) {
-    map_.insert({app_control->GetId(), app_control});
-  }
-
  private:
   void HandleMethodCall(const MethodCall<EncodableValue>& method_call,
                         std::unique_ptr<MethodResult<EncodableValue>> result);
   void RegisterEventHandler(std::unique_ptr<EventSink<EncodableValue>> events);
   void UnregisterEventHandler();
   void SendAlreadyQueuedEvents();
-
-  void RegisterReplyHandler(std::unique_ptr<EventSink<EncodableValue>> events);
-  void UnregisterReplyHandler();
 
   std::shared_ptr<AppControl> GetAppControl(const EncodableValue* arguments);
 
@@ -62,16 +53,12 @@ class AppControlChannel {
 
   std::unique_ptr<MethodChannel<EncodableValue>> method_channel_;
   std::unique_ptr<EventChannel<EncodableValue>> event_channel_;
-  std::unique_ptr<EventChannel<EncodableValue>> reply_channel_;
   std::unique_ptr<EventSink<EncodableValue>> event_sink_;
-  std::shared_ptr<EventSink<EncodableValue>> reply_sink_;
 
   // We need this queue, because there is no quarantee
   // that EventChannel on Dart side will be registered
   // before native OnAppControl event
   std::queue<std::shared_ptr<AppControl>> queue_;
-
-  std::unordered_map<int, std::shared_ptr<AppControl>> map_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Part of https://github.com/flutter-tizen/flutter-tizen/issues/210.

Changes:

- The reply channel and related code are completely removed. The `sendLaunchRequest` method now returns the response as a `Map<String, dynamic>` if `waitForReply` is true.
- API changes: Change `callerId` to `callerAppId` and newly implement `shouldReply`.
- Create a dedicated `AppControlManager` for managing AppControl instances. They were previously managed by `AppControlChannel`.
- Minor changes. e.g. Change the type of AppControl IDs from `int` to `int32_t`, and use `unique_ptr` instead of `shared_ptr`.

Newly exported APIs:

- The following new APIs were added to support automatic disposal of native app_control handles associated with Dart objects.
  - `NativeInitializeDartApi`
  - `NativeCreateAppControl`
  - `NativeAttachAppControl`
- The usage can be found [here](https://github.com/swift-kim/plugins/blob/add-tizen-app-control/packages/tizen_app_control/lib/src/ffi.dart). Native handles created in this way do not need to be destroyed explicitly. The destruction callback is automatically called during GC. (The `create` and `dispose` methods are still supported just for backward compatibility.)
- Refer to https://github.com/dart-lang/sdk/issues/35770 for detailed information.
- Please suggest better design and naming for these APIs!
- `NativeInitializeDartApi` may be moved outside `app_control.cc` if more FFI functions are added in the future.

Notes:
- Any existing code that uses app_control channels should still work after this change unless the code uses the reply channel.
- The Dart wrapper of app_control channels is being worked in https://github.com/swift-kim/plugins/tree/add-tizen-app-control/packages/tizen_app_control. The package contains an example app so you can test this change with it.
- I checked all native handles are properly disposed after GC (no memory leak) using the example app:<p>
  ```dart
  E/ConsoleMessage( 9853): app_control.cc: AppControl(49) > Create AppControl 1
  E/ConsoleMessage( 9853): app_control.cc: AppControl(49) > Create AppControl 2
  E/ConsoleMessage( 9853): app_control.cc: ~AppControl(75) > Destroy AppControl 1
  E/ConsoleMessage( 9853): app_control.cc: ~AppControl(75) > Destroy AppControl 2
  E/ConsoleMessage( 9853): app_control.cc: AppControl(49) > Create AppControl 3
  E/ConsoleMessage( 9853): app_control.cc: AppControl(62) > Create AppControl 4
  E/ConsoleMessage( 9853): app_control.cc: ~AppControl(75) > Destroy AppControl 3
  E/ConsoleMessage( 9853): app_control.cc: ~AppControl(75) > Destroy AppControl 4
  E/ConsoleMessage( 9853): app_control.cc: AppControl(49) > Create AppControl 5
  E/ConsoleMessage( 9853): app_control.cc: AppControl(62) > Create AppControl 6
  E/ConsoleMessage( 9853): app_control.cc: AppControl(49) > Create AppControl 7
  E/ConsoleMessage( 9853): app_control.cc: AppControl(62) > Create AppControl 8
  E/ConsoleMessage( 9853): app_control.cc: ~AppControl(75) > Destroy AppControl 7
  E/ConsoleMessage( 9853): app_control.cc: ~AppControl(75) > Destroy AppControl 5
  E/ConsoleMessage( 9853): app_control.cc: ~AppControl(75) > Destroy AppControl 6
  E/ConsoleMessage( 9853): app_control.cc: ~AppControl(75) > Destroy AppControl 8
  E/ConsoleMessage( 9853): app_control.cc: AppControl(49) > Create AppControl 9
  E/ConsoleMessage( 9853): app_control.cc: AppControl(62) > Create AppControl 10
  E/ConsoleMessage( 9853): app_control.cc: ~AppControl(75) > Destroy AppControl 10
  E/ConsoleMessage( 9853): app_control.cc: ~AppControl(75) > Destroy AppControl 9
  ```
- I'll do some more refactoring after this change. I tried not to make style changes other than logic changes in this PR.