### PR TITLE
Allow null of user_data in FlutterDesktopMessengerSendWithReply

### DIFF
--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -302,7 +302,7 @@ bool FlutterTizenEngine::SendPlatformMessage(
     const FlutterDesktopBinaryReply reply,
     void* user_data) {
   FlutterPlatformMessageResponseHandle* response_handle = nullptr;
-  if (reply != nullptr && user_data != nullptr) {
+  if (reply != nullptr) {
     FlutterEngineResult result =
         embedder_api_.PlatformMessageCreateResponseHandle(
             engine_, reply, user_data, &response_handle);


### PR DESCRIPTION
`user_data` can be null. 
Currently, if the `user_data` of `FlutterDesktopMessengerSendWithReply` method is `null`, the reply callback is not called.
