### PR TITLE
[docker] Restore mtime of .git* files

### DIFF
--- a/ci/docker/tizen/tools/cache-checksum.sh
+++ b/ci/docker/tizen/tools/cache-checksum.sh
@@ -40,7 +40,7 @@ if [[ "$COMMAND" == "restore" ]]; then
     fi
 
     # Set mtime of files in $TARGET_DIRS to OLD time.
-    for d in $(find $TARGET_DIRS -type d -not -path "*/.git*"); do
+    for d in $(find $TARGET_DIRS -type d); do
         touch -c -m -d @1600000000 $d/* &
     done
 


### PR DESCRIPTION
Restore mtime of .git* files to OLD TIME together because some ninja build uses the `.git/logs/HEAD` files to get the version information. This affects the incremental build.

