### PR TITLE
Refactor AppControl and AppControlChannel

### DIFF
--- a/shell/platform/tizen/channels/app_control.cc
+++ b/shell/platform/tizen/channels/app_control.cc
@@ -250,7 +250,7 @@ AppControlResult AppControl::SetExtraData(const EncodableMap& map) {
 }
 
 AppControlResult AppControl::GetCaller(std::string& caller) {
-  return GetString(caller, &app_control_get_caller);
+  return GetString(caller, app_control_get_caller);
 }
 
 AppControlResult AppControl::IsReplyRequested(bool& value) {
@@ -270,27 +270,32 @@ EncodableValue AppControl::SerializeToMap() {
   results[6] = GetExtraData(extra_data);
   for (AppControlResult result : results) {
     if (!result) {
-      FT_LOG(Error) << "Failed to serialize AppControl data: "
+      FT_LOG(Error) << "Failed to serialize application control data: "
                     << result.message();
-      return EncodableValue(EncodableMap());
+      return EncodableValue();
     }
   }
-
-  std::string caller_app_id;
-  GetCaller(caller_app_id);
+  std::string caller;
   bool should_reply = false;
+  GetCaller(caller);
   IsReplyRequested(should_reply);
 
   EncodableMap map;
   map[EncodableValue("id")] = EncodableValue(id_);
-  map[EncodableValue("appId")] = EncodableValue(app_id);
-  map[EncodableValue("operation")] = EncodableValue(operation);
-  map[EncodableValue("mime")] = EncodableValue(mime);
-  map[EncodableValue("category")] = EncodableValue(category);
-  map[EncodableValue("uri")] = EncodableValue(uri);
+  map[EncodableValue("appId")] =
+      app_id.empty() ? EncodableValue() : EncodableValue(app_id);
+  map[EncodableValue("operation")] =
+      operation.empty() ? EncodableValue() : EncodableValue(operation);
+  map[EncodableValue("uri")] =
+      uri.empty() ? EncodableValue() : EncodableValue(uri);
+  map[EncodableValue("mime")] =
+      mime.empty() ? EncodableValue() : EncodableValue(mime);
+  map[EncodableValue("category")] =
+      category.empty() ? EncodableValue() : EncodableValue(category);
   map[EncodableValue("launchMode")] = EncodableValue(launch_mode);
   map[EncodableValue("extraData")] = EncodableValue(extra_data);
-  map[EncodableValue("callerAppId")] = EncodableValue(caller_app_id);
+  map[EncodableValue("callerAppId")] =
+      caller.empty() ? EncodableValue() : EncodableValue(caller);
   map[EncodableValue("shouldReply")] = EncodableValue(should_reply);
   return EncodableValue(map);
 }
@@ -304,12 +309,9 @@ AppControlResult AppControl::SendLaunchRequestWithReply(
   auto reply_callback = [](app_control_h request, app_control_h reply,
                            app_control_result_e result, void* user_data) {
     auto app_control = static_cast<AppControl*>(user_data);
-    EncodableMap map;
-
     auto reply_app_control = std::make_unique<AppControl>(reply);
+    EncodableMap map;
     map[EncodableValue("reply")] = reply_app_control->SerializeToMap();
-    AppControlManager::GetInstance().Insert(std::move(reply_app_control));
-
     if (result == APP_CONTROL_RESULT_APP_STARTED) {
       map[EncodableValue("result")] = EncodableValue("appStarted");
     } else if (result == APP_CONTROL_RESULT_SUCCEEDED) {
@@ -319,6 +321,7 @@ AppControlResult AppControl::SendLaunchRequestWithReply(
     } else if (result == APP_CONTROL_RESULT_CANCELED) {
       map[EncodableValue("result")] = EncodableValue("canceled");
     }
+    AppControlManager::GetInstance().Insert(std::move(reply_app_control));
     app_control->on_reply_(EncodableValue(map));
     app_control->on_reply_ = nullptr;
   };

--- a/shell/platform/tizen/channels/app_control.cc
+++ b/shell/platform/tizen/channels/app_control.cc
@@ -72,44 +72,65 @@ AppControl::~AppControl() {
   }
 }
 
-AppControlResult AppControl::GetAppId(char** app_id) {
-  return app_control_get_app_id(handle_, app_id);
+AppControlResult AppControl::GetString(std::string& string,
+                                       int func(app_control_h, char**)) {
+  char* output;
+  AppControlResult ret = func(handle_, &output);
+  if (!ret) {
+    return ret;
+  }
+  if (output) {
+    string = output;
+    free(output);
+  } else {
+    string = "";
+  }
+  return APP_CONTROL_ERROR_NONE;
 }
 
-AppControlResult AppControl::SetAppId(const char* app_id) {
-  return app_control_set_app_id(handle_, app_id);
+AppControlResult AppControl::SetString(const std::string& string,
+                                       int func(app_control_h, const char*)) {
+  return func(handle_, string.c_str());
 }
 
-AppControlResult AppControl::GetOperation(char** operation) {
-  return app_control_get_operation(handle_, operation);
+AppControlResult AppControl::GetAppId(std::string& app_id) {
+  return GetString(app_id, app_control_get_app_id);
 }
 
-AppControlResult AppControl::SetOperation(const char* operation) {
-  return app_control_set_operation(handle_, operation);
+AppControlResult AppControl::SetAppId(const std::string& app_id) {
+  return SetString(app_id, app_control_set_app_id);
 }
 
-AppControlResult AppControl::GetUri(char** uri) {
-  return app_control_get_uri(handle_, uri);
+AppControlResult AppControl::GetOperation(std::string& operation) {
+  return GetString(operation, app_control_get_operation);
 }
 
-AppControlResult AppControl::SetUri(const char* uri) {
-  return app_control_set_uri(handle_, uri);
+AppControlResult AppControl::SetOperation(const std::string& operation) {
+  return SetString(operation, app_control_set_operation);
 }
 
-AppControlResult AppControl::GetMime(char** mime) {
-  return app_control_get_mime(handle_, mime);
+AppControlResult AppControl::GetUri(std::string& uri) {
+  return GetString(uri, app_control_get_uri);
 }
 
-AppControlResult AppControl::SetMime(const char* mime) {
-  return app_control_set_mime(handle_, mime);
+AppControlResult AppControl::SetUri(const std::string& uri) {
+  return SetString(uri, app_control_set_uri);
 }
 
-AppControlResult AppControl::GetCategory(char** category) {
-  return app_control_get_category(handle_, category);
+AppControlResult AppControl::GetMime(std::string& mime) {
+  return GetString(mime, app_control_get_mime);
 }
 
-AppControlResult AppControl::SetCategory(const char* category) {
-  return app_control_set_category(handle_, category);
+AppControlResult AppControl::SetMime(const std::string& mime) {
+  return SetString(mime, app_control_set_mime);
+}
+
+AppControlResult AppControl::GetCategory(std::string& category) {
+  return GetString(category, app_control_get_category);
+}
+
+AppControlResult AppControl::SetCategory(const std::string& category) {
+  return SetString(category, app_control_set_category);
 }
 
 AppControlResult AppControl::GetLaunchMode(std::string& launch_mode) {
@@ -228,8 +249,8 @@ AppControlResult AppControl::SetExtraData(const EncodableMap& map) {
   return AppControlResult();
 }
 
-AppControlResult AppControl::GetCaller(char** caller) {
-  return app_control_get_caller(handle_, caller);
+AppControlResult AppControl::GetCaller(std::string& caller) {
+  return GetString(caller, &app_control_get_caller);
 }
 
 AppControlResult AppControl::IsReplyRequested(bool& value) {
@@ -238,15 +259,14 @@ AppControlResult AppControl::IsReplyRequested(bool& value) {
 
 EncodableValue AppControl::SerializeToMap() {
   AppControlResult results[7];
-  char *app_id, *operation, *uri, *mime, *category;
-  results[0] = GetAppId(&app_id);
-  results[1] = GetOperation(&operation);
-  results[2] = GetUri(&uri);
-  results[3] = GetMime(&mime);
-  results[4] = GetCategory(&category);
-  std::string launch_mode;
-  results[5] = GetLaunchMode(launch_mode);
+  std::string app_id, operation, uri, mime, category, launch_mode;
   EncodableMap extra_data;
+  results[0] = GetAppId(app_id);
+  results[1] = GetOperation(operation);
+  results[2] = GetUri(uri);
+  results[3] = GetMime(mime);
+  results[4] = GetCategory(category);
+  results[5] = GetLaunchMode(launch_mode);
   results[6] = GetExtraData(extra_data);
   for (AppControlResult result : results) {
     if (!result) {
@@ -255,8 +275,9 @@ EncodableValue AppControl::SerializeToMap() {
       return EncodableValue(EncodableMap());
     }
   }
-  char* caller_app_id;
-  GetCaller(&caller_app_id);
+
+  std::string caller_app_id;
+  GetCaller(caller_app_id);
   bool should_reply = false;
   IsReplyRequested(should_reply);
 

--- a/shell/platform/tizen/channels/app_control.cc
+++ b/shell/platform/tizen/channels/app_control.cc
@@ -72,65 +72,44 @@ AppControl::~AppControl() {
   }
 }
 
-AppControlResult AppControl::GetString(std::string& string,
-                                       int func(app_control_h, char**)) {
-  char* output;
-  AppControlResult ret = func(handle_, &output);
-  if (!ret) {
-    return ret;
-  }
-  if (output) {
-    string = output;
-    free(output);
-  } else {
-    string = "";
-  }
-  return APP_CONTROL_ERROR_NONE;
+AppControlResult AppControl::GetAppId(char** app_id) {
+  return app_control_get_app_id(handle_, app_id);
 }
 
-AppControlResult AppControl::SetString(const std::string& string,
-                                       int func(app_control_h, const char*)) {
-  return func(handle_, string.c_str());
+AppControlResult AppControl::SetAppId(const char* app_id) {
+  return app_control_set_app_id(handle_, app_id);
 }
 
-AppControlResult AppControl::GetAppId(std::string& app_id) {
-  return GetString(app_id, app_control_get_app_id);
+AppControlResult AppControl::GetOperation(char** operation) {
+  return app_control_get_operation(handle_, operation);
 }
 
-AppControlResult AppControl::SetAppId(const std::string& app_id) {
-  return SetString(app_id, app_control_set_app_id);
+AppControlResult AppControl::SetOperation(const char* operation) {
+  return app_control_set_operation(handle_, operation);
 }
 
-AppControlResult AppControl::GetOperation(std::string& operation) {
-  return GetString(operation, app_control_get_operation);
+AppControlResult AppControl::GetUri(char** uri) {
+  return app_control_get_uri(handle_, uri);
 }
 
-AppControlResult AppControl::SetOperation(const std::string& operation) {
-  return SetString(operation, app_control_set_operation);
+AppControlResult AppControl::SetUri(const char* uri) {
+  return app_control_set_uri(handle_, uri);
 }
 
-AppControlResult AppControl::GetUri(std::string& uri) {
-  return GetString(uri, app_control_get_uri);
+AppControlResult AppControl::GetMime(char** mime) {
+  return app_control_get_mime(handle_, mime);
 }
 
-AppControlResult AppControl::SetUri(const std::string& uri) {
-  return SetString(uri, app_control_set_uri);
+AppControlResult AppControl::SetMime(const char* mime) {
+  return app_control_set_mime(handle_, mime);
 }
 
-AppControlResult AppControl::GetMime(std::string& mime) {
-  return GetString(mime, app_control_get_mime);
+AppControlResult AppControl::GetCategory(char** category) {
+  return app_control_get_category(handle_, category);
 }
 
-AppControlResult AppControl::SetMime(const std::string& mime) {
-  return SetString(mime, app_control_set_mime);
-}
-
-AppControlResult AppControl::GetCategory(std::string& category) {
-  return GetString(category, app_control_get_category);
-}
-
-AppControlResult AppControl::SetCategory(const std::string& category) {
-  return SetString(category, app_control_set_category);
+AppControlResult AppControl::SetCategory(const char* category) {
+  return app_control_set_category(handle_, category);
 }
 
 AppControlResult AppControl::GetLaunchMode(std::string& launch_mode) {
@@ -249,8 +228,8 @@ AppControlResult AppControl::SetExtraData(const EncodableMap& map) {
   return AppControlResult();
 }
 
-AppControlResult AppControl::GetCaller(std::string& caller) {
-  return GetString(caller, &app_control_get_caller);
+AppControlResult AppControl::GetCaller(char** caller) {
+  return app_control_get_caller(handle_, caller);
 }
 
 AppControlResult AppControl::IsReplyRequested(bool& value) {
@@ -259,14 +238,15 @@ AppControlResult AppControl::IsReplyRequested(bool& value) {
 
 EncodableValue AppControl::SerializeToMap() {
   AppControlResult results[7];
-  std::string app_id, operation, uri, mime, category, launch_mode;
-  EncodableMap extra_data;
-  results[0] = GetAppId(app_id);
-  results[1] = GetOperation(operation);
-  results[2] = GetUri(uri);
-  results[3] = GetMime(mime);
-  results[4] = GetCategory(category);
+  char *app_id, *operation, *uri, *mime, *category;
+  results[0] = GetAppId(&app_id);
+  results[1] = GetOperation(&operation);
+  results[2] = GetUri(&uri);
+  results[3] = GetMime(&mime);
+  results[4] = GetCategory(&category);
+  std::string launch_mode;
   results[5] = GetLaunchMode(launch_mode);
+  EncodableMap extra_data;
   results[6] = GetExtraData(extra_data);
   for (AppControlResult result : results) {
     if (!result) {
@@ -275,9 +255,8 @@ EncodableValue AppControl::SerializeToMap() {
       return EncodableValue(EncodableMap());
     }
   }
-
-  std::string caller_app_id;
-  GetCaller(caller_app_id);
+  char* caller_app_id;
+  GetCaller(&caller_app_id);
   bool should_reply = false;
   IsReplyRequested(should_reply);
 

--- a/shell/platform/tizen/channels/app_control.cc
+++ b/shell/platform/tizen/channels/app_control.cc
@@ -304,9 +304,12 @@ AppControlResult AppControl::SendLaunchRequestWithReply(
   auto reply_callback = [](app_control_h request, app_control_h reply,
                            app_control_result_e result, void* user_data) {
     auto app_control = static_cast<AppControl*>(user_data);
-    auto reply_app_control = std::make_unique<AppControl>(reply);
     EncodableMap map;
+
+    auto reply_app_control = std::make_unique<AppControl>(reply);
     map[EncodableValue("reply")] = reply_app_control->SerializeToMap();
+    AppControlManager::GetInstance().Insert(std::move(reply_app_control));
+
     if (result == APP_CONTROL_RESULT_APP_STARTED) {
       map[EncodableValue("result")] = EncodableValue("appStarted");
     } else if (result == APP_CONTROL_RESULT_SUCCEEDED) {
@@ -318,7 +321,6 @@ AppControlResult AppControl::SendLaunchRequestWithReply(
     }
     app_control->on_reply_(EncodableValue(map));
     app_control->on_reply_ = nullptr;
-    AppControlManager::GetInstance().Insert(std::move(reply_app_control));
   };
   on_reply_ = on_reply;
   return app_control_send_launch_request(handle_, reply_callback, this);

--- a/shell/platform/tizen/channels/app_control.cc
+++ b/shell/platform/tizen/channels/app_control.cc
@@ -48,7 +48,8 @@ AppControl::AppControl() : id_(next_id_++) {
   app_control_h handle = nullptr;
   AppControlResult ret = app_control_create(&handle);
   if (!ret) {
-    FT_LOG(Error) << "app_control_create() failed: " << ret.message();
+    FT_LOG(Error) << "Failed to create an application control handle: "
+                  << ret.message();
     return;
   }
   handle_ = handle;
@@ -58,7 +59,8 @@ AppControl::AppControl(app_control_h handle) : id_(next_id_++) {
   app_control_h clone = nullptr;
   AppControlResult ret = app_control_clone(&clone, handle);
   if (!ret) {
-    FT_LOG(Error) << "app_control_clone() failed: " << ret.message();
+    FT_LOG(Error) << "Failed to clone an application control handle: "
+                  << ret.message();
     return;
   }
   handle_ = clone;
@@ -70,95 +72,33 @@ AppControl::~AppControl() {
   }
 }
 
-AppControlResult AppControl::GetString(std::string& str,
+AppControlResult AppControl::GetString(std::string& string,
                                        int func(app_control_h, char**)) {
-  char* op;
-  AppControlResult ret = func(handle_, &op);
+  char* output;
+  AppControlResult ret = func(handle_, &output);
   if (!ret) {
     return ret;
   }
-  if (op != nullptr) {
-    str = std::string{op};
-    free(op);
+  if (output) {
+    string = output;
+    free(output);
   } else {
-    str = "";
+    string = "";
   }
-  return AppControlResult(APP_CONTROL_ERROR_NONE);
+  return APP_CONTROL_ERROR_NONE;
 }
 
-AppControlResult AppControl::SetString(const std::string& str,
+AppControlResult AppControl::SetString(const std::string& string,
                                        int func(app_control_h, const char*)) {
-  int ret = func(handle_, str.c_str());
-  return AppControlResult(ret);
+  return func(handle_, string.c_str());
 }
 
-bool OnAppControlExtraDataCallback(app_control_h app,
-                                   const char* key,
-                                   void* user_data) {
-  auto extra_data = static_cast<EncodableMap*>(user_data);
-  bool is_array = false;
-  int ret = app_control_is_extra_data_array(app, key, &is_array);
-  if (ret != APP_CONTROL_ERROR_NONE) {
-    FT_LOG(Error) << "app_control_is_extra_data_array() failed at key " << key;
-    return false;
-  }
-
-  if (is_array) {
-    char** strings = nullptr;
-    int length = 0;
-    ret = app_control_get_extra_data_array(app, key, &strings, &length);
-    if (ret != APP_CONTROL_ERROR_NONE) {
-      FT_LOG(Error) << "app_control_get_extra_data_array() failed at key "
-                    << key;
-      return false;
-    }
-    EncodableList list;
-    for (int i = 0; i < length; i++) {
-      list.push_back(EncodableValue(std::string(strings[i])));
-      free(strings[i]);
-    }
-    free(strings);
-    extra_data->insert(
-        {EncodableValue(std::string(key)), EncodableValue(list)});
-  } else {
-    char* value = nullptr;
-    ret = app_control_get_extra_data(app, key, &value);
-    if (ret != APP_CONTROL_ERROR_NONE) {
-      FT_LOG(Error) << "app_control_get_extra_data() failed at key " << key;
-      return false;
-    }
-    extra_data->insert(
-        {EncodableValue(std::string(key)), EncodableValue(std::string(value))});
-    free(value);
-  }
-
-  return true;
+AppControlResult AppControl::GetAppId(std::string& app_id) {
+  return GetString(app_id, app_control_get_app_id);
 }
 
-AppControlResult AppControl::GetExtraData(EncodableMap& value) {
-  EncodableMap extra_data;
-  int ret = app_control_foreach_extra_data(
-      handle_, OnAppControlExtraDataCallback, &extra_data);
-  if (ret == APP_CONTROL_ERROR_NONE) {
-    value = std::move(extra_data);
-  }
-  return AppControlResult(ret);
-}
-
-AppControlResult AppControl::SetExtraData(const EncodableMap& map) {
-  for (const auto& v : map) {
-    if (!std::holds_alternative<std::string>(v.first)) {
-      FT_LOG(Error) << "Key for extra data has to be string, omitting.";
-      continue;
-    }
-    std::string key = std::get<std::string>(v.first);
-    AppControlResult ret = AddExtraData(key, v.second);
-    if (!ret) {
-      FT_LOG(Error) << "Invalid data at " << key << ", omitting.";
-      continue;
-    }
-  }
-  return AppControlResult();
+AppControlResult AppControl::SetAppId(const std::string& app_id) {
+  return SetString(app_id, app_control_set_app_id);
 }
 
 AppControlResult AppControl::GetOperation(std::string& operation) {
@@ -193,76 +133,165 @@ AppControlResult AppControl::SetCategory(const std::string& category) {
   return SetString(category, app_control_set_category);
 }
 
-AppControlResult AppControl::GetAppId(std::string& app_id) {
-  return GetString(app_id, app_control_get_app_id);
-}
-
-AppControlResult AppControl::SetAppId(const std::string& app_id) {
-  return SetString(app_id, app_control_set_app_id);
-}
-
-AppControlResult AppControl::GetCaller(std::string& caller) {
-  return GetString(caller, app_control_get_caller);
-}
-
 AppControlResult AppControl::GetLaunchMode(std::string& launch_mode) {
   app_control_launch_mode_e launch_mode_e;
-  int ret = app_control_get_launch_mode(handle_, &launch_mode_e);
-  if (ret != APP_CONTROL_ERROR_NONE) {
-    return AppControlResult(ret);
+  AppControlResult ret = app_control_get_launch_mode(handle_, &launch_mode_e);
+  if (!ret) {
+    return ret;
   }
-  launch_mode =
-      (launch_mode_e == APP_CONTROL_LAUNCH_MODE_SINGLE ? "single" : "group");
-  return AppControlResult(APP_CONTROL_ERROR_NONE);
+  if (launch_mode_e == APP_CONTROL_LAUNCH_MODE_GROUP) {
+    launch_mode = "group";
+  } else {
+    launch_mode = "single";
+  }
+  return APP_CONTROL_ERROR_NONE;
 }
 
 AppControlResult AppControl::SetLaunchMode(const std::string& launch_mode) {
   app_control_launch_mode_e launch_mode_e;
-  if (launch_mode.compare("single")) {
-    launch_mode_e = APP_CONTROL_LAUNCH_MODE_SINGLE;
-  } else {
+  if (launch_mode == "group") {
     launch_mode_e = APP_CONTROL_LAUNCH_MODE_GROUP;
+  } else {
+    launch_mode_e = APP_CONTROL_LAUNCH_MODE_SINGLE;
   }
-  int ret = app_control_set_launch_mode(handle_, launch_mode_e);
-  return AppControlResult(ret);
+  return app_control_set_launch_mode(handle_, launch_mode_e);
 }
 
-bool AppControl::IsReplyRequested() {
-  bool requested = false;
-  app_control_is_reply_requested(handle_, &requested);
-  return requested;
+bool OnAppControlExtraDataCallback(app_control_h handle,
+                                   const char* key,
+                                   void* user_data) {
+  auto extra_data = static_cast<EncodableMap*>(user_data);
+
+  bool is_array = false;
+  int ret = app_control_is_extra_data_array(handle, key, &is_array);
+  if (ret != APP_CONTROL_ERROR_NONE) {
+    FT_LOG(Error) << "app_control_is_extra_data_array() failed at key " << key;
+    return false;
+  }
+
+  if (is_array) {
+    char** strings = nullptr;
+    int length = 0;
+    ret = app_control_get_extra_data_array(handle, key, &strings, &length);
+    if (ret != APP_CONTROL_ERROR_NONE) {
+      FT_LOG(Error) << "app_control_get_extra_data_array() failed at key "
+                    << key;
+      return false;
+    }
+    EncodableList list;
+    for (int i = 0; i < length; i++) {
+      list.push_back(EncodableValue(std::string(strings[i])));
+      free(strings[i]);
+    }
+    free(strings);
+    extra_data->insert(
+        {EncodableValue(std::string(key)), EncodableValue(list)});
+  } else {
+    char* value = nullptr;
+    ret = app_control_get_extra_data(handle, key, &value);
+    if (ret != APP_CONTROL_ERROR_NONE) {
+      FT_LOG(Error) << "app_control_get_extra_data() failed at key " << key;
+      return false;
+    }
+    extra_data->insert(
+        {EncodableValue(std::string(key)), EncodableValue(std::string(value))});
+    free(value);
+  }
+  return true;
 }
 
-EncodableValue AppControl::SerializeAppControlToMap() {
-  std::string app_id, operation, mime, category, uri, caller_id, launch_mode;
-  AppControlResult results[7];
-  results[0] = GetAppId(app_id);
-  results[1] = GetOperation(operation);
-  results[2] = GetMime(mime);
-  results[3] = GetCategory(category);
-  results[4] = GetUri(uri);
-  results[5] = GetLaunchMode(launch_mode);
-  // Caller Id is optional.
-  GetCaller(caller_id);
+AppControlResult AppControl::GetExtraData(EncodableMap& map) {
   EncodableMap extra_data;
-  results[6] = GetExtraData(extra_data);
-  for (int i = 0; i < 7; i++) {
-    if (!results[i]) {
-      return EncodableValue();
+  AppControlResult ret = app_control_foreach_extra_data(
+      handle_, OnAppControlExtraDataCallback, &extra_data);
+  if (ret) {
+    map = std::move(extra_data);
+  }
+  return ret;
+}
+
+AppControlResult AppControl::AddExtraData(std::string key,
+                                          EncodableValue value) {
+  if (std::holds_alternative<EncodableList>(value)) {
+    auto strings = std::vector<const char*>();
+    for (const EncodableValue& value : std::get<EncodableList>(value)) {
+      if (std::holds_alternative<std::string>(value)) {
+        strings.push_back(std::get<std::string>(value).c_str());
+      } else {
+        return APP_ERROR_INVALID_PARAMETER;
+      }
+    }
+    return app_control_add_extra_data_array(handle_, key.c_str(),
+                                            strings.data(), strings.size());
+  } else if (std::holds_alternative<std::string>(value)) {
+    return app_control_add_extra_data(handle_, key.c_str(),
+                                      std::get<std::string>(value).c_str());
+  } else {
+    return APP_ERROR_INVALID_PARAMETER;
+  }
+}
+
+AppControlResult AppControl::SetExtraData(const EncodableMap& map) {
+  for (const auto& v : map) {
+    if (!std::holds_alternative<std::string>(v.first)) {
+      FT_LOG(Error) << "Invalid key. Omitting.";
+      continue;
+    }
+    const auto& key = std::get<std::string>(v.first);
+    AppControlResult ret = AddExtraData(key, v.second);
+    if (!ret) {
+      FT_LOG(Error)
+          << "The value for the key " << key
+          << " must be either a string or a list of strings. Omitting.";
+      continue;
     }
   }
+  return AppControlResult();
+}
+
+AppControlResult AppControl::GetCaller(std::string& caller) {
+  return GetString(caller, &app_control_get_caller);
+}
+
+AppControlResult AppControl::IsReplyRequested(bool& value) {
+  return app_control_is_reply_requested(handle_, &value);
+}
+
+EncodableValue AppControl::SerializeToMap() {
+  AppControlResult results[7];
+  std::string app_id, operation, uri, mime, category, launch_mode;
+  EncodableMap extra_data;
+  results[0] = GetAppId(app_id);
+  results[1] = GetOperation(operation);
+  results[2] = GetUri(uri);
+  results[3] = GetMime(mime);
+  results[4] = GetCategory(category);
+  results[5] = GetLaunchMode(launch_mode);
+  results[6] = GetExtraData(extra_data);
+  for (AppControlResult result : results) {
+    if (!result) {
+      FT_LOG(Error) << "Failed to serialize AppControl data: "
+                    << result.message();
+      return EncodableValue(EncodableMap());
+    }
+  }
+
+  std::string caller_app_id;
+  GetCaller(caller_app_id);
+  bool should_reply = false;
+  IsReplyRequested(should_reply);
+
   EncodableMap map;
-  map[EncodableValue("id")] = EncodableValue(id());
+  map[EncodableValue("id")] = EncodableValue(id_);
   map[EncodableValue("appId")] = EncodableValue(app_id);
   map[EncodableValue("operation")] = EncodableValue(operation);
   map[EncodableValue("mime")] = EncodableValue(mime);
   map[EncodableValue("category")] = EncodableValue(category);
   map[EncodableValue("uri")] = EncodableValue(uri);
-  map[EncodableValue("callerAppId")] = EncodableValue(caller_id);
   map[EncodableValue("launchMode")] = EncodableValue(launch_mode);
   map[EncodableValue("extraData")] = EncodableValue(extra_data);
-  map[EncodableValue("shouldReply")] = EncodableValue(IsReplyRequested());
-
+  map[EncodableValue("callerAppId")] = EncodableValue(caller_app_id);
+  map[EncodableValue("shouldReply")] = EncodableValue(should_reply);
   return EncodableValue(map);
 }
 
@@ -274,11 +303,10 @@ AppControlResult AppControl::SendLaunchRequestWithReply(
     ReplyCallback on_reply) {
   auto reply_callback = [](app_control_h request, app_control_h reply,
                            app_control_result_e result, void* user_data) {
-    AppControl* app_control = static_cast<AppControl*>(user_data);
-    auto app_control_reply = std::make_unique<AppControl>(reply);
+    auto app_control = static_cast<AppControl*>(user_data);
+    auto reply_app_control = std::make_unique<AppControl>(reply);
     EncodableMap map;
-    map[EncodableValue("reply")] =
-        app_control_reply->SerializeAppControlToMap();
+    map[EncodableValue("reply")] = reply_app_control->SerializeToMap();
     if (result == APP_CONTROL_RESULT_APP_STARTED) {
       map[EncodableValue("result")] = EncodableValue("appStarted");
     } else if (result == APP_CONTROL_RESULT_SUCCEEDED) {
@@ -290,15 +318,14 @@ AppControlResult AppControl::SendLaunchRequestWithReply(
     }
     app_control->on_reply_(EncodableValue(map));
     app_control->on_reply_ = nullptr;
-    AppControlManager::GetInstance().Insert(std::move(app_control_reply));
+    AppControlManager::GetInstance().Insert(std::move(reply_app_control));
   };
   on_reply_ = on_reply;
   return app_control_send_launch_request(handle_, reply_callback, this);
 }
 
 AppControlResult AppControl::SendTerminateRequest() {
-  AppControlResult ret = app_control_send_terminate_request(handle_);
-  return ret;
+  return app_control_send_terminate_request(handle_);
 }
 
 AppControlResult AppControl::Reply(AppControl* reply,
@@ -313,47 +340,10 @@ AppControlResult AppControl::Reply(AppControl* reply,
   } else if (result == "canceled") {
     result_e = APP_CONTROL_RESULT_CANCELED;
   } else {
-    return AppControlResult(APP_CONTROL_ERROR_INVALID_PARAMETER);
+    return APP_CONTROL_ERROR_INVALID_PARAMETER;
   }
-  AppControlResult ret = app_control_reply_to_launch_request(
-      reply->handle(), this->handle_, result_e);
-  return ret;
-}
-
-AppControlResult AppControl::AddExtraData(std::string key,
-                                          EncodableValue value) {
-  bool is_array = std::holds_alternative<EncodableList>(value);
-  if (is_array) {
-    EncodableList& list = std::get<EncodableList>(value);
-    return AddExtraDataList(key, list);
-  } else {
-    bool is_string = std::holds_alternative<std::string>(value);
-    if (is_string) {
-      int ret = app_control_add_extra_data(
-          handle_, key.c_str(), std::get<std::string>(value).c_str());
-      return AppControlResult(ret);
-    } else {
-      return AppControlResult(APP_ERROR_INVALID_PARAMETER);
-    }
-  }
-  return AppControlResult(APP_CONTROL_ERROR_NONE);
-}
-
-AppControlResult AppControl::AddExtraDataList(std::string& key,
-                                              EncodableList& list) {
-  size_t length = list.size();
-  auto strings = std::vector<const char*>(length);
-  for (size_t i = 0; i < length; i++) {
-    bool is_string = std::holds_alternative<std::string>(list[i]);
-    if (is_string) {
-      strings[i] = std::get<std::string>(list[i]).c_str();
-    } else {
-      return AppControlResult(APP_ERROR_INVALID_PARAMETER);
-    }
-  }
-  int ret = app_control_add_extra_data_array(handle_, key.c_str(),
-                                             strings.data(), length);
-  return AppControlResult(ret);
+  return app_control_reply_to_launch_request(reply->handle_, this->handle_,
+                                             result_e);
 }
 
 }  // namespace flutter

--- a/shell/platform/tizen/channels/app_control.h
+++ b/shell/platform/tizen/channels/app_control.h
@@ -70,21 +70,21 @@ class AppControl {
   int32_t id() { return id_; }
   app_control_h handle() { return handle_; }
 
-  AppControlResult GetAppId(char** app_id);
-  AppControlResult SetAppId(const char* app_id);
-  AppControlResult GetOperation(char** operation);
-  AppControlResult SetOperation(const char* operation);
-  AppControlResult GetUri(char** uri);
-  AppControlResult SetUri(const char* uri);
-  AppControlResult GetMime(char** mime);
-  AppControlResult SetMime(const char* mime);
-  AppControlResult GetCategory(char** category);
-  AppControlResult SetCategory(const char* category);
+  AppControlResult GetAppId(std::string& app_id);
+  AppControlResult SetAppId(const std::string& app_id);
+  AppControlResult GetOperation(std::string& operation);
+  AppControlResult SetOperation(const std::string& operation);
+  AppControlResult GetUri(std::string& uri);
+  AppControlResult SetUri(const std::string& uri);
+  AppControlResult GetMime(std::string& mime);
+  AppControlResult SetMime(const std::string& mime);
+  AppControlResult GetCategory(std::string& category);
+  AppControlResult SetCategory(const std::string& category);
   AppControlResult GetLaunchMode(std::string& launch_mode);
   AppControlResult SetLaunchMode(const std::string& launch_mode);
   AppControlResult GetExtraData(EncodableMap& map);
   AppControlResult SetExtraData(const EncodableMap& map);
-  AppControlResult GetCaller(char** caller);
+  AppControlResult GetCaller(std::string& caller);
   AppControlResult IsReplyRequested(bool& value);
 
   EncodableValue SerializeToMap();
@@ -96,6 +96,10 @@ class AppControl {
   AppControlResult Reply(AppControl* reply, const std::string& result);
 
  private:
+  AppControlResult GetString(std::string& string,
+                             int func(app_control_h, char**));
+  AppControlResult SetString(const std::string& string,
+                             int func(app_control_h, const char*));
   AppControlResult AddExtraData(std::string key, EncodableValue value);
 
   static int32_t next_id_;

--- a/shell/platform/tizen/channels/app_control.h
+++ b/shell/platform/tizen/channels/app_control.h
@@ -61,8 +61,8 @@ class AppControl {
   // handle.
   explicit AppControl();
 
-  // Creates an instance of AppControl by creating a copy of existing
-  // application control |handle|.
+  // Creates an instance of AppControl by duplicating an existing application
+  // control |handle|.
   explicit AppControl(app_control_h handle);
 
   virtual ~AppControl();

--- a/shell/platform/tizen/channels/app_control.h
+++ b/shell/platform/tizen/channels/app_control.h
@@ -7,6 +7,7 @@
 
 #include <app.h>
 
+#include <string>
 #include <unordered_map>
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
@@ -44,6 +45,8 @@ struct AppControlResult {
 
   // Returns false on error.
   operator bool() const { return (APP_CONTROL_ERROR_NONE == error_code); }
+
+  std::string code() { return std::to_string(error_code); }
 
   std::string message() { return get_error_message(error_code); }
 

--- a/shell/platform/tizen/channels/app_control.h
+++ b/shell/platform/tizen/channels/app_control.h
@@ -70,21 +70,21 @@ class AppControl {
   int32_t id() { return id_; }
   app_control_h handle() { return handle_; }
 
-  AppControlResult GetAppId(std::string& app_id);
-  AppControlResult SetAppId(const std::string& app_id);
-  AppControlResult GetOperation(std::string& operation);
-  AppControlResult SetOperation(const std::string& operation);
-  AppControlResult GetUri(std::string& uri);
-  AppControlResult SetUri(const std::string& uri);
-  AppControlResult GetMime(std::string& mime);
-  AppControlResult SetMime(const std::string& mime);
-  AppControlResult GetCategory(std::string& category);
-  AppControlResult SetCategory(const std::string& category);
+  AppControlResult GetAppId(char** app_id);
+  AppControlResult SetAppId(const char* app_id);
+  AppControlResult GetOperation(char** operation);
+  AppControlResult SetOperation(const char* operation);
+  AppControlResult GetUri(char** uri);
+  AppControlResult SetUri(const char* uri);
+  AppControlResult GetMime(char** mime);
+  AppControlResult SetMime(const char* mime);
+  AppControlResult GetCategory(char** category);
+  AppControlResult SetCategory(const char* category);
   AppControlResult GetLaunchMode(std::string& launch_mode);
   AppControlResult SetLaunchMode(const std::string& launch_mode);
   AppControlResult GetExtraData(EncodableMap& map);
   AppControlResult SetExtraData(const EncodableMap& map);
-  AppControlResult GetCaller(std::string& caller);
+  AppControlResult GetCaller(char** caller);
   AppControlResult IsReplyRequested(bool& value);
 
   EncodableValue SerializeToMap();
@@ -96,10 +96,6 @@ class AppControl {
   AppControlResult Reply(AppControl* reply, const std::string& result);
 
  private:
-  AppControlResult GetString(std::string& string,
-                             int func(app_control_h, char**));
-  AppControlResult SetString(const std::string& string,
-                             int func(app_control_h, const char*));
   AppControlResult AddExtraData(std::string key, EncodableValue value);
 
   static int32_t next_id_;

--- a/shell/platform/tizen/channels/app_control.h
+++ b/shell/platform/tizen/channels/app_control.h
@@ -57,13 +57,21 @@ class AppControl {
  public:
   using ReplyCallback = std::function<void(const EncodableValue& response)>;
 
+  // Creates an instance of AppControl by allocating a new application control
+  // handle.
   explicit AppControl();
+
+  // Creates an instance of AppControl by creating a copy of existing
+  // application control |handle|.
   explicit AppControl(app_control_h handle);
+
   virtual ~AppControl();
 
   int32_t id() { return id_; }
   app_control_h handle() { return handle_; }
 
+  AppControlResult GetAppId(std::string& app_id);
+  AppControlResult SetAppId(const std::string& app_id);
   AppControlResult GetOperation(std::string& operation);
   AppControlResult SetOperation(const std::string& operation);
   AppControlResult GetUri(std::string& uri);
@@ -72,14 +80,14 @@ class AppControl {
   AppControlResult SetMime(const std::string& mime);
   AppControlResult GetCategory(std::string& category);
   AppControlResult SetCategory(const std::string& category);
-  AppControlResult GetAppId(std::string& app_id);
-  AppControlResult SetAppId(const std::string& app_id);
-  AppControlResult GetCaller(std::string& caller);
   AppControlResult GetLaunchMode(std::string& launch_mode);
   AppControlResult SetLaunchMode(const std::string& launch_mode);
-  bool IsReplyRequested();
+  AppControlResult GetExtraData(EncodableMap& map);
+  AppControlResult SetExtraData(const EncodableMap& map);
+  AppControlResult GetCaller(std::string& caller);
+  AppControlResult IsReplyRequested(bool& value);
 
-  EncodableValue SerializeAppControlToMap();
+  EncodableValue SerializeToMap();
 
   AppControlResult SendLaunchRequest();
   AppControlResult SendLaunchRequestWithReply(ReplyCallback on_reply);
@@ -87,20 +95,17 @@ class AppControl {
 
   AppControlResult Reply(AppControl* reply, const std::string& result);
 
-  AppControlResult GetExtraData(EncodableMap& value);
-  AppControlResult SetExtraData(const EncodableMap& value);
-
  private:
-  AppControlResult GetString(std::string& str, int func(app_control_h, char**));
-  AppControlResult SetString(const std::string& str,
+  AppControlResult GetString(std::string& string,
+                             int func(app_control_h, char**));
+  AppControlResult SetString(const std::string& string,
                              int func(app_control_h, const char*));
-
   AppControlResult AddExtraData(std::string key, EncodableValue value);
-  AppControlResult AddExtraDataList(std::string& key, EncodableList& list);
 
-  app_control_h handle_ = nullptr;
-  int32_t id_;
   static int32_t next_id_;
+
+  int32_t id_;
+  app_control_h handle_ = nullptr;
   ReplyCallback on_reply_ = nullptr;
 };
 

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -108,7 +108,7 @@ void AppControlChannel::RegisterEventHandler(
     std::unique_ptr<EventSink<EncodableValue>> events) {
   event_sink_ = std::move(events);
 
-  // Send any queued events.
+  // Send already queued events if any.
   while (!queue_.empty()) {
     SendAppControlEvent(queue_.front());
     queue_.pop();

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -239,19 +239,19 @@ void AppControlChannel::SetAppControlData(
 
   std::vector<AppControlResult> results;
   if (app_id) {
-    results.push_back(app_control->SetAppId(app_id->c_str()));
+    results.push_back(app_control->SetAppId(*app_id));
   }
   if (operation) {
-    results.push_back(app_control->SetOperation(operation->c_str()));
+    results.push_back(app_control->SetOperation(*operation));
   }
   if (uri) {
-    results.push_back(app_control->SetUri(uri->c_str()));
+    results.push_back(app_control->SetUri(*uri));
   }
   if (mime) {
-    results.push_back(app_control->SetMime(mime->c_str()));
+    results.push_back(app_control->SetMime(*mime));
   }
   if (category) {
-    results.push_back(app_control->SetCategory(category->c_str()));
+    results.push_back(app_control->SetCategory(*category));
   }
   if (launch_mode) {
     results.push_back(app_control->SetLaunchMode(*launch_mode));

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -67,8 +67,15 @@ void AppControlChannel::HandleMethodCall(
 
   // The methods "create" and "dispose" are deprecated and will be removed in
   // the future.
-  if (method_name.compare("create") == 0) {
-    Create(std::move(result));
+  if (method_name == "create") {
+    auto app_control = std::make_unique<AppControl>();
+    if (app_control->handle()) {
+      result->Success(EncodableValue(app_control->id()));
+      AppControlManager::GetInstance().Insert(std::move(app_control));
+    } else {
+      result->Error("Internal error",
+                    "Could not create an instance of AppControl.");
+    }
     return;
   }
 
@@ -89,15 +96,16 @@ void AppControlChannel::HandleMethodCall(
     return;
   }
 
-  if (method_name.compare("dispose") == 0) {
-    Dispose(app_control, std::move(result));
-  } else if (method_name.compare("reply") == 0) {
+  if (method_name == "dispose") {
+    AppControlManager::GetInstance().Remove(app_control->id());
+    result->Success();
+  } else if (method_name == "reply") {
     Reply(app_control, arguments, std::move(result));
-  } else if (method_name.compare("sendLaunchRequest") == 0) {
+  } else if (method_name == "sendLaunchRequest") {
     SendLaunchRequest(app_control, arguments, std::move(result));
-  } else if (method_name.compare("sendTerminateRequest") == 0) {
+  } else if (method_name == "sendTerminateRequest") {
     SendTerminateRequest(app_control, std::move(result));
-  } else if (method_name.compare("setAppControlData") == 0) {
+  } else if (method_name == "setAppControlData") {
     SetAppControlData(app_control, arguments, std::move(result));
   } else {
     result->NotImplemented();
@@ -117,25 +125,6 @@ void AppControlChannel::RegisterEventHandler(
 
 void AppControlChannel::UnregisterEventHandler() {
   event_sink_.reset();
-}
-
-void AppControlChannel::Create(
-    std::unique_ptr<MethodResult<EncodableValue>> result) {
-  auto app_control = std::make_unique<AppControl>();
-  if (app_control->handle()) {
-    result->Success(EncodableValue(app_control->id()));
-    AppControlManager::GetInstance().Insert(std::move(app_control));
-  } else {
-    result->Error("Internal error",
-                  "Could not create an instance of AppControl.");
-  }
-}
-
-void AppControlChannel::Dispose(
-    AppControl* app_control,
-    std::unique_ptr<MethodResult<EncodableValue>> result) {
-  AppControlManager::GetInstance().Remove(app_control->id());
-  result->Success();
 }
 
 void AppControlChannel::Reply(

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -21,14 +21,12 @@ constexpr char kEventChannelName[] = "tizen/internal/app_control_event";
 AppControlChannel::AppControlChannel(BinaryMessenger* messenger) {
   method_channel_ = std::make_unique<MethodChannel<EncodableValue>>(
       messenger, kChannelName, &StandardMethodCodec::GetInstance());
-
   method_channel_->SetMethodCallHandler([this](const auto& call, auto result) {
     this->HandleMethodCall(call, std::move(result));
   });
 
   event_channel_ = std::make_unique<EventChannel<EncodableValue>>(
       messenger, kEventChannelName, &StandardMethodCodec::GetInstance());
-
   auto event_channel_handler = std::make_unique<StreamHandlerFunctions<>>(
       [this](const EncodableValue* arguments,
              std::unique_ptr<EventSink<>>&& events)
@@ -41,7 +39,6 @@ AppControlChannel::AppControlChannel(BinaryMessenger* messenger) {
         UnregisterEventHandler();
         return nullptr;
       });
-
   event_channel_->SetStreamHandler(std::move(event_channel_handler));
 }
 
@@ -54,11 +51,11 @@ void AppControlChannel::NotifyAppControl(void* handle) {
     FT_LOG(Error) << "Could not create an instance of AppControl.";
     return;
   }
-  if (!event_sink_) {
-    FT_LOG(Info) << "EventChannel not set yet.";
-    queue_.push(app_control.get());
+  if (event_sink_) {
+    SendAppControlEvent(app_control.get());
   } else {
-    SendAppControlDataEvent(app_control.get());
+    FT_LOG(Info) << "No event channel has been initialized.";
+    queue_.push(app_control.get());
   }
   AppControlManager::GetInstance().Insert(std::move(app_control));
 }
@@ -66,19 +63,29 @@ void AppControlChannel::NotifyAppControl(void* handle) {
 void AppControlChannel::HandleMethodCall(
     const MethodCall<EncodableValue>& method_call,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
-  const auto arguments = method_call.arguments();
   const auto& method_name = method_call.method_name();
 
-  // AppControl is not needed.
+  // The methods "create" and "dispose" are deprecated and will be removed in
+  // the future.
   if (method_name.compare("create") == 0) {
-    CreateAppControl(std::move(result));
+    Create(std::move(result));
     return;
   }
 
-  // AppControl is needed.
-  auto app_control = GetAppControl(arguments);
-  if (app_control == nullptr) {
-    result->Error("Could not find app_control", "Invalid id provided");
+  auto arguments = std::get_if<EncodableMap>(method_call.arguments());
+  if (!arguments) {
+    result->Error("Invalid arguments");
+    return;
+  }
+  EncodableValueHolder<int32_t> id(arguments, "id");
+  if (!id) {
+    result->Error("Invalid arguments", "No ID provided.");
+    return;
+  }
+  auto app_control = AppControlManager::GetInstance().FindById(*id);
+  if (!app_control) {
+    result->Error("Invalid arguments",
+                  "No instance of AppControl matches the given ID.");
     return;
   }
 
@@ -88,10 +95,10 @@ void AppControlChannel::HandleMethodCall(
     Reply(app_control, arguments, std::move(result));
   } else if (method_name.compare("sendLaunchRequest") == 0) {
     SendLaunchRequest(app_control, arguments, std::move(result));
-  } else if (method_name.compare("setAppControlData") == 0) {
-    SetAppControlData(app_control, arguments, std::move(result));
   } else if (method_name.compare("sendTerminateRequest") == 0) {
     SendTerminateRequest(app_control, std::move(result));
+  } else if (method_name.compare("setAppControlData") == 0) {
+    SetAppControlData(app_control, arguments, std::move(result));
   } else {
     result->NotImplemented();
   }
@@ -100,49 +107,27 @@ void AppControlChannel::HandleMethodCall(
 void AppControlChannel::RegisterEventHandler(
     std::unique_ptr<EventSink<EncodableValue>> events) {
   event_sink_ = std::move(events);
-  SendAlreadyQueuedEvents();
+
+  // Send any queued events.
+  while (!queue_.empty()) {
+    SendAppControlEvent(queue_.front());
+    queue_.pop();
+  }
 }
 
 void AppControlChannel::UnregisterEventHandler() {
   event_sink_.reset();
 }
 
-void AppControlChannel::SendAlreadyQueuedEvents() {
-  while (!queue_.empty()) {
-    SendAppControlDataEvent(queue_.front());
-    queue_.pop();
-  }
-}
-
-AppControl* AppControlChannel::GetAppControl(const EncodableValue* arguments) {
-  auto map_ptr = std::get_if<EncodableMap>(arguments);
-  if (!map_ptr) {
-    FT_LOG(Error) << "Invalid arguments.";
-    return nullptr;
-  }
-
-  EncodableValueHolder<int32_t> id(map_ptr, "id");
-  if (!id) {
-    FT_LOG(Error) << "Could not get proper id from arguments.";
-    return nullptr;
-  }
-
-  auto app_control = AppControlManager::GetInstance().FindById(*id);
-  if (!app_control) {
-    FT_LOG(Error) << "Could not find AppControl with id " << *id;
-    return nullptr;
-  }
-  return app_control;
-}
-
-void AppControlChannel::CreateAppControl(
+void AppControlChannel::Create(
     std::unique_ptr<MethodResult<EncodableValue>> result) {
   auto app_control = std::make_unique<AppControl>();
   if (app_control->handle()) {
     result->Success(EncodableValue(app_control->id()));
     AppControlManager::GetInstance().Insert(std::move(app_control));
   } else {
-    result->Error("Internal error", "Could not create AppControl.");
+    result->Error("Internal error",
+                  "Could not create an instance of AppControl.");
   }
 }
 
@@ -155,51 +140,59 @@ void AppControlChannel::Dispose(
 
 void AppControlChannel::Reply(
     AppControl* app_control,
-    const EncodableValue* arguments,
+    const EncodableMap* arguments,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
-  auto map_ptr = std::get_if<EncodableMap>(arguments);
-  if (!map_ptr) {
-    result->Error("Invalid arguments");
+  EncodableValueHolder<std::string> result_str(arguments, "result");
+  if (!result_str) {
+    result->Error("Invalid arguments", "No result provided.");
     return;
   }
 
-  EncodableValueHolder<int32_t> request_id(map_ptr, "requestId");
+  EncodableValueHolder<int32_t> reply_id(arguments, "replyId");
+  if (reply_id) {
+    auto reply_app_control =
+        AppControlManager::GetInstance().FindById(*reply_id);
+    if (!reply_app_control) {
+      result->Error("Invalid arguments",
+                    "No instance of AppControl matches the given ID.");
+      return;
+    }
+    AppControlResult ret = app_control->Reply(reply_app_control, *result_str);
+    if (ret) {
+      result->Success();
+    } else {
+      result->Error(ret.code(), ret.message());
+    }
+    return;
+  }
+
+  // Deprecated. Use replyId instead.
+  EncodableValueHolder<int32_t> request_id(arguments, "requestId");
   if (!request_id) {
-    result->Error("Invalid arguments", "Invalid requestId parameter");
+    result->Error("Invalid arguments",
+                  "Either replyId or requestId must be provided.");
     return;
   }
   auto request_app_control =
       AppControlManager::GetInstance().FindById(*request_id);
   if (!request_app_control) {
     result->Error("Invalid arguments",
-                  "Could not find AppControl with the given ID.");
-    return;
-  }
-
-  EncodableValueHolder<std::string> result_str(map_ptr, "result");
-  if (!result_str) {
-    result->Error("Could not reply", "Invalid result parameter");
+                  "No instance of AppControl matches the given ID.");
     return;
   }
   AppControlResult ret = request_app_control->Reply(app_control, *result_str);
   if (ret) {
     result->Success();
   } else {
-    result->Error("Could not reply to app control", ret.message());
+    result->Error(ret.code(), ret.message());
   }
 }
 
 void AppControlChannel::SendLaunchRequest(
     AppControl* app_control,
-    const EncodableValue* arguments,
+    const EncodableMap* arguments,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
-  auto map_ptr = std::get_if<EncodableMap>(arguments);
-  if (!map_ptr) {
-    result->Error("Invalid arguments");
-    return;
-  }
-
-  EncodableValueHolder<bool> wait_for_reply(map_ptr, "waitForReply");
+  EncodableValueHolder<bool> wait_for_reply(arguments, "waitForReply");
   if (wait_for_reply && *wait_for_reply) {
     auto result_ptr = result.release();
     auto on_reply = [result_ptr](const EncodableValue& response) {
@@ -208,7 +201,7 @@ void AppControlChannel::SendLaunchRequest(
     };
     AppControlResult ret = app_control->SendLaunchRequestWithReply(on_reply);
     if (!ret) {
-      result_ptr->Error(ret.message());
+      result_ptr->Error(ret.code(), ret.message());
       delete result_ptr;
     }
   } else {
@@ -216,7 +209,7 @@ void AppControlChannel::SendLaunchRequest(
     if (ret) {
       result->Success();
     } else {
-      result->Error(ret.message());
+      result->Error(ret.code(), ret.message());
     }
   }
 }
@@ -228,35 +221,31 @@ void AppControlChannel::SendTerminateRequest(
   if (ret) {
     result->Success();
   } else {
-    result->Error("Could not terminate", ret.message());
+    result->Error(ret.code(), ret.message());
   }
 }
 
 void AppControlChannel::SetAppControlData(
     AppControl* app_control,
-    const EncodableValue* arguments,
+    const EncodableMap* arguments,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
-  auto map_ptr = std::get_if<EncodableMap>(arguments);
-  if (!map_ptr) {
-    result->Error("Invalid arguments");
-    return;
-  }
-
-  EncodableValueHolder<std::string> app_id(map_ptr, "appId");
-  EncodableValueHolder<std::string> operation(map_ptr, "operation");
-  EncodableValueHolder<std::string> mime(map_ptr, "mime");
-  EncodableValueHolder<std::string> category(map_ptr, "category");
-  EncodableValueHolder<std::string> launch_mode(map_ptr, "launchMode");
-  EncodableValueHolder<std::string> uri(map_ptr, "uri");
-  EncodableValueHolder<EncodableMap> extra_data(map_ptr, "extraData");
+  EncodableValueHolder<std::string> app_id(arguments, "appId");
+  EncodableValueHolder<std::string> operation(arguments, "operation");
+  EncodableValueHolder<std::string> uri(arguments, "uri");
+  EncodableValueHolder<std::string> mime(arguments, "mime");
+  EncodableValueHolder<std::string> category(arguments, "category");
+  EncodableValueHolder<std::string> launch_mode(arguments, "launchMode");
+  EncodableValueHolder<EncodableMap> extra_data(arguments, "extraData");
 
   std::vector<AppControlResult> results;
-
   if (app_id) {
     results.emplace_back(app_control->SetAppId(*app_id));
   }
   if (operation) {
     results.emplace_back(app_control->SetOperation(*operation));
+  }
+  if (uri) {
+    results.emplace_back(app_control->SetUri(*uri));
   }
   if (mime) {
     results.emplace_back(app_control->SetMime(*mime));
@@ -264,25 +253,22 @@ void AppControlChannel::SetAppControlData(
   if (category) {
     results.emplace_back(app_control->SetCategory(*category));
   }
-  if (uri) {
-    results.emplace_back(app_control->SetUri(*uri));
-  }
   if (launch_mode) {
     results.emplace_back(app_control->SetLaunchMode(*launch_mode));
   }
   if (extra_data) {
     results.emplace_back(app_control->SetExtraData(*extra_data));
   }
-  for (size_t i = 0; i < results.size(); i++) {
-    if (!results[i]) {
-      result->Error("Could not set value for app control",
-                    results[i].message());
+  for (auto ret : results) {
+    if (!ret) {
+      result->Error(ret.code(), ret.message());
+      return;
     }
   }
   result->Success();
 }
 
-void AppControlChannel::SendAppControlDataEvent(AppControl* app_control) {
+void AppControlChannel::SendAppControlEvent(AppControl* app_control) {
   EncodableValue map = app_control->SerializeAppControlToMap();
   if (!map.IsNull()) {
     event_sink_->Success(map);

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -239,19 +239,19 @@ void AppControlChannel::SetAppControlData(
 
   std::vector<AppControlResult> results;
   if (app_id) {
-    results.push_back(app_control->SetAppId(*app_id));
+    results.push_back(app_control->SetAppId(app_id->c_str()));
   }
   if (operation) {
-    results.push_back(app_control->SetOperation(*operation));
+    results.push_back(app_control->SetOperation(operation->c_str()));
   }
   if (uri) {
-    results.push_back(app_control->SetUri(*uri));
+    results.push_back(app_control->SetUri(uri->c_str()));
   }
   if (mime) {
-    results.push_back(app_control->SetMime(*mime));
+    results.push_back(app_control->SetMime(mime->c_str()));
   }
   if (category) {
-    results.push_back(app_control->SetCategory(*category));
+    results.push_back(app_control->SetCategory(category->c_str()));
   }
   if (launch_mode) {
     results.push_back(app_control->SetLaunchMode(*launch_mode));

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -54,7 +54,7 @@ void AppControlChannel::NotifyAppControl(void* handle) {
   if (event_sink_) {
     SendAppControlEvent(app_control.get());
   } else {
-    FT_LOG(Info) << "No event channel has been initialized.";
+    FT_LOG(Info) << "No event channel has been set up.";
     queue_.push(app_control.get());
   }
   AppControlManager::GetInstance().Insert(std::move(app_control));
@@ -239,27 +239,27 @@ void AppControlChannel::SetAppControlData(
 
   std::vector<AppControlResult> results;
   if (app_id) {
-    results.emplace_back(app_control->SetAppId(*app_id));
+    results.push_back(app_control->SetAppId(*app_id));
   }
   if (operation) {
-    results.emplace_back(app_control->SetOperation(*operation));
+    results.push_back(app_control->SetOperation(*operation));
   }
   if (uri) {
-    results.emplace_back(app_control->SetUri(*uri));
+    results.push_back(app_control->SetUri(*uri));
   }
   if (mime) {
-    results.emplace_back(app_control->SetMime(*mime));
+    results.push_back(app_control->SetMime(*mime));
   }
   if (category) {
-    results.emplace_back(app_control->SetCategory(*category));
+    results.push_back(app_control->SetCategory(*category));
   }
   if (launch_mode) {
-    results.emplace_back(app_control->SetLaunchMode(*launch_mode));
+    results.push_back(app_control->SetLaunchMode(*launch_mode));
   }
   if (extra_data) {
-    results.emplace_back(app_control->SetExtraData(*extra_data));
+    results.push_back(app_control->SetExtraData(*extra_data));
   }
-  for (auto ret : results) {
+  for (AppControlResult ret : results) {
     if (!ret) {
       result->Error(ret.code(), ret.message());
       return;
@@ -269,7 +269,7 @@ void AppControlChannel::SetAppControlData(
 }
 
 void AppControlChannel::SendAppControlEvent(AppControl* app_control) {
-  EncodableValue map = app_control->SerializeAppControlToMap();
+  EncodableValue map = app_control->SerializeToMap();
   if (!map.IsNull()) {
     event_sink_->Success(map);
   }

--- a/shell/platform/tizen/channels/app_control_channel.h
+++ b/shell/platform/tizen/channels/app_control_channel.h
@@ -29,9 +29,6 @@ class AppControlChannel {
   void RegisterEventHandler(std::unique_ptr<EventSink<EncodableValue>> events);
   void UnregisterEventHandler();
 
-  void Create(std::unique_ptr<MethodResult<EncodableValue>> result);
-  void Dispose(AppControl* app_control,
-               std::unique_ptr<MethodResult<EncodableValue>> result);
   void Reply(AppControl* app_control,
              const EncodableMap* arguments,
              std::unique_ptr<MethodResult<EncodableValue>> result);

--- a/shell/platform/tizen/channels/app_control_channel.h
+++ b/shell/platform/tizen/channels/app_control_channel.h
@@ -28,36 +28,31 @@ class AppControlChannel {
                         std::unique_ptr<MethodResult<EncodableValue>> result);
   void RegisterEventHandler(std::unique_ptr<EventSink<EncodableValue>> events);
   void UnregisterEventHandler();
-  void SendAlreadyQueuedEvents();
 
-  AppControl* GetAppControl(const EncodableValue* arguments);
-
-  void CreateAppControl(std::unique_ptr<MethodResult<EncodableValue>> result);
-
+  void Create(std::unique_ptr<MethodResult<EncodableValue>> result);
   void Dispose(AppControl* app_control,
                std::unique_ptr<MethodResult<EncodableValue>> result);
   void Reply(AppControl* app_control,
-             const EncodableValue* arguments,
+             const EncodableMap* arguments,
              std::unique_ptr<MethodResult<EncodableValue>> result);
   void SendLaunchRequest(AppControl* app_control,
-                         const EncodableValue* arguments,
+                         const EncodableMap* arguments,
                          std::unique_ptr<MethodResult<EncodableValue>> result);
   void SendTerminateRequest(
       AppControl* app_control,
       std::unique_ptr<MethodResult<EncodableValue>> result);
-
   void SetAppControlData(AppControl* app_control,
-                         const EncodableValue* arguments,
+                         const EncodableMap* arguments,
                          std::unique_ptr<MethodResult<EncodableValue>> result);
-  void SendAppControlDataEvent(AppControl* app_control);
+
+  void SendAppControlEvent(AppControl* app_control);
 
   std::unique_ptr<MethodChannel<EncodableValue>> method_channel_;
   std::unique_ptr<EventChannel<EncodableValue>> event_channel_;
   std::unique_ptr<EventSink<EncodableValue>> event_sink_;
 
-  // We need this queue, because there is no quarantee
-  // that EventChannel on Dart side will be registered
-  // before native OnAppControl event
+  // We need this queue, because there is no quarantee that EventChannel on
+  // Dart side will be registered before native OnAppControl event.
   std::queue<AppControl*> queue_;
 };
 


### PR DESCRIPTION
- Clarify error messages.
- Use implicit construction of `AppControlResult` aggressively.
- Allow null values for `appId`, `operation`, `uri`, `mime`, `category`, and `callerAppId` when receiving messages.
- Ensure `AppControlManager.Insert()` is called before `AppControl.on_reply_` is called to avoid subtle timing issues.
- Remove and inline `AppControlChannel.GetAppControl()` and `AppControlChannel.SendAlreadyQueuedEvents()`.
- Deprecate `requestId` and use `replyId` instead if available.
- General clean up.

Contributes to https://github.com/flutter-tizen/flutter-tizen/issues/210.

I'll implement [`GetMatchedAppIds`](https://docs.tizen.org/application/dotnet/api/TizenFX/API8/api/Tizen.Applications.AppControl.html#Tizen_Applications_AppControl_GetMatchedApplicationIds_Tizen_Applications_AppControl_) ~and some lifecycle events (especially `onTerminate`)~ in the next PR.