### PR TITLE
Implement getMatchedAppIds

### DIFF
--- a/shell/platform/tizen/channels/app_control.cc
+++ b/shell/platform/tizen/channels/app_control.cc
@@ -300,6 +300,23 @@ EncodableValue AppControl::SerializeToMap() {
   return EncodableValue(map);
 }
 
+AppControlResult AppControl::GetMatchedAppIds(EncodableList& list) {
+  EncodableList app_ids;
+  AppControlResult ret = app_control_foreach_app_matched(
+      handle_,
+      [](app_control_h app_control, const char* app_id,
+         void* user_data) -> bool {
+        auto app_ids = static_cast<EncodableList*>(user_data);
+        app_ids->push_back(EncodableValue(app_id));
+        return true;
+      },
+      &app_ids);
+  if (ret) {
+    list = std::move(app_ids);
+  }
+  return ret;
+}
+
 AppControlResult AppControl::SendLaunchRequest() {
   return app_control_send_launch_request(handle_, nullptr, nullptr);
 }

--- a/shell/platform/tizen/channels/app_control.h
+++ b/shell/platform/tizen/channels/app_control.h
@@ -89,6 +89,7 @@ class AppControl {
 
   EncodableValue SerializeToMap();
 
+  AppControlResult GetMatchedAppIds(EncodableList& list);
   AppControlResult SendLaunchRequest();
   AppControlResult SendLaunchRequestWithReply(ReplyCallback on_reply);
   AppControlResult SendTerminateRequest();

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -99,6 +99,14 @@ void AppControlChannel::HandleMethodCall(
   if (method_name == "dispose") {
     AppControlManager::GetInstance().Remove(app_control->id());
     result->Success();
+  } else if (method_name == "getMatchedAppIds") {
+    EncodableList app_ids;
+    AppControlResult ret = app_control->GetMatchedAppIds(app_ids);
+    if (ret) {
+      result->Success(EncodableValue(app_ids));
+    } else {
+      result->Error(ret.code(), ret.message());
+    }
   } else if (method_name == "reply") {
     Reply(app_control, arguments, std::move(result));
   } else if (method_name == "sendLaunchRequest") {


### PR DESCRIPTION
Adds support for the app_control channel's `getMatchedAppIds` method.

Should be rebased after https://github.com/flutter-tizen/engine/pull/184 is merged.