### PR TITLE
Add window channel

### DIFF
--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -157,6 +157,7 @@ template("embedder") {
         "channels/app_control_channel.cc",
         "channels/platform_channel_tizen.cc",
         "channels/settings_channel_tizen.cc",
+        "channels/window_channel.cc",
         "external_texture_surface_gl_tizen.cc",
         "system_utils_tizen.cc",
       ]

--- a/shell/platform/tizen/channels/window_channel.cc
+++ b/shell/platform/tizen/channels/window_channel.cc
@@ -49,7 +49,7 @@ void WindowChannel::HandleMethodCall(
   const auto& method_name = method_call.method_name();
 
   if (method_name == "getWindowGeometry") {
-    TizenRenderer::WindowGeometry geometry = renderer_->GetCurrentGeometry();
+    TizenRenderer::Geometry geometry = renderer_->GetWindowGeometry();
     EncodableMap map;
     map[EncodableValue("x")] = EncodableValue(geometry.x);
     map[EncodableValue("y")] = EncodableValue(geometry.y);
@@ -72,15 +72,15 @@ void WindowChannel::HandleMethodCall(
     EncodableValueHolder<int32_t> width(arguments, "width");
     EncodableValueHolder<int32_t> height(arguments, "height");
 
-    TizenRenderer::WindowGeometry geometry = renderer_->GetCurrentGeometry();
+    TizenRenderer::Geometry geometry = renderer_->GetWindowGeometry();
 
     delegate_->OnGeometryChange(x ? *x : geometry.x, y ? *y : geometry.y,
                                 width ? *width : geometry.w,
                                 height ? *height : geometry.h);
     result->Success();
 #endif
-  } else if (method_name == "getScreenSize") {
-    TizenRenderer::WindowGeometry geometry = renderer_->GetScreenGeometry();
+  } else if (method_name == "getScreenGeometry") {
+    TizenRenderer::Geometry geometry = renderer_->GetScreenGeometry();
     EncodableMap map;
     map[EncodableValue("width")] = EncodableValue(geometry.w);
     map[EncodableValue("height")] = EncodableValue(geometry.h);

--- a/shell/platform/tizen/channels/window_channel.cc
+++ b/shell/platform/tizen/channels/window_channel.cc
@@ -2,14 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-private-field"
 #include "window_channel.h"
-
-#include <system_info.h>
+#pragma clang diagnostic pop
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
 #include "flutter/shell/platform/tizen/channels/encodable_value_holder.h"
 #include "flutter/shell/platform/tizen/logger.h"
-
 namespace flutter {
 
 namespace {
@@ -18,17 +18,6 @@ constexpr char kChannelName[] = "tizen/internal/window";
 
 }  // namespace
 
-#ifdef TIZEN_RENDERER_EVAS_GL
-WindowChannel::WindowChannel(BinaryMessenger* messenger,
-                             TizenRenderer* renderer)
-    : renderer_(renderer) {
-  channel_ = std::make_unique<MethodChannel<EncodableValue>>(
-      messenger, kChannelName, &StandardMethodCodec::GetInstance());
-  channel_->SetMethodCallHandler([this](const auto& call, auto result) {
-    this->HandleMethodCall(call, std::move(result));
-  });
-}
-#else
 WindowChannel::WindowChannel(BinaryMessenger* messenger,
                              TizenRenderer* renderer,
                              TizenRenderer::Delegate* delegate)
@@ -39,7 +28,6 @@ WindowChannel::WindowChannel(BinaryMessenger* messenger,
     this->HandleMethodCall(call, std::move(result));
   });
 }
-#endif
 
 WindowChannel::~WindowChannel() {}
 

--- a/shell/platform/tizen/channels/window_channel.cc
+++ b/shell/platform/tizen/channels/window_channel.cc
@@ -58,9 +58,8 @@ void WindowChannel::HandleMethodCall(
     result->Success(EncodableValue(map));
   } else if (method_name == "setWindowGeometry") {
 #ifdef TIZEN_RENDERER_EVAS_GL
-    FT_LOG(Error) << "setGeometry is not supported on wearables.";
-    result->Error("Not supported",
-                  "setGeometry is not supported on wearables.");
+    FT_LOG(Error) << "setWindowGeometry is not supported on evas_gl.";
+    result->NotImplemented();
 #else
     auto arguments = std::get_if<EncodableMap>(method_call.arguments());
     if (!arguments) {

--- a/shell/platform/tizen/channels/window_channel.cc
+++ b/shell/platform/tizen/channels/window_channel.cc
@@ -1,0 +1,97 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "window_channel.h"
+
+#include <system_info.h>
+
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
+#include "flutter/shell/platform/tizen/channels/encodable_value_holder.h"
+#include "flutter/shell/platform/tizen/logger.h"
+
+namespace flutter {
+
+namespace {
+
+constexpr char kChannelName[] = "tizen/internal/window";
+
+}  // namespace
+
+#ifdef TIZEN_RENDERER_EVAS_GL
+WindowChannel::WindowChannel(BinaryMessenger* messenger,
+                             TizenRenderer* renderer)
+    : renderer_(renderer) {
+  channel_ = std::make_unique<MethodChannel<EncodableValue>>(
+      messenger, kChannelName, &StandardMethodCodec::GetInstance());
+  channel_->SetMethodCallHandler([this](const auto& call, auto result) {
+    this->HandleMethodCall(call, std::move(result));
+  });
+}
+#else
+WindowChannel::WindowChannel(BinaryMessenger* messenger,
+                             TizenRenderer* renderer,
+                             TizenRenderer::Delegate* delegate)
+    : renderer_(renderer), delegate_(delegate) {
+  channel_ = std::make_unique<MethodChannel<EncodableValue>>(
+      messenger, kChannelName, &StandardMethodCodec::GetInstance());
+  channel_->SetMethodCallHandler([this](const auto& call, auto result) {
+    this->HandleMethodCall(call, std::move(result));
+  });
+}
+#endif
+
+WindowChannel::~WindowChannel() {}
+
+void WindowChannel::HandleMethodCall(
+    const MethodCall<EncodableValue>& method_call,
+    std::unique_ptr<MethodResult<EncodableValue>> result) {
+  const auto& method_name = method_call.method_name();
+
+  if (method_name == "getWindowGeometry") {
+    TizenRenderer::WindowGeometry geometry = renderer_->GetCurrentGeometry();
+    EncodableMap map;
+    map[EncodableValue("x")] = EncodableValue(geometry.x);
+    map[EncodableValue("y")] = EncodableValue(geometry.y);
+    map[EncodableValue("width")] = EncodableValue(geometry.w);
+    map[EncodableValue("height")] = EncodableValue(geometry.h);
+    result->Success(EncodableValue(map));
+  } else if (method_name == "setWindowGeometry") {
+#ifdef TIZEN_RENDERER_EVAS_GL
+    FT_LOG(Error) << "setGeometry is not supported on wearables.";
+    result->Error("Not supported",
+                  "setGeometry is not supported on wearables.");
+#else
+    auto arguments = std::get_if<EncodableMap>(method_call.arguments());
+    if (!arguments) {
+      result->Error("Invalid arguments");
+      return;
+    }
+    EncodableValueHolder<int32_t> x(arguments, "x");
+    EncodableValueHolder<int32_t> y(arguments, "y");
+    EncodableValueHolder<int32_t> width(arguments, "width");
+    EncodableValueHolder<int32_t> height(arguments, "height");
+
+    TizenRenderer::WindowGeometry geometry = renderer_->GetCurrentGeometry();
+
+    delegate_->OnGeometryChange(x ? *x : geometry.x, y ? *y : geometry.y,
+                                width ? *width : geometry.w,
+                                height ? *height : geometry.h);
+    result->Success();
+#endif
+  } else if (method_name == "getScreenSize") {
+    int width, height;
+    system_info_get_platform_int("http://tizen.org/feature/screen.width",
+                                 &width);
+    system_info_get_platform_int("http://tizen.org/feature/screen.height",
+                                 &height);
+    EncodableMap map;
+    map[EncodableValue("width")] = EncodableValue(width);
+    map[EncodableValue("height")] = EncodableValue(height);
+    result->Success(EncodableValue(map));
+  } else {
+    result->NotImplemented();
+  }
+}
+
+}  // namespace flutter

--- a/shell/platform/tizen/channels/window_channel.cc
+++ b/shell/platform/tizen/channels/window_channel.cc
@@ -80,14 +80,10 @@ void WindowChannel::HandleMethodCall(
     result->Success();
 #endif
   } else if (method_name == "getScreenSize") {
-    int width, height;
-    system_info_get_platform_int("http://tizen.org/feature/screen.width",
-                                 &width);
-    system_info_get_platform_int("http://tizen.org/feature/screen.height",
-                                 &height);
+    TizenRenderer::WindowGeometry geometry = renderer_->GetScreenGeometry();
     EncodableMap map;
-    map[EncodableValue("width")] = EncodableValue(width);
-    map[EncodableValue("height")] = EncodableValue(height);
+    map[EncodableValue("width")] = EncodableValue(geometry.w);
+    map[EncodableValue("height")] = EncodableValue(geometry.h);
     result->Success(EncodableValue(map));
   } else {
     result->NotImplemented();

--- a/shell/platform/tizen/channels/window_channel.cc
+++ b/shell/platform/tizen/channels/window_channel.cc
@@ -10,6 +10,7 @@
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
 #include "flutter/shell/platform/tizen/channels/encodable_value_holder.h"
 #include "flutter/shell/platform/tizen/logger.h"
+
 namespace flutter {
 
 namespace {

--- a/shell/platform/tizen/channels/window_channel.h
+++ b/shell/platform/tizen/channels/window_channel.h
@@ -16,13 +16,9 @@ namespace flutter {
 
 class WindowChannel {
  public:
-#ifdef TIZEN_RENDERER_EVAS_GL
-  WindowChannel(BinaryMessenger* messenger, TizenRenderer* renderer);
-#else
-  WindowChannel(BinaryMessenger* messenger,
-                TizenRenderer* renderer,
-                TizenRenderer::Delegate* delegate);
-#endif
+  explicit WindowChannel(BinaryMessenger* messenger,
+                         TizenRenderer* renderer,
+                         TizenRenderer::Delegate* delegate);
   virtual ~WindowChannel();
 
  private:
@@ -34,9 +30,7 @@ class WindowChannel {
   // A reference to the renderer object managed by FlutterTizenEngine.
   // This can be nullptr if the engine is running in headless mode.
   TizenRenderer* renderer_;
-#ifndef TIZEN_RENDERER_EVAS_GL
   TizenRenderer::Delegate* delegate_;
-#endif
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/channels/window_channel.h
+++ b/shell/platform/tizen/channels/window_channel.h
@@ -6,7 +6,6 @@
 #define EMBEDDER_WINDOW_CHANNEL_H_
 
 #include <memory>
-#include <queue>
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"

--- a/shell/platform/tizen/channels/window_channel.h
+++ b/shell/platform/tizen/channels/window_channel.h
@@ -1,0 +1,45 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef EMBEDDER_WINDOW_CHANNEL_H_
+#define EMBEDDER_WINDOW_CHANNEL_H_
+
+#include <memory>
+#include <queue>
+
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
+#include "flutter/shell/platform/tizen/tizen_renderer.h"
+
+namespace flutter {
+
+class WindowChannel {
+ public:
+#ifdef TIZEN_RENDERER_EVAS_GL
+  WindowChannel(BinaryMessenger* messenger, TizenRenderer* renderer);
+#else
+  WindowChannel(BinaryMessenger* messenger,
+                TizenRenderer* renderer,
+                TizenRenderer::Delegate* delegate);
+#endif
+  virtual ~WindowChannel();
+
+ private:
+  void HandleMethodCall(const MethodCall<EncodableValue>& method_call,
+                        std::unique_ptr<MethodResult<EncodableValue>> result);
+
+  std::unique_ptr<MethodChannel<EncodableValue>> channel_;
+
+  // A reference to the renderer object managed by FlutterTizenEngine.
+  // This can be nullptr if the engine is running in headless mode.
+  TizenRenderer* renderer_;
+#ifndef TIZEN_RENDERER_EVAS_GL
+  TizenRenderer::Delegate* delegate_;
+#endif
+};
+
+}  // namespace flutter
+
+#endif  // EMBEDDER_WINDOW_CHANNEL_H_

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -90,9 +90,8 @@ void FlutterTizenEngine::InitializeRenderer(int32_t x,
                                             int32_t width,
                                             int32_t height,
                                             bool transparent,
-                                            bool focusable,
-                                            bool top_level) {
-  TizenRenderer::WindowGeometry geometry = {x, y, width, height};
+                                            bool focusable) {
+  TizenRenderer::Geometry geometry = {x, y, width, height};
 
 #ifdef TIZEN_RENDERER_EVAS_GL
   renderer_ = std::make_unique<TizenRendererEvasGL>(
@@ -248,16 +247,7 @@ bool FlutterTizenEngine::RunEngine(const char* entrypoint) {
 #ifndef __X64_SHELL__
   app_control_channel_ = std::make_unique<AppControlChannel>(
       internal_plugin_registrar_->messenger());
-  if (IsHeaded()) {
-#ifdef TIZEN_RENDERER_EVAS_GL
-    window_channel_ = std::make_unique<WindowChannel>(
-        internal_plugin_registrar_->messenger(), renderer_.get());
-#else
-    window_channel_ = std::make_unique<WindowChannel>(
-        internal_plugin_registrar_->messenger(), renderer_.get(), this);
-#endif  // TIZEN_RENDERER_EVAS_GL
-  }
-#endif  // !__X64_SHELL__
+#endif
   lifecycle_channel_ = std::make_unique<LifecycleChannel>(
       internal_plugin_registrar_->messenger());
   platform_channel_ = std::make_unique<PlatformChannel>(
@@ -276,6 +266,15 @@ bool FlutterTizenEngine::RunEngine(const char* entrypoint) {
     text_input_channel_ = std::make_unique<TextInputChannel>(
         internal_plugin_registrar_->messenger(),
         std::make_unique<TizenInputMethodContext>(this));
+#ifndef __X64_SHELL__
+#ifdef TIZEN_RENDERER_EVAS_GL
+    window_channel_ = std::make_unique<WindowChannel>(
+        internal_plugin_registrar_->messenger(), renderer_.get());
+#else
+    window_channel_ = std::make_unique<WindowChannel>(
+        internal_plugin_registrar_->messenger(), renderer_.get(), this);
+#endif  // TIZEN_RENDERER_EVAS_GL
+#endif  // !__X64_SHELL__
     key_event_handler_ = std::make_unique<KeyEventHandler>(this);
     touch_event_handler_ = std::make_unique<TouchEventHandler>(this);
 
@@ -390,7 +389,7 @@ void FlutterTizenEngine::SetWindowOrientation(int32_t degree) {
   renderer_->SetRotate(degree);
   // Compute renderer transformation based on the angle of rotation.
   double rad = (360 - degree) * M_PI / 180;
-  auto geometry = renderer_->GetCurrentGeometry();
+  auto geometry = renderer_->GetWindowGeometry();
   double width = geometry.w;
   double height = geometry.h;
 
@@ -413,7 +412,7 @@ void FlutterTizenEngine::SetWindowOrientation(int32_t degree) {
     std::swap(width, height);
   }
   renderer_->ResizeWithRotation(geometry.x, geometry.y, width, height, degree);
-  // Window position does not change on rotation regardless of it's size.
+  // Window position does not change on rotation regardless of its orientation.
   SendWindowMetrics(geometry.x, geometry.y, width, height, 0.0);
 }
 

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -248,7 +248,16 @@ bool FlutterTizenEngine::RunEngine(const char* entrypoint) {
 #ifndef __X64_SHELL__
   app_control_channel_ = std::make_unique<AppControlChannel>(
       internal_plugin_registrar_->messenger());
-#endif
+  if (IsHeaded()) {
+#ifdef TIZEN_RENDERER_EVAS_GL
+    window_channel_ = std::make_unique<WindowChannel>(
+        internal_plugin_registrar_->messenger(), renderer_.get());
+#else
+    window_channel_ = std::make_unique<WindowChannel>(
+        internal_plugin_registrar_->messenger(), renderer_.get(), this);
+#endif  // TIZEN_RENDERER_EVAS_GL
+  }
+#endif  // !__X64_SHELL__
   lifecycle_channel_ = std::make_unique<LifecycleChannel>(
       internal_plugin_registrar_->messenger());
   platform_channel_ = std::make_unique<PlatformChannel>(
@@ -343,11 +352,15 @@ void FlutterTizenEngine::SendPointerEvent(const FlutterPointerEvent& event) {
   embedder_api_.SendPointerEvent(engine_, &event, 1);
 }
 
-void FlutterTizenEngine::SendWindowMetrics(int32_t width,
+void FlutterTizenEngine::SendWindowMetrics(int32_t x,
+                                           int32_t y,
+                                           int32_t width,
                                            int32_t height,
                                            double pixel_ratio) {
   FlutterWindowMetricsEvent event = {};
   event.struct_size = sizeof(FlutterWindowMetricsEvent);
+  event.left = static_cast<size_t>(x);
+  event.top = static_cast<size_t>(y);
   event.width = static_cast<size_t>(width);
   event.height = static_cast<size_t>(height);
   if (pixel_ratio == 0.0) {
@@ -397,19 +410,31 @@ void FlutterTizenEngine::SetWindowOrientation(int32_t degree) {
   };
   touch_event_handler_->rotation = degree;
   if (degree == 90 || degree == 270) {
-    renderer_->ResizeWithRotation(geometry.x, geometry.y, height, width,
-                                  degree);
-    SendWindowMetrics(height, width, 0.0);
-  } else {
-    renderer_->ResizeWithRotation(geometry.x, geometry.y, width, height,
-                                  degree);
-    SendWindowMetrics(width, height, 0.0);
+    std::swap(width, height);
   }
+  renderer_->ResizeWithRotation(geometry.x, geometry.y, width, height, degree);
+  // Window position does not change on rotation regardless of it's size.
+  SendWindowMetrics(geometry.x, geometry.y, width, height, 0.0);
 }
 
 void FlutterTizenEngine::OnOrientationChange(int32_t degree) {
   SetWindowOrientation(degree);
 }
+
+#ifndef TIZEN_RENDERER_EVAS_GL
+void FlutterTizenEngine::OnGeometryChange(int32_t x,
+                                          int32_t y,
+                                          int32_t width,
+                                          int32_t height) {
+  if (!renderer_->IsValid()) {
+    return;
+  }
+  static_cast<TizenRendererEcoreWl2*>(renderer_.get())
+      ->SetGeometry(x, y, width, height);
+  renderer_->ResizeWithRotation(x, y, width, height, 0);
+  SendWindowMetrics(x, y, width, height, 0.0);
+}
+#endif
 
 void FlutterTizenEngine::OnVsync(intptr_t baton,
                                  uint64_t frame_start_time_nanos,
@@ -456,8 +481,8 @@ bool FlutterTizenEngine::MarkExternalTextureFrameAvailable(int64_t texture_id) {
               engine_, texture_id) == kSuccess);
 }
 
-// The Flutter Engine calls out to this function when new platform messages are
-// available.
+// The Flutter Engine calls out to this function when new platform messages
+// are available.
 
 // Converts a FlutterPlatformMessage to an equivalent FlutterDesktopMessage.
 FlutterDesktopMessage FlutterTizenEngine::ConvertToDesktopMessage(

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -90,7 +90,8 @@ void FlutterTizenEngine::InitializeRenderer(int32_t x,
                                             int32_t width,
                                             int32_t height,
                                             bool transparent,
-                                            bool focusable) {
+                                            bool focusable,
+                                            bool top_level) {
   TizenRenderer::Geometry geometry = {x, y, width, height};
 
 #ifdef TIZEN_RENDERER_EVAS_GL

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -420,7 +420,6 @@ void FlutterTizenEngine::OnOrientationChange(int32_t degree) {
   SetWindowOrientation(degree);
 }
 
-#ifndef TIZEN_RENDERER_EVAS_GL
 void FlutterTizenEngine::OnGeometryChange(int32_t x,
                                           int32_t y,
                                           int32_t width,
@@ -428,12 +427,10 @@ void FlutterTizenEngine::OnGeometryChange(int32_t x,
   if (!renderer_->IsValid()) {
     return;
   }
-  static_cast<TizenRendererEcoreWl2*>(renderer_.get())
-      ->SetGeometry(x, y, width, height);
+  renderer_->SetGeometry(x, y, width, height);
   renderer_->ResizeWithRotation(x, y, width, height, 0);
   SendWindowMetrics(x, y, width, height, 0.0);
 }
-#endif
 
 void FlutterTizenEngine::OnVsync(intptr_t baton,
                                  uint64_t frame_start_time_nanos,

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -268,14 +268,9 @@ bool FlutterTizenEngine::RunEngine(const char* entrypoint) {
         internal_plugin_registrar_->messenger(),
         std::make_unique<TizenInputMethodContext>(this));
 #ifndef __X64_SHELL__
-#ifdef TIZEN_RENDERER_EVAS_GL
-    window_channel_ = std::make_unique<WindowChannel>(
-        internal_plugin_registrar_->messenger(), renderer_.get());
-#else
     window_channel_ = std::make_unique<WindowChannel>(
         internal_plugin_registrar_->messenger(), renderer_.get(), this);
-#endif  // TIZEN_RENDERER_EVAS_GL
-#endif  // !__X64_SHELL__
+#endif
     key_event_handler_ = std::make_unique<KeyEventHandler>(this);
     touch_event_handler_ = std::make_unique<TouchEventHandler>(this);
 
@@ -425,12 +420,16 @@ void FlutterTizenEngine::OnGeometryChange(int32_t x,
                                           int32_t y,
                                           int32_t width,
                                           int32_t height) {
+#ifdef TIZEN_RENDERER_EVAS_GL
+  FT_UNIMPLEMENTED();
+#else
   if (!renderer_->IsValid()) {
     return;
   }
   renderer_->SetGeometry(x, y, width, height);
   renderer_->ResizeWithRotation(x, y, width, height, 0);
   SendWindowMetrics(x, y, width, height, 0.0);
+#endif
 }
 
 void FlutterTizenEngine::OnVsync(intptr_t baton,

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -145,12 +145,10 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
 
   void SetWindowOrientation(int32_t degree);
   void OnOrientationChange(int32_t degree) override;
-#ifndef TIZEN_RENDERER_EVAS_GL
   void OnGeometryChange(int32_t x,
                         int32_t y,
                         int32_t width,
                         int32_t height) override;
-#endif
   void OnVsync(intptr_t baton,
                uint64_t frame_start_time_nanos,
                uint64_t frame_target_time_nanos);

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -21,6 +21,7 @@
 #include "flutter/shell/platform/tizen/channels/platform_view_channel.h"
 #include "flutter/shell/platform/tizen/channels/settings_channel.h"
 #include "flutter/shell/platform/tizen/channels/text_input_channel.h"
+#include "flutter/shell/platform/tizen/channels/window_channel.h"
 #include "flutter/shell/platform/tizen/flutter_project_bundle.h"
 #include "flutter/shell/platform/tizen/flutter_tizen_texture_registrar.h"
 #include "flutter/shell/platform/tizen/key_event_handler.h"
@@ -136,10 +137,20 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
 
   // Sends a window metrics update to the Flutter engine using current window
   // dimensions in physical
-  void SendWindowMetrics(int32_t width, int32_t height, double pixel_ratio);
+  void SendWindowMetrics(int32_t x,
+                         int32_t y,
+                         int32_t width,
+                         int32_t height,
+                         double pixel_ratio);
 
   void SetWindowOrientation(int32_t degree);
   void OnOrientationChange(int32_t degree) override;
+#ifndef TIZEN_RENDERER_EVAS_GL
+  void OnGeometryChange(int32_t x,
+                        int32_t y,
+                        int32_t width,
+                        int32_t height) override;
+#endif
   void OnVsync(intptr_t baton,
                uint64_t frame_start_time_nanos,
                uint64_t frame_target_time_nanos);
@@ -216,6 +227,9 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
 #ifndef __X64_SHELL__
   // A plugin that implements Tizen app_control channels.
   std::unique_ptr<AppControlChannel> app_control_channel_;
+
+  // A plugin that implements the Tizen window channel.
+  std::unique_ptr<WindowChannel> window_channel_;
 #endif
 
   // A plugin that implements the Flutter keyevent channel.

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -227,9 +227,6 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
 #ifndef __X64_SHELL__
   // A plugin that implements Tizen app_control channels.
   std::unique_ptr<AppControlChannel> app_control_channel_;
-
-  // A plugin that implements the Tizen window channel.
-  std::unique_ptr<WindowChannel> window_channel_;
 #endif
 
   // A plugin that implements the Flutter keyevent channel.
@@ -252,6 +249,11 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
 
   // A plugin that implements the Flutter textinput channel.
   std::unique_ptr<TextInputChannel> text_input_channel_;
+
+#ifndef __X64_SHELL__
+  // A plugin that implements the Tizen window channel.
+  std::unique_ptr<WindowChannel> window_channel_;
+#endif
 
   // The event loop for the main thread that allows for delayed task execution.
   std::unique_ptr<TizenPlatformEventLoop> event_loop_;

--- a/shell/platform/tizen/tizen_renderer.cc
+++ b/shell/platform/tizen/tizen_renderer.cc
@@ -6,7 +6,7 @@
 
 namespace flutter {
 
-TizenRenderer::TizenRenderer(WindowGeometry geometry,
+TizenRenderer::TizenRenderer(Geometry geometry,
                              bool transparent,
                              bool focusable,
                              bool top_level,

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -19,12 +19,10 @@ class TizenRenderer {
   class Delegate {
    public:
     virtual void OnOrientationChange(int32_t degree) = 0;
-#ifndef TIZEN_RENDERER_EVAS_GL
     virtual void OnGeometryChange(int32_t x,
                                   int32_t y,
                                   int32_t width,
                                   int32_t height) = 0;
-#endif
   };
 
   virtual ~TizenRenderer();
@@ -49,6 +47,10 @@ class TizenRenderer {
   virtual void* GetWindowHandle() = 0;
 
   virtual void SetRotate(int angle) = 0;
+  virtual void SetGeometry(int32_t x,
+                           int32_t y,
+                           int32_t width,
+                           int32_t height) = 0;
   virtual void ResizeWithRotation(int32_t x,
                                   int32_t y,
                                   int32_t width,

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -12,7 +12,7 @@ namespace flutter {
 
 class TizenRenderer {
  public:
-  struct WindowGeometry {
+  struct Geometry {
     int32_t x{0}, y{0}, w{0}, h{0};
   };
 
@@ -39,10 +39,10 @@ class TizenRenderer {
   virtual void* OnProcResolver(const char* name) = 0;
 
   // Returns the geometry of the current window.
-  virtual WindowGeometry GetCurrentGeometry() = 0;
+  virtual Geometry GetWindowGeometry() = 0;
 
   // Returns the geometry of the display screen.
-  virtual WindowGeometry GetScreenGeometry() = 0;
+  virtual Geometry GetScreenGeometry() = 0;
 
   virtual int32_t GetDpi() = 0;
   virtual uintptr_t GetWindowId() = 0;
@@ -58,13 +58,13 @@ class TizenRenderer {
   virtual bool IsSupportedExtention(const char* name) = 0;
 
  protected:
-  explicit TizenRenderer(WindowGeometry geometry,
+  explicit TizenRenderer(Geometry geometry,
                          bool transparent,
                          bool focusable,
                          bool top_level,
                          Delegate& delegate);
 
-  WindowGeometry initial_geometry_;
+  Geometry initial_geometry_;
   bool transparent_;
   bool focusable_;
   bool top_level_;

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -19,6 +19,12 @@ class TizenRenderer {
   class Delegate {
    public:
     virtual void OnOrientationChange(int32_t degree) = 0;
+#ifndef TIZEN_RENDERER_EVAS_GL
+    virtual void OnGeometryChange(int32_t x,
+                                  int32_t y,
+                                  int32_t width,
+                                  int32_t height) = 0;
+#endif
   };
 
   virtual ~TizenRenderer();

--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -38,7 +38,12 @@ class TizenRenderer {
   virtual uint32_t OnGetFBO() = 0;
   virtual void* OnProcResolver(const char* name) = 0;
 
+  // Returns the geometry of the current window.
   virtual WindowGeometry GetCurrentGeometry() = 0;
+
+  // Returns the geometry of the display screen.
+  virtual WindowGeometry GetScreenGeometry() = 0;
+
   virtual int32_t GetDpi() = 0;
   virtual uintptr_t GetWindowId() = 0;
   virtual void* GetWindowHandle() = 0;

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -11,7 +11,7 @@
 
 namespace flutter {
 
-TizenRendererEcoreWl2::TizenRendererEcoreWl2(WindowGeometry geometry,
+TizenRendererEcoreWl2::TizenRendererEcoreWl2(Geometry geometry,
                                              bool transparent,
                                              bool focusable,
                                              bool top_level,
@@ -206,15 +206,15 @@ void* TizenRendererEcoreWl2::OnProcResolver(const char* name) {
   return nullptr;
 }
 
-TizenRenderer::WindowGeometry TizenRendererEcoreWl2::GetCurrentGeometry() {
-  WindowGeometry result;
+TizenRenderer::Geometry TizenRendererEcoreWl2::GetWindowGeometry() {
+  Geometry result;
   ecore_wl2_window_geometry_get(ecore_wl2_window_, &result.x, &result.y,
                                 &result.w, &result.h);
   return result;
 }
 
-TizenRenderer::WindowGeometry TizenRendererEcoreWl2::GetScreenGeometry() {
-  WindowGeometry result;
+TizenRenderer::Geometry TizenRendererEcoreWl2::GetScreenGeometry() {
+  Geometry result;
   ecore_wl2_display_screen_size_get(ecore_wl2_display_, &result.w, &result.h);
   return result;
 }

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -214,7 +214,7 @@ TizenRenderer::Geometry TizenRendererEcoreWl2::GetWindowGeometry() {
 }
 
 TizenRenderer::Geometry TizenRendererEcoreWl2::GetScreenGeometry() {
-  Geometry result;
+  Geometry result = {};
   ecore_wl2_display_screen_size_get(ecore_wl2_display_, &result.w, &result.h);
   return result;
 }

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -213,6 +213,12 @@ TizenRenderer::WindowGeometry TizenRendererEcoreWl2::GetCurrentGeometry() {
   return result;
 }
 
+TizenRenderer::WindowGeometry TizenRendererEcoreWl2::GetScreenGeometry() {
+  WindowGeometry result;
+  ecore_wl2_display_screen_size_get(ecore_wl2_display_, &result.w, &result.h);
+  return result;
+}
+
 int32_t TizenRendererEcoreWl2::GetDpi() {
   auto* output = ecore_wl2_window_output_find(ecore_wl2_window_);
   if (!output) {

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -553,6 +553,14 @@ void TizenRendererEcoreWl2::SetRotate(int angle) {
   received_rotation_ = true;
 }
 
+void TizenRendererEcoreWl2::SetGeometry(int32_t x,
+                                        int32_t y,
+                                        int32_t width,
+                                        int32_t height) {
+  ecore_wl2_window_geometry_set(ecore_wl2_window_, x, y, width, height);
+  ecore_wl2_window_position_set(ecore_wl2_window_, x, y);
+}
+
 void TizenRendererEcoreWl2::ResizeWithRotation(int32_t x,
                                                int32_t y,
                                                int32_t width,

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -38,13 +38,16 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   uintptr_t GetWindowId() override;
   void* GetWindowHandle() override;
 
+  void SetRotate(int angle) override;
+  void SetGeometry(int32_t x,
+                   int32_t y,
+                   int32_t width,
+                   int32_t height) override;
   void ResizeWithRotation(int32_t x,
                           int32_t y,
                           int32_t width,
                           int32_t height,
                           int32_t angle) override;
-  void SetRotate(int angle) override;
-  void SetGeometry(int32_t x, int32_t y, int32_t width, int32_t height);
   void SetPreferredOrientations(const std::vector<int>& rotations) override;
   bool IsSupportedExtention(const char* name) override;
 

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -33,6 +33,7 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   void* OnProcResolver(const char* name) override;
 
   WindowGeometry GetCurrentGeometry() override;
+  WindowGeometry GetScreenGeometry() override;
   int32_t GetDpi() override;
   uintptr_t GetWindowId() override;
   void* GetWindowHandle() override;

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -18,7 +18,7 @@ namespace flutter {
 
 class TizenRendererEcoreWl2 : public TizenRenderer {
  public:
-  explicit TizenRendererEcoreWl2(WindowGeometry geometry,
+  explicit TizenRendererEcoreWl2(Geometry geometry,
                                  bool transparent,
                                  bool focusable,
                                  bool top_level,
@@ -32,8 +32,8 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   uint32_t OnGetFBO() override;
   void* OnProcResolver(const char* name) override;
 
-  WindowGeometry GetCurrentGeometry() override;
-  WindowGeometry GetScreenGeometry() override;
+  Geometry GetWindowGeometry() override;
+  Geometry GetScreenGeometry() override;
   int32_t GetDpi() override;
   uintptr_t GetWindowId() override;
   void* GetWindowHandle() override;

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -43,6 +43,7 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
                           int32_t height,
                           int32_t angle) override;
   void SetRotate(int angle) override;
+  void SetGeometry(int32_t x, int32_t y, int32_t width, int32_t height);
   void SetPreferredOrientations(const std::vector<int>& rotations) override;
   bool IsSupportedExtention(const char* name) override;
 

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -16,7 +16,7 @@ EVAS_GL_GLOBAL_GLES3_DEFINE();
 
 namespace flutter {
 
-TizenRendererEvasGL::TizenRendererEvasGL(WindowGeometry geometry,
+TizenRendererEvasGL::TizenRendererEvasGL(Geometry geometry,
                                          bool transparent,
                                          bool focusable,
                                          bool top_level,
@@ -546,15 +546,15 @@ void* TizenRendererEvasGL::OnProcResolver(const char* name) {
   return nullptr;
 }
 
-TizenRenderer::WindowGeometry TizenRendererEvasGL::GetCurrentGeometry() {
-  WindowGeometry result;
+TizenRenderer::Geometry TizenRendererEvasGL::GetWindowGeometry() {
+  Geometry result;
   evas_object_geometry_get(evas_window_, &result.x, &result.y, &result.w,
                            &result.h);
   return result;
 }
 
-TizenRenderer::WindowGeometry TizenRendererEvasGL::GetScreenGeometry() {
-  WindowGeometry result;
+TizenRenderer::Geometry TizenRendererEvasGL::GetScreenGeometry() {
+  Geometry result;
   auto* ecore_evas =
       ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_));
   ecore_evas_screen_geometry_get(ecore_evas, nullptr, nullptr, &result.w,

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -739,6 +739,13 @@ void TizenRendererEvasGL::SetRotate(int angle) {
   received_rotation_ = true;
 }
 
+void TizenRendererEvasGL::SetGeometry(int32_t x,
+                                      int32_t y,
+                                      int32_t width,
+                                      int32_t height) {
+  FT_UNIMPLEMENTED();
+}
+
 void TizenRendererEvasGL::ResizeWithRotation(int32_t x,
                                              int32_t y,
                                              int32_t width,

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -553,6 +553,15 @@ TizenRenderer::WindowGeometry TizenRendererEvasGL::GetCurrentGeometry() {
   return result;
 }
 
+TizenRenderer::WindowGeometry TizenRendererEvasGL::GetScreenGeometry() {
+  WindowGeometry result;
+  auto* ecore_evas =
+      ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_));
+  ecore_evas_screen_geometry_get(ecore_evas, nullptr, nullptr, &result.w,
+                                 &result.h);
+  return result;
+}
+
 int32_t TizenRendererEvasGL::GetDpi() {
   auto* ecore_evas =
       ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_));

--- a/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -31,6 +31,7 @@ class TizenRendererEvasGL : public TizenRenderer {
   void* OnProcResolver(const char* name) override;
 
   WindowGeometry GetCurrentGeometry() override;
+  WindowGeometry GetScreenGeometry() override;
   int32_t GetDpi() override;
   uintptr_t GetWindowId() override;
   void* GetWindowHandle() override;

--- a/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -16,7 +16,7 @@ namespace flutter {
 
 class TizenRendererEvasGL : public TizenRenderer {
  public:
-  explicit TizenRendererEvasGL(WindowGeometry geometry,
+  explicit TizenRendererEvasGL(Geometry geometry,
                                bool transparent,
                                bool focusable,
                                bool top_level,
@@ -30,8 +30,8 @@ class TizenRendererEvasGL : public TizenRenderer {
   uint32_t OnGetFBO() override;
   void* OnProcResolver(const char* name) override;
 
-  WindowGeometry GetCurrentGeometry() override;
-  WindowGeometry GetScreenGeometry() override;
+  Geometry GetWindowGeometry() override;
+  Geometry GetScreenGeometry() override;
   int32_t GetDpi() override;
   uintptr_t GetWindowId() override;
   void* GetWindowHandle() override;

--- a/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -36,12 +36,16 @@ class TizenRendererEvasGL : public TizenRenderer {
   uintptr_t GetWindowId() override;
   void* GetWindowHandle() override;
 
+  void SetRotate(int angle) override;
+  void SetGeometry(int32_t x,
+                   int32_t y,
+                   int32_t width,
+                   int32_t height) override;
   void ResizeWithRotation(int32_t x,
                           int32_t y,
                           int32_t width,
                           int32_t height,
                           int32_t angle) override;
-  void SetRotate(int angle) override;
   void SetPreferredOrientations(const std::vector<int>& rotations) override;
   bool IsSupportedExtention(const char* name) override;
 

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -39,7 +39,7 @@ void TouchEventHandler::SendFlutterPointerEvent(FlutterPointerPhase phase,
                                                 size_t timestamp,
                                                 int device_id = 0) {
   // Correct errors caused by window rotation.
-  auto geometry = engine_->renderer()->GetCurrentGeometry();
+  auto geometry = engine_->renderer()->GetWindowGeometry();
   double width = geometry.w;
   double height = geometry.h;
   double new_x = x, new_y = y;


### PR DESCRIPTION
The use case for setting window geometry at runtime is explained [here](https://github.sec.samsung.net/f-project/system_ui_app/issues/38) (internal repo).

Test app: https://github.com/HakkyuKim/flutter_tizen_window_resize_test_app

## TODO
- [x] Disable for evas_gl renderer.
- [x] Investigate why it works for TV and wearable emulators but not for mobile.
    Can't figure out why, decided not to support in this PR since it's not important compared to other tasks.
- [x] Investigate why x and y position are not set correctly.
    Must also call `ecore_wl2_window_position_set`.
- [x] ~~Test with rotation.~~
    I'll write a "remaining issues" in the issue tab.
- [x] Test with top_level window, #191.
- [x] Formatting.
- [x] ~~Check dynamic type of `TizenRenderer` in `WindowChannel::HandleMethodCall()`.~~ Use conditional compilation.