### PR TITLE
Enable the quick panel pull-down gesture

### DIFF
--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -310,6 +310,13 @@ bool TizenRendererEcoreWl2::SetupEcoreWlWindow(int32_t width, int32_t height) {
     ecore_wl2_window_focus_skip_set(ecore_wl2_window_, EINA_TRUE);
   }
 
+  ecore_wl2_window_indicator_state_set(ecore_wl2_window_,
+                                       ECORE_WL2_INDICATOR_STATE_ON);
+  ecore_wl2_window_indicator_opacity_set(ecore_wl2_window_,
+                                         ECORE_WL2_INDICATOR_OPAQUE);
+  ecore_wl2_indicator_visible_type_set(ecore_wl2_window_,
+                                       ECORE_WL2_INDICATOR_VISIBLE_TYPE_SHOWN);
+
   int rotations[4] = {0, 90, 180, 270};
   ecore_wl2_window_available_rotations_set(ecore_wl2_window_, rotations,
                                            sizeof(rotations) / sizeof(int));

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -665,6 +665,9 @@ Evas_Object* TizenRendererEvasGL::SetupEvasWindow(int32_t* width,
   evas_object_resize(evas_window_, *width, *height);
   evas_object_raise(evas_window_);
 
+  elm_win_indicator_mode_set(evas_window_, ELM_WIN_INDICATOR_SHOW);
+  elm_win_indicator_opacity_set(evas_window_, ELM_WIN_INDICATOR_OPAQUE);
+
   Evas_Object* bg = elm_bg_add(evas_window_);
   evas_object_color_set(bg, 0x00, 0x00, 0x00, 0x00);
 


### PR DESCRIPTION
Fixes https://github.com/flutter-tizen/flutter-tizen/issues/246.

The gesture now works but the notification bar itself is still not being displayed (the app launches in full screen mode).

![](https://user-images.githubusercontent.com/40190588/138624061-9b75927b-96da-4fe6-9cea-bbd9957585d2.png) ![](https://user-images.githubusercontent.com/40190588/138624065-15c3f07c-1022-4289-ad84-055f205ce198.png)

cf. Non-Flutter (native) app

![](https://user-images.githubusercontent.com/40190588/138624184-d677ca42-b7f0-4347-847b-6190cc267256.png)


