### PR TITLE
Migrate to Flutter 2.5.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,8 @@ jobs:
       gclient sync -f -D
       sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' build/config/compiler/BUILD.gn
       sed -i 's/"-Wno-psabi",//g' build/config/compiler/BUILD.gn
+      sed -i 's/"-Wno-unused-but-set-parameter",//g' build/config/compiler/BUILD.gn
+      sed -i 's/"-Wno-unused-but-set-variable",//g' build/config/compiler/BUILD.gn
     displayName: Disable build flags
     workingDirectory: $(Pipeline.Workspace)/src
     failOnStderr: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,17 +8,7 @@ pr:
 - flutter-*-tizen
 
 jobs:
-- job: format
-  pool:
-    name: Default
-    demands: Agent.os -equals Linux
-  steps:
-  - checkout: self
-    path: src/flutter
-  - bash: ci/format.sh
-    displayName: Verify formatting
 - job: test
-  dependsOn: format
   pool:
     name: Default
     demands: agent.os -equals Linux

--- a/ci/docker/tizen/tools/build-engine.sh
+++ b/ci/docker/tizen/tools/build-engine.sh
@@ -59,6 +59,8 @@ else
     # FIXME: Remove unsupported options of tizen toolchains from BUILD.gn.
     sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' src/build/config/compiler/BUILD.gn
     sed -i 's/"-Wno-psabi",//g' src/build/config/compiler/BUILD.gn
+    sed -i 's/"-Wno-unused-but-set-parameter",//g' build/config/compiler/BUILD.gn
+    sed -i 's/"-Wno-unused-but-set-variable",//g' build/config/compiler/BUILD.gn
 
     src/flutter/tools/gn \
         --target-os $BUILD_OS \

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -343,7 +343,7 @@ void FlutterTizenEngine::SendPointerEvent(const FlutterPointerEvent& event) {
 void FlutterTizenEngine::SendWindowMetrics(int32_t width,
                                            int32_t height,
                                            double pixel_ratio) {
-  FlutterWindowMetricsEvent event;
+  FlutterWindowMetricsEvent event = {};
   event.struct_size = sizeof(FlutterWindowMetricsEvent);
   event.width = width;
   event.height = height;

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -67,6 +67,7 @@ void TouchEventHandler::SendFlutterPointerEvent(FlutterPointerPhase phase,
   event.scroll_delta_y = scroll_delta_y * 2;
   event.timestamp = timestamp * 1000;
   event.device = device_id;
+  event.device_kind = kFlutterPointerDeviceKindTouch;
 
   engine_->SendPointerEvent(event);
 }


### PR DESCRIPTION
- Deal with additional unsupported compiler options: `-Wno-unused-but-set-parameter`, `-Wno-unused-but-set-variable`
- Zero-initialize `FlutterWindowMetricsEvent` to prevent runtime errors.
- Explicitly specify `FlutterPointerEvent.device_kind` as `kFlutterPointerDeviceKindTouch` for `FlutterEngineSendPointerEvent`.
- Remove the format job in `azure-pipelines.yml`. [githooks](https://github.com/flutter-tizen/engine/tree/flutter-2.5.1-tizen/tools/githooks) were added to the repo (upstream) so verifying formatting in the CI is redundant.

Part of https://github.com/flutter-tizen/flutter-tizen/issues/230.