### PR TITLE
Implement the forwarding logger

### DIFF
--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -211,7 +211,6 @@ template("embedder") {
     public_deps = [ ":flutter_engine" ]
 
     deps = [
-      "//flutter/fml:command_line",
       "//flutter/shell/platform/common:common_cpp",
       "//flutter/shell/platform/common:common_cpp_input",
       "//flutter/shell/platform/common:common_cpp_library_headers",

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -211,6 +211,7 @@ template("embedder") {
     public_deps = [ ":flutter_engine" ]
 
     deps = [
+      "//flutter/fml:command_line",
       "//flutter/shell/platform/common:common_cpp",
       "//flutter/shell/platform/common:common_cpp_input",
       "//flutter/shell/platform/common:common_cpp_library_headers",

--- a/shell/platform/tizen/flutter_project_bundle.cc
+++ b/shell/platform/tizen/flutter_project_bundle.cc
@@ -67,16 +67,34 @@ FlutterProjectBundle::FlutterProjectBundle(
     }
   }
 
-  switches_.insert(switches_.end(), properties.switches,
-                   properties.switches + properties.switches_count);
+  engine_arguments_.insert(engine_arguments_.end(), properties.switches,
+                           properties.switches + properties.switches_count);
 }
 
 bool FlutterProjectBundle::HasValidPaths() {
   return !assets_path_.empty() && !icu_path_.empty();
 }
 
-// Attempts to load AOT data from the given path, which must be absolute and
-// non-empty. Logs and returns nullptr on failure.
+bool FlutterProjectBundle::HasArgument(const std::string& name) {
+  return std::find(engine_arguments_.begin(), engine_arguments_.end(), name) !=
+         engine_arguments_.end();
+}
+
+bool FlutterProjectBundle::GetArgumentValue(const std::string& name,
+                                            std::string* value) {
+  auto iter =
+      std::find(engine_arguments_.begin(), engine_arguments_.end(), name);
+  if (iter == engine_arguments_.end()) {
+    return false;
+  }
+  auto next = std::next(iter);
+  if (next == engine_arguments_.end()) {
+    return false;
+  }
+  *value = *next;
+  return true;
+}
+
 UniqueAotDataPtr FlutterProjectBundle::LoadAotData(
     const FlutterEngineProcTable& engine_procs) {
   if (aot_library_path_.empty()) {

--- a/shell/platform/tizen/flutter_project_bundle.h
+++ b/shell/platform/tizen/flutter_project_bundle.h
@@ -39,8 +39,16 @@ class FlutterProjectBundle {
   // Returns the path to the ICU data file.
   const std::filesystem::path& icu_path() { return icu_path_; }
 
-  // Returns any switches that should be passed to the engine.
-  const std::vector<std::string> switches() { return switches_; }
+  // Returns the arguments to be passed to the engine.
+  const std::vector<std::string> engine_arguments() {
+    return engine_arguments_;
+  }
+
+  // Returns true if |engine_arguments| contains the argument |name|.
+  bool HasArgument(const std::string& name);
+
+  // Gets the value of the argument |name| from |engine_arguments|.
+  bool GetArgumentValue(const std::string& name, std::string* value);
 
   // Attempts to load AOT data for this bundle. The returned data must be
   // retained until any engine instance it is passed to has been shut down.
@@ -57,7 +65,7 @@ class FlutterProjectBundle {
  private:
   std::filesystem::path assets_path_;
   std::filesystem::path icu_path_;
-  std::vector<std::string> switches_ = {};
+  std::vector<std::string> engine_arguments_ = {};
 
   // Path to the AOT library file, if any.
   std::filesystem::path aot_library_path_;

--- a/shell/platform/tizen/flutter_project_bundle_unittests.cc
+++ b/shell/platform/tizen/flutter_project_bundle_unittests.cc
@@ -34,7 +34,7 @@ TEST(FlutterProjectBundle, BasicPropertiesRelativePaths) {
   EXPECT_EQ(project.icu_path().filename().string(), "icudtl.dat");
 }
 
-TEST(FlutterProjectBundle, SwitchesEmpty) {
+TEST(FlutterProjectBundle, EmptyEngineArguments) {
   FlutterDesktopEngineProperties properties = {};
   properties.assets_path = "foo/flutter_assets";
   properties.icu_data_path = "foo/icudtl.dat";
@@ -45,10 +45,10 @@ TEST(FlutterProjectBundle, SwitchesEmpty) {
 
   FlutterProjectBundle project(properties);
 
-  EXPECT_EQ(project.switches().size(), 0u);
+  EXPECT_EQ(project.engine_arguments().size(), 0u);
 }
 
-TEST(FlutterProjectBundle, Switches) {
+TEST(FlutterProjectBundle, HasEngineArguments) {
   FlutterDesktopEngineProperties properties = {};
   properties.assets_path = "foo/flutter_assets";
   properties.icu_data_path = "foo/icudtl.dat";
@@ -62,9 +62,9 @@ TEST(FlutterProjectBundle, Switches) {
 
   FlutterProjectBundle project(properties);
 
-  EXPECT_EQ(project.switches().size(), 2u);
-  EXPECT_EQ(project.switches()[0], "--abc");
-  EXPECT_EQ(project.switches()[1], "--foo=\"bar, baz\"");
+  EXPECT_EQ(project.engine_arguments().size(), 2u);
+  EXPECT_EQ(project.engine_arguments()[0], "--abc");
+  EXPECT_EQ(project.engine_arguments()[1], "--foo=\"bar, baz\"");
 }
 
 }  // namespace testing

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -5,6 +5,7 @@
 
 #include "public/flutter_tizen.h"
 
+#include "flutter/fml/command_line.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
 #include "flutter/shell/platform/common/incoming_message_dispatcher.h"
@@ -28,7 +29,16 @@ static FlutterDesktopEngineRef HandleForEngine(
 FlutterDesktopEngineRef FlutterDesktopRunEngine(
     const FlutterDesktopWindowProperties& window_properties,
     const FlutterDesktopEngineProperties& engine_properties) {
+  fml::CommandLine switches = fml::CommandLineFromArgcArgv(
+      engine_properties.switches_count, engine_properties.switches);
+  if (switches.HasOption("verbose-logging")) {
+    flutter::Logger::SetLoggingLevel(flutter::kLogLevelDebug);
+  }
 #ifndef __X64_SHELL__
+  std::string logging_port;
+  if (switches.GetOptionValue("tizen-logging-port", &logging_port)) {
+    flutter::Logger::SetLoggingPort(std::stoi(logging_port));
+  }
   flutter::Logger::Start();
 #endif
 
@@ -48,6 +58,9 @@ FlutterDesktopEngineRef FlutterDesktopRunEngine(
 }
 
 void FlutterDesktopShutdownEngine(FlutterDesktopEngineRef engine_ref) {
+#ifndef __X64_SHELL__
+  flutter::Logger::Stop();
+#endif
   auto engine = EngineFromHandle(engine_ref);
   engine->StopEngine();
   delete engine;

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -5,7 +5,6 @@
 
 #include "public/flutter_tizen.h"
 
-#include "flutter/fml/command_line.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
 #include "flutter/shell/platform/common/incoming_message_dispatcher.h"
@@ -14,35 +13,47 @@
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/public/flutter_platform_view.h"
 
+namespace {
+
 // Returns the engine corresponding to the given opaque API handle.
-static flutter::FlutterTizenEngine* EngineFromHandle(
-    FlutterDesktopEngineRef ref) {
+flutter::FlutterTizenEngine* EngineFromHandle(FlutterDesktopEngineRef ref) {
   return reinterpret_cast<flutter::FlutterTizenEngine*>(ref);
 }
 
 // Returns the opaque API handle for the given engine instance.
-static FlutterDesktopEngineRef HandleForEngine(
-    flutter::FlutterTizenEngine* engine) {
+FlutterDesktopEngineRef HandleForEngine(flutter::FlutterTizenEngine* engine) {
   return reinterpret_cast<FlutterDesktopEngineRef>(engine);
 }
+
+// Returns the texture registrar corresponding to the given opaque API handle.
+flutter::FlutterTizenTextureRegistrar* TextureRegistrarFromHandle(
+    FlutterDesktopTextureRegistrarRef ref) {
+  return reinterpret_cast<flutter::FlutterTizenTextureRegistrar*>(ref);
+}
+
+// Returns the opaque API handle for the given texture registrar instance.
+FlutterDesktopTextureRegistrarRef HandleForTextureRegistrar(
+    flutter::FlutterTizenTextureRegistrar* registrar) {
+  return reinterpret_cast<FlutterDesktopTextureRegistrarRef>(registrar);
+}
+
+}  // namespace
 
 FlutterDesktopEngineRef FlutterDesktopRunEngine(
     const FlutterDesktopWindowProperties& window_properties,
     const FlutterDesktopEngineProperties& engine_properties) {
-  fml::CommandLine switches = fml::CommandLineFromArgcArgv(
-      engine_properties.switches_count, engine_properties.switches);
-  if (switches.HasOption("verbose-logging")) {
+  flutter::FlutterProjectBundle project(engine_properties);
+  if (project.HasArgument("--verbose-logging")) {
     flutter::Logger::SetLoggingLevel(flutter::kLogLevelDebug);
   }
 #ifndef __X64_SHELL__
   std::string logging_port;
-  if (switches.GetOptionValue("tizen-logging-port", &logging_port)) {
+  if (project.GetArgumentValue("--tizen-logging-port", &logging_port)) {
     flutter::Logger::SetLoggingPort(std::stoi(logging_port));
   }
   flutter::Logger::Start();
 #endif
 
-  flutter::FlutterProjectBundle project(engine_properties);
   auto engine = std::make_unique<flutter::FlutterTizenEngine>(project);
   if (window_properties.headed) {
     engine->InitializeRenderer(
@@ -172,18 +183,6 @@ void FlutterRegisterViewFactory(
   registrar->engine->platform_view_channel()->ViewFactories().insert(
       std::pair<std::string, std::unique_ptr<PlatformViewFactory>>(
           view_type, std::move(view_factory)));
-}
-
-// Returns the texture registrar corresponding to the given opaque API handle.
-static flutter::FlutterTizenTextureRegistrar* TextureRegistrarFromHandle(
-    FlutterDesktopTextureRegistrarRef ref) {
-  return reinterpret_cast<flutter::FlutterTizenTextureRegistrar*>(ref);
-}
-
-// Returns the opaque API handle for the given texture registrar instance.
-static FlutterDesktopTextureRegistrarRef HandleForTextureRegistrar(
-    flutter::FlutterTizenTextureRegistrar* registrar) {
-  return reinterpret_cast<FlutterDesktopTextureRegistrarRef>(registrar);
 }
 
 FlutterDesktopTextureRegistrarRef FlutterDesktopRegistrarGetTextureRegistrar(

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -148,11 +148,6 @@ bool FlutterTizenEngine::RunEngine(const char* entrypoint) {
       switches.begin(), switches.end(), std::back_inserter(argv),
       [](const std::string& arg) -> const char* { return arg.c_str(); });
 
-  if (std::find(switches.begin(), switches.end(), "--verbose-logging") !=
-      switches.end()) {
-    Logger::SetLoggingLevel(kLogLevelDebug);
-  }
-
   const std::vector<std::string>& entrypoint_args =
       project_->dart_entrypoint_arguments();
   std::vector<const char*> entrypoint_argv;

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -142,10 +142,10 @@ bool FlutterTizenEngine::RunEngine(const char* entrypoint) {
   // FlutterProjectArgs is expecting a full argv, so when processing it for
   // flags the first item is treated as the executable and ignored. Add a dummy
   // value so that all provided arguments are used.
-  std::vector<std::string> switches = project_->switches();
-  std::vector<const char*> argv = {"placeholder"};
+  std::vector<std::string> engine_args = project_->engine_arguments();
+  std::vector<const char*> engine_argv = {"placeholder"};
   std::transform(
-      switches.begin(), switches.end(), std::back_inserter(argv),
+      engine_args.begin(), engine_args.end(), std::back_inserter(engine_argv),
       [](const std::string& arg) -> const char* { return arg.c_str(); });
 
   const std::vector<std::string>& entrypoint_args =
@@ -195,8 +195,9 @@ bool FlutterTizenEngine::RunEngine(const char* entrypoint) {
   args.struct_size = sizeof(FlutterProjectArgs);
   args.assets_path = assets_path_string.c_str();
   args.icu_data_path = icu_path_string.c_str();
-  args.command_line_argc = static_cast<int>(argv.size());
-  args.command_line_argv = argv.size() > 0 ? argv.data() : nullptr;
+  args.command_line_argc = static_cast<int>(engine_argv.size());
+  args.command_line_argv =
+      engine_argv.size() > 0 ? engine_argv.data() : nullptr;
   args.dart_entrypoint_argc = static_cast<int>(entrypoint_argv.size());
   args.dart_entrypoint_argv =
       entrypoint_argv.size() > 0 ? entrypoint_argv.data() : nullptr;

--- a/shell/platform/tizen/logger.cc
+++ b/shell/platform/tizen/logger.cc
@@ -17,6 +17,7 @@
 
 namespace {
 
+#ifndef __X64_SHELL__
 constexpr char kLogTag[] = "ConsoleMessage";
 
 std::string GetLevelName(int level) {
@@ -34,7 +35,6 @@ std::string GetLevelName(int level) {
   }
 }
 
-#ifndef __X64_SHELL__
 log_priority LevelToPriority(int level) {
   switch (level) {
     case flutter::kLogLevelDebug:
@@ -49,7 +49,7 @@ log_priority LevelToPriority(int level) {
       return DLOG_FATAL;
   }
 }
-#endif
+#endif  // __X64_SHELL__
 
 }  // namespace
 

--- a/shell/platform/tizen/logger.cc
+++ b/shell/platform/tizen/logger.cc
@@ -7,6 +7,9 @@
 #ifndef __X64_SHELL__
 #include <dlog.h>
 #endif
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <cstdlib>
@@ -19,24 +22,83 @@ void* Logger::Redirect(void* arg) {
   ssize_t size;
   char buffer[1024];
 
-  while ((size = read(pipe[0], buffer, sizeof(buffer) - 1)) > 0) {
+  while ((size = read(pipe[0], buffer, sizeof(buffer) - 1)) > 0 &&
+         is_running_) {
     buffer[size] = 0;
     Print(pipe == stdout_pipe_ ? kLogLevelInfo : kLogLevelError,
           std::string(buffer));
   }
+  return nullptr;
+}
 
-  close(pipe[0]);
-  close(pipe[1]);
+void* Logger::Forward(void* arg) {
+  if (logging_port_ == 0) {
+    return nullptr;
+  }
 
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) {
+    FT_LOG(Error) << "Error opening a socket.";
+    return nullptr;
+  }
+  int optval = 1;
+  setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+
+  struct sockaddr_in addr = {};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(logging_port_);
+  if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+    FT_LOG(Error) << "Error on binding: " << strerror(errno);
+    close(fd);
+    return nullptr;
+  }
+  if (listen(fd, 1) < 0) {
+    FT_LOG(Error) << "Error listening to incoming connection: "
+                  << strerror(errno);
+    close(fd);
+    return nullptr;
+  }
+
+  struct sockaddr_in client_addr;
+  socklen_t addr_len = sizeof(client_addr);
+  int new_fd = accept(fd, (struct sockaddr*)&client_addr, &addr_len);
+  if (new_fd < 0) {
+    FT_LOG(Error) << "Error on accept: " << strerror(errno);
+    close(fd);
+    return nullptr;
+  }
+  FT_LOG(Info) << "Accepted connection on port: " << logging_port_;
+  close(fd);
+
+  ssize_t size;
+  char buffer[1024];
+
+  if (write(new_fd, "ACCEPTED", 8) < 0) {
+    FT_LOG(Error) << "Error writing to socket: " << strerror(errno);
+    close(new_fd);
+    return nullptr;
+  }
+  while ((size = read(logging_pipe_[0], buffer, sizeof(buffer) - 1)) > 0 &&
+         is_running_) {
+    if (write(new_fd, buffer, size) < 0) {
+      FT_LOG(Error) << "Error writing to socket: " << strerror(errno);
+      break;
+    }
+  }
+  close(new_fd);
   return nullptr;
 }
 
 void Logger::Start() {
-  if (started_) {
-    FT_LOG(Info) << "The threads have already started.";
+  if (is_running_) {
+    FT_LOG(Info) << "The logging threads have already started.";
     return;
   }
-  if (pipe(stdout_pipe_) < 0 || pipe(stderr_pipe_) < 0) {
+  is_running_ = true;
+
+  if (pipe(stdout_pipe_) < 0 || pipe(stderr_pipe_) < 0 ||
+      pipe(logging_pipe_) < 0) {
     FT_LOG(Error) << "Failed to create pipes.";
     return;
   }
@@ -45,30 +107,42 @@ void Logger::Start() {
     return;
   }
   if (pthread_create(&stdout_thread_, 0, Redirect, stdout_pipe_) != 0 ||
-      pthread_create(&stderr_thread_, 0, Redirect, stderr_pipe_) != 0) {
+      pthread_create(&stderr_thread_, 0, Redirect, stderr_pipe_) != 0 ||
+      pthread_create(&logging_thread_, 0, Forward, nullptr) != 0) {
     FT_LOG(Error) << "Failed to create threads.";
     return;
   }
   if (pthread_detach(stdout_thread_) != 0 ||
-      pthread_detach(stderr_thread_) != 0) {
+      pthread_detach(stderr_thread_) != 0 ||
+      pthread_detach(logging_thread_) != 0) {
     FT_LOG(Warn) << "Failed to detach threads.";
   }
-  started_ = true;
 }
 
-int Logger::GetLoggingLevel() {
-  return logging_level_;
+void Logger::Stop() {
+  if (!is_running_) {
+    return;
+  }
+  is_running_ = false;
+
+  close(stdout_pipe_[0]);
+  close(stdout_pipe_[1]);
+  close(stderr_pipe_[0]);
+  close(stderr_pipe_[1]);
+  close(logging_pipe_[0]);
+  close(logging_pipe_[1]);
 }
 
-void Logger::SetLoggingLevel(int level) {
-  logging_level_ = level;
-}
-
-void Logger::Print(int level, std::string message) {
+void Logger::Print(int level, const std::string& message) {
 #ifdef __X64_SHELL__
   std::cerr << message << std::endl;
   std::cerr.flush();
 #else
+  if (logging_port_ > 0) {
+    // TODO: tag and level, else statement.
+    std::string formatted = message + '\n';
+    write(logging_pipe_[1], formatted.c_str(), formatted.size());
+  }
   log_priority priority;
   if (level == kLogLevelDebug) {
     priority = DLOG_DEBUG;
@@ -84,8 +158,8 @@ void Logger::Print(int level, std::string message) {
     priority = DLOG_INFO;
   }
 #ifdef TV_PROFILE
-  // LOG_ID_MAIN must be used to display logs properly on TV devices.
-  // Note: dlog_print(...) is an alias of __dlog_print(LOG_ID_APPS, ...).
+  // dlog_print(..) which is an alias of __dlog_print(LOG_ID_APPS, ..) is not
+  // compatible on TV devices.
   __dlog_print(LOG_ID_MAIN, priority, "ConsoleMessage", "%s", message.c_str());
 #else
   dlog_print(priority, "ConsoleMessage", "%s", message.c_str());

--- a/shell/platform/tizen/logger.cc
+++ b/shell/platform/tizen/logger.cc
@@ -178,7 +178,7 @@ void Logger::Print(int level, const std::string& message) {
 #else
   // Write the message to the logging pipe so that it can be forwarded to the
   // connected host.
-  if (logging_port_ > 0) {
+  if (logging_port_ > 0 && level >= kLogLevelInfo) {
     std::string prefix = "[" + GetLevelName(level) + "] ";
     std::string formatted = prefix + message + "\n";
     write(logging_pipe_[1], formatted.c_str(), formatted.size());

--- a/shell/platform/tizen/logger.cc
+++ b/shell/platform/tizen/logger.cc
@@ -133,13 +133,13 @@ void Logger::Start() {
     FT_LOG(Info) << "The threads have already started.";
     return;
   }
-  is_running_ = true;
-
   if (pipe(stdout_pipe_) < 0 || pipe(stderr_pipe_) < 0 ||
       pipe(logging_pipe_) < 0) {
     FT_LOG(Error) << "Failed to create pipes.";
     return;
   }
+  is_running_ = true;
+
   if (dup2(stdout_pipe_[1], 1) < 0 || dup2(stderr_pipe_[1], 2) < 0) {
     FT_LOG(Error) << "Failed to duplicate file descriptors.";
     return;

--- a/shell/platform/tizen/logger.cc
+++ b/shell/platform/tizen/logger.cc
@@ -15,6 +15,52 @@
 #include <cstdlib>
 #include <iostream>
 
+namespace {
+
+std::string GetLogLevelInitial(int level) {
+  if (level == flutter::kLogLevelDebug) {
+    return "D";
+  } else if (level == flutter::kLogLevelInfo) {
+    return "I";
+  } else if (level == flutter::kLogLevelWarn) {
+    return "W";
+  } else if (level == flutter::kLogLevelError) {
+    return "E";
+  } else if (level == flutter::kLogLevelFatal) {
+    return "F";
+  } else {
+    return "I";
+  }
+}
+
+#ifndef __X64_SHELL__
+static void PrintToDlog(int level, const std::string& message) {
+  log_priority priority;
+  if (level == flutter::kLogLevelDebug) {
+    priority = DLOG_DEBUG;
+  } else if (level == flutter::kLogLevelInfo) {
+    priority = DLOG_INFO;
+  } else if (level == flutter::kLogLevelWarn) {
+    priority = DLOG_WARN;
+  } else if (level == flutter::kLogLevelError) {
+    priority = DLOG_ERROR;
+  } else if (level == flutter::kLogLevelFatal) {
+    priority = DLOG_FATAL;
+  } else {
+    priority = DLOG_INFO;
+  }
+#ifdef TV_PROFILE
+  // dlog_print(..) which is an alias of __dlog_print(LOG_ID_APPS, ..) is not
+  // compatible on TV devices.
+  __dlog_print(LOG_ID_MAIN, priority, "ConsoleMessage", "%s", message.c_str());
+#else
+  dlog_print(priority, "ConsoleMessage", "%s", message.c_str());
+#endif
+}
+#endif  // __X64_SHELL__
+
+}  // namespace
+
 namespace flutter {
 
 void* Logger::Redirect(void* arg) {
@@ -138,33 +184,15 @@ void Logger::Print(int level, const std::string& message) {
   std::cerr << message << std::endl;
   std::cerr.flush();
 #else
+  // Write to logging pipe so that the message is forwarded to the host.
   if (logging_port_ > 0) {
-    // TODO: tag and level, else statement.
-    std::string formatted = message + '\n';
+    std::string prefix = "[" + GetLogLevelInitial(level) + "] ";
+    std::string formatted = prefix + message + '\n';
     write(logging_pipe_[1], formatted.c_str(), formatted.size());
   }
-  log_priority priority;
-  if (level == kLogLevelDebug) {
-    priority = DLOG_DEBUG;
-  } else if (level == kLogLevelInfo) {
-    priority = DLOG_INFO;
-  } else if (level == kLogLevelWarn) {
-    priority = DLOG_WARN;
-  } else if (level == kLogLevelError) {
-    priority = DLOG_ERROR;
-  } else if (level == kLogLevelFatal) {
-    priority = DLOG_FATAL;
-  } else {
-    priority = DLOG_INFO;
-  }
-#ifdef TV_PROFILE
-  // dlog_print(..) which is an alias of __dlog_print(LOG_ID_APPS, ..) is not
-  // compatible on TV devices.
-  __dlog_print(LOG_ID_MAIN, priority, "ConsoleMessage", "%s", message.c_str());
-#else
-  dlog_print(priority, "ConsoleMessage", "%s", message.c_str());
+  // Also write to dlog for convenience.
+  PrintToDlog(level, message);
 #endif
-#endif  // __X64_SHELL__
 }
 
 LogMessage::LogMessage(int level,

--- a/shell/platform/tizen/logger.cc
+++ b/shell/platform/tizen/logger.cc
@@ -9,55 +9,47 @@
 #endif
 #include <netinet/in.h>
 #include <sys/socket.h>
-#include <sys/types.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <cstdlib>
 #include <iostream>
 
 namespace {
 
-std::string GetLogLevelInitial(int level) {
-  if (level == flutter::kLogLevelDebug) {
-    return "D";
-  } else if (level == flutter::kLogLevelInfo) {
-    return "I";
-  } else if (level == flutter::kLogLevelWarn) {
-    return "W";
-  } else if (level == flutter::kLogLevelError) {
-    return "E";
-  } else if (level == flutter::kLogLevelFatal) {
-    return "F";
-  } else {
-    return "I";
+constexpr char kLogTag[] = "ConsoleMessage";
+
+std::string GetLevelName(int level) {
+  switch (level) {
+    case flutter::kLogLevelDebug:
+      return "D";
+    default:
+      return "I";
+    case flutter::kLogLevelWarn:
+      return "W";
+    case flutter::kLogLevelError:
+      return "E";
+    case flutter::kLogLevelFatal:
+      return "F";
   }
 }
 
 #ifndef __X64_SHELL__
-static void PrintToDlog(int level, const std::string& message) {
-  log_priority priority;
-  if (level == flutter::kLogLevelDebug) {
-    priority = DLOG_DEBUG;
-  } else if (level == flutter::kLogLevelInfo) {
-    priority = DLOG_INFO;
-  } else if (level == flutter::kLogLevelWarn) {
-    priority = DLOG_WARN;
-  } else if (level == flutter::kLogLevelError) {
-    priority = DLOG_ERROR;
-  } else if (level == flutter::kLogLevelFatal) {
-    priority = DLOG_FATAL;
-  } else {
-    priority = DLOG_INFO;
+log_priority LevelToPriority(int level) {
+  switch (level) {
+    case flutter::kLogLevelDebug:
+      return DLOG_DEBUG;
+    default:
+      return DLOG_INFO;
+    case flutter::kLogLevelWarn:
+      return DLOG_WARN;
+    case flutter::kLogLevelError:
+      return DLOG_ERROR;
+    case flutter::kLogLevelFatal:
+      return DLOG_FATAL;
   }
-#ifdef TV_PROFILE
-  // dlog_print(..) which is an alias of __dlog_print(LOG_ID_APPS, ..) is not
-  // compatible on TV devices.
-  __dlog_print(LOG_ID_MAIN, priority, "ConsoleMessage", "%s", message.c_str());
-#else
-  dlog_print(priority, "ConsoleMessage", "%s", message.c_str());
-#endif
 }
-#endif  // __X64_SHELL__
+#endif
 
 }  // namespace
 
@@ -66,7 +58,7 @@ namespace flutter {
 void* Logger::Redirect(void* arg) {
   int* pipe = static_cast<int*>(arg);
   ssize_t size;
-  char buffer[1024];
+  char buffer[4096];
 
   while ((size = read(pipe[0], buffer, sizeof(buffer) - 1)) > 0 &&
          is_running_) {
@@ -114,18 +106,18 @@ void* Logger::Forward(void* arg) {
     close(fd);
     return nullptr;
   }
-  FT_LOG(Info) << "Accepted connection on port: " << logging_port_;
+  FT_LOG(Info) << "Connection accepted on port: " << logging_port_;
   close(fd);
 
   ssize_t size;
-  char buffer[1024];
+  char buffer[4096];
 
   if (write(new_fd, "ACCEPTED", 8) < 0) {
     FT_LOG(Error) << "Error writing to socket: " << strerror(errno);
     close(new_fd);
     return nullptr;
   }
-  while ((size = read(logging_pipe_[0], buffer, sizeof(buffer) - 1)) > 0 &&
+  while ((size = read(logging_pipe_[0], buffer, sizeof(buffer))) > 0 &&
          is_running_) {
     if (write(new_fd, buffer, size) < 0) {
       FT_LOG(Error) << "Error writing to socket: " << strerror(errno);
@@ -138,7 +130,7 @@ void* Logger::Forward(void* arg) {
 
 void Logger::Start() {
   if (is_running_) {
-    FT_LOG(Info) << "The logging threads have already started.";
+    FT_LOG(Info) << "The threads have already started.";
     return;
   }
   is_running_ = true;
@@ -184,15 +176,24 @@ void Logger::Print(int level, const std::string& message) {
   std::cerr << message << std::endl;
   std::cerr.flush();
 #else
-  // Write to logging pipe so that the message is forwarded to the host.
+  // Write the message to the logging pipe so that it can be forwarded to the
+  // connected host.
   if (logging_port_ > 0) {
-    std::string prefix = "[" + GetLogLevelInitial(level) + "] ";
-    std::string formatted = prefix + message + '\n';
+    std::string prefix = "[" + GetLevelName(level) + "] ";
+    std::string formatted = prefix + message + "\n";
     write(logging_pipe_[1], formatted.c_str(), formatted.size());
   }
-  // Also write to dlog for convenience.
-  PrintToDlog(level, message);
+
+  // Also print to dlog for convenience.
+  log_priority priority = LevelToPriority(level);
+#ifdef TV_PROFILE
+  // dlog_print(..) which is an alias of __dlog_print(LOG_ID_APPS, ..) is not
+  // valid on TV devices.
+  __dlog_print(LOG_ID_MAIN, priority, kLogTag, "%s", message.c_str());
+#else
+  dlog_print(priority, kLogTag, "%s", message.c_str());
 #endif
+#endif  // __X64_SHELL__
 }
 
 LogMessage::LogMessage(int level,

--- a/shell/platform/tizen/logger.h
+++ b/shell/platform/tizen/logger.h
@@ -21,27 +21,32 @@ constexpr int kLogLevelFatal = 4;
 
 class Logger {
  public:
-  // Starts logging threads which constantly redirect stdout/stderr to dlog.
-  // The threads should be started only once per process.
   static void Start();
+  static void Stop();
 
-  static int GetLoggingLevel();
-  static void SetLoggingLevel(int level);
+  static int GetLoggingLevel() { return logging_level_; }
+  static void SetLoggingLevel(int level) { logging_level_ = level; }
 
-  static void Print(int level, std::string message);
+  static void SetLoggingPort(int32_t port) { logging_port_ = port; }
+
+  static void Print(int level, const std::string& message);
 
  private:
   explicit Logger();
 
   static void* Redirect(void* arg);
+  static void* Forward(void* arg);
 
-  static inline bool started_ = false;
+  static inline bool is_running_ = false;
   static inline int stdout_pipe_[2];
   static inline int stderr_pipe_[2];
+  static inline int logging_pipe_[2];
   static inline pthread_t stdout_thread_;
   static inline pthread_t stderr_thread_;
+  static inline pthread_t logging_thread_;
 
   static inline int logging_level_ = kLogLevelError;
+  static inline int32_t logging_port_ = 0;
 };
 
 class LogMessage {


### PR DESCRIPTION
- A logging thread is started on app startup which constantly forwards log messages to a connected host. The thread listens for an incoming TCP connection on a port given as an engine argument.
- Checks the presence of the engine argument `verbose-logging` at the very beginning of `FlutterDesktopRunEngine`.
- Misc changes:
  - Rename `switches` in `FlutterProjectBundle` with `engine_arguments`.
  - Add methods `HasArgument` and `GetArgumentValue` to `FlutterProjectBundle`.
  - Move static functions in `flutter_tizen.cc` into an anonymous namespace.
  - Inline `GetLoggingLevel` and `SetLoggingLevel` and minor cleanups.

Contributes to https://github.com/flutter-tizen/flutter-tizen/issues/260.

You can use https://github.com/flutter-tizen/flutter-tizen/pull/271 to test this change.