### PR TITLE
Fix a crash when Ecore device name is null

### DIFF
--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -324,7 +324,7 @@ bool TextInputChannel::FilterEvent(Ecore_Event_Key* event) {
 #if defined(__X64_SHELL__)
   bool is_ime = false;
 #elif defined(WEARABLE_PROFILE)
-  // Hardware keyboard not supported on watches.
+  // Hardware keyboard is not supported on watch devices.
   bool is_ime = true;
   // FIXME: Only for wearable.
   if (is_ime && strcmp(event->key, "Select") == 0) {
@@ -332,7 +332,8 @@ bool TextInputChannel::FilterEvent(Ecore_Event_Key* event) {
     FT_LOG(Debug) << "Entering select mode.";
   }
 #else
-  bool is_ime = strcmp(ecore_device_name_get(event->dev), "ime") == 0;
+  auto device_name = ecore_device_name_get(event->dev);
+  bool is_ime = device_name ? strcmp(device_name, "ime") == 0 : true;
 #endif
 
   if (ShouldNotFilterEvent(event->key, is_ime)) {


### PR DESCRIPTION
How to reproduce:
1. Run the [form_app](https://github.com/flutter/samples/tree/master/form_app) sample app on a RPi device with a mouse connected.
2. Click "Autofill" and click any text field in the screen.
3. Right click twice. The app will crash with a segfault.

Why it crashes: The value returned by `ecore_device_name_get` is possibly `nullptr` but passing `nullptr` to `strcmp` is an undefined behavior.