### PR TITLE
Initial implementation of the system UI overlay methods

### DIFF
--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -59,6 +59,7 @@ config("rootstrap_include_dirs") {
     "$local_prefix/include/eo-1",
     "$local_prefix/include/feedback",
     "$local_prefix/include/system",
+    "$local_prefix/include/tzsh",
     "$local_prefix/include/wayland-extension",
   ]
 
@@ -175,6 +176,8 @@ template("embedder") {
         "feedback",
         "tbm",
         "tdm-client",
+        "tzsh_common",
+        "tzsh_softkey",
         "EGL",
         "GLESv2",
       ]

--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -18,14 +18,16 @@ constexpr char kSetClipboardDataMethod[] = "Clipboard.setData";
 constexpr char kPlaySoundMethod[] = "SystemSound.play";
 constexpr char kHapticFeedbackVibrateMethod[] = "HapticFeedback.vibrate";
 constexpr char kSystemNavigatorPopMethod[] = "SystemNavigator.pop";
-constexpr char kSetPreferredOrientationsMethod[] =
-    "SystemChrome.setPreferredOrientations";
-constexpr char kSetApplicationSwitcherDescriptionMethod[] =
-    "SystemChrome.setApplicationSwitcherDescription";
-constexpr char kSetEnabledSystemUIOverlaysMethod[] =
-    "SystemChrome.setEnabledSystemUIOverlays";
 constexpr char kRestoreSystemUIOverlaysMethod[] =
     "SystemChrome.restoreSystemUIOverlays";
+constexpr char kSetApplicationSwitcherDescriptionMethod[] =
+    "SystemChrome.setApplicationSwitcherDescription";
+constexpr char kSetEnabledSystemUIModeMethod[] =
+    "SystemChrome.setEnabledSystemUIMode";
+constexpr char kSetEnabledSystemUIOverlaysMethod[] =
+    "SystemChrome.setEnabledSystemUIOverlays";
+constexpr char kSetPreferredOrientationsMethod[] =
+    "SystemChrome.setPreferredOrientations";
 constexpr char kSetSystemUIOverlayStyleMethod[] =
     "SystemChrome.setSystemUIOverlayStyle";
 
@@ -100,6 +102,17 @@ void PlatformChannel::HandleMethodCall(
     }
     text_clipboard = iter->value.GetString();
     result->Success();
+  } else if (method == kRestoreSystemUIOverlaysMethod) {
+    RestoreSystemUIOverlays();
+    result->Success();
+  } else if (method == kSetEnabledSystemUIOverlaysMethod) {
+    const auto& list = arguments[0];
+    std::vector<std::string> overlays;
+    for (auto iter = list.Begin(); iter != list.End(); ++iter) {
+      overlays.push_back(iter->GetString());
+    }
+    SetEnabledSystemUIOverlays(overlays);
+    result->Success();
   } else if (method == kSetPreferredOrientationsMethod) {
     const auto& list = arguments[0];
     std::vector<std::string> orientations;
@@ -110,9 +123,7 @@ void PlatformChannel::HandleMethodCall(
     result->Success();
   } else if (method == kSetApplicationSwitcherDescriptionMethod) {
     result->NotImplemented();
-  } else if (method == kSetEnabledSystemUIOverlaysMethod) {
-    result->NotImplemented();
-  } else if (method == kRestoreSystemUIOverlaysMethod) {
+  } else if (method == kSetEnabledSystemUIModeMethod) {
     result->NotImplemented();
   } else if (method == kSetSystemUIOverlayStyleMethod) {
     result->NotImplemented();

--- a/shell/platform/tizen/channels/platform_channel.h
+++ b/shell/platform/tizen/channels/platform_channel.h
@@ -29,6 +29,8 @@ class PlatformChannel {
   void SystemNavigatorPop();
   void PlaySystemSound(const std::string& sound_type);
   void HapticFeedbackVibrate(const std::string& feedback_type);
+  void RestoreSystemUIOverlays();
+  void SetEnabledSystemUIOverlays(const std::vector<std::string>& overlays);
   void SetPreferredOrientations(const std::vector<std::string>& orientations);
 
   std::unique_ptr<MethodChannel<rapidjson::Document>> channel_;

--- a/shell/platform/tizen/channels/platform_channel_linux.cc
+++ b/shell/platform/tizen/channels/platform_channel_linux.cc
@@ -22,6 +22,15 @@ void PlatformChannel::HapticFeedbackVibrate(const std::string& feedback_type) {
   FT_UNIMPLEMENTED();
 }
 
+void PlatformChannel::RestoreSystemUIOverlays() {
+  FT_UNIMPLEMENTED();
+}
+
+void PlatformChannel::SetEnabledSystemUIOverlays(
+    const std::vector<std::string>& overlays) {
+  FT_UNIMPLEMENTED();
+}
+
 void PlatformChannel::SetPreferredOrientations(
     const std::vector<std::string>& orientations) {
   FT_UNIMPLEMENTED();

--- a/shell/platform/tizen/channels/platform_channel_tizen.cc
+++ b/shell/platform/tizen/channels/platform_channel_tizen.cc
@@ -6,6 +6,10 @@
 
 #include <app.h>
 #include <feedback.h>
+#ifdef COMMON_PROFILE
+#include <tzsh.h>
+#include <tzsh_softkey.h>
+#endif
 
 #include <map>
 
@@ -49,8 +53,8 @@ class FeedbackManager {
 
  private:
   FeedbackManager() {
-    auto ret = feedback_initialize();
-    if (FEEDBACK_ERROR_NONE != ret) {
+    int ret = feedback_initialize();
+    if (ret != FEEDBACK_ERROR_NONE) {
       FT_LOG(Error) << "feedback_initialize() failed with error: "
                     << get_error_message(ret);
       return;
@@ -59,10 +63,8 @@ class FeedbackManager {
   }
 
   ~FeedbackManager() {
-    auto ret = feedback_deinitialize();
-    if (FEEDBACK_ERROR_NONE != ret) {
-      FT_LOG(Error) << "feedback_deinitialize() failed with error: "
-                    << get_error_message(ret);
+    if (initialized_) {
+      feedback_deinitialize();
     }
   }
 
@@ -70,12 +72,12 @@ class FeedbackManager {
     if (!initialized_) {
       return;
     }
-    auto ret = feedback_play_type(type, pattern);
-    if (FEEDBACK_ERROR_PERMISSION_DENIED == ret) {
+    int ret = feedback_play_type(type, pattern);
+    if (ret == FEEDBACK_ERROR_PERMISSION_DENIED) {
       FT_LOG(Error)
           << "Permission denied. Add \"http://tizen.org/privilege/haptic\" "
              "privilege to tizen-manifest.xml to use haptic feedbacks.";
-    } else if (FEEDBACK_ERROR_NONE != ret) {
+    } else if (ret != FEEDBACK_ERROR_NONE) {
       FT_LOG(Error) << "feedback_play_type() failed with error: "
                     << get_error_message(ret);
     }
@@ -83,6 +85,87 @@ class FeedbackManager {
 
   bool initialized_ = false;
 };
+
+#ifdef COMMON_PROFILE
+class TizenWindowSystemShell {
+ public:
+  static TizenWindowSystemShell& GetInstance() {
+    static TizenWindowSystemShell instance;
+    return instance;
+  }
+
+  TizenWindowSystemShell(const TizenWindowSystemShell&) = delete;
+  TizenWindowSystemShell& operator=(const TizenWindowSystemShell&) = delete;
+
+  bool IsSoftkeyShown() { return is_softkey_shown_; }
+
+  void InitializeSoftkey(uint32_t window_id) {
+    if (tizen_shell_softkey_ || !tizen_shell_) {
+      return;
+    }
+    tizen_shell_softkey_ = tzsh_softkey_create(tizen_shell_, window_id);
+    if (!tizen_shell_softkey_) {
+      int ret = get_last_result();
+      if (ret == TZSH_ERROR_PERMISSION_DENIED) {
+        FT_LOG(Error) << "Permission denied. You need a "
+                         "\"http://tizen.org/privilege/windowsystem.admin\" "
+                         "privilege to use this method.";
+      } else {
+        FT_LOG(Error) << "tzsh_softkey_create() failed with error: "
+                      << get_error_message(ret);
+      }
+    }
+  }
+
+  void ShowSoftkey() {
+    if (!tizen_shell_softkey_) {
+      return;
+    }
+    int ret = tzsh_softkey_global_show(tizen_shell_softkey_);
+    if (ret != TZSH_ERROR_NONE) {
+      FT_LOG(Error) << "tzsh_softkey_global_show() failed with error: "
+                    << get_error_message(ret);
+    }
+    is_softkey_shown_ = true;
+  }
+
+  void HideSoftkey() {
+    if (!tizen_shell_softkey_) {
+      return;
+    }
+    // Always show the softkey before hiding it again, to avoid subtle bugs.
+    tzsh_softkey_global_show(tizen_shell_softkey_);
+    int ret = tzsh_softkey_global_hide(tizen_shell_softkey_);
+    if (ret != TZSH_ERROR_NONE) {
+      FT_LOG(Error) << "tzsh_softkey_global_hide() failed with error: "
+                    << get_error_message(ret);
+    }
+    is_softkey_shown_ = false;
+  }
+
+ private:
+  TizenWindowSystemShell() {
+    tizen_shell_ = tzsh_create(TZSH_TOOLKIT_TYPE_EFL);
+    if (!tizen_shell_) {
+      FT_LOG(Error) << "tzsh_create() failed with error: "
+                    << get_error_message(get_last_result());
+    }
+  }
+
+  ~TizenWindowSystemShell() {
+    if (tizen_shell_softkey_) {
+      tzsh_softkey_destroy(tizen_shell_softkey_);
+    }
+    if (tizen_shell_) {
+      tzsh_destroy(tizen_shell_);
+    }
+  }
+
+  tzsh_h tizen_shell_ = nullptr;
+  tzsh_softkey_h tizen_shell_softkey_ = nullptr;
+  bool is_softkey_shown_ = true;
+};
+#endif
 
 }  // namespace
 
@@ -98,6 +181,44 @@ void PlatformChannel::HapticFeedbackVibrate(const std::string& feedback_type) {
   FeedbackManager::GetInstance().Vibrate(feedback_type);
 }
 
+void PlatformChannel::RestoreSystemUIOverlays() {
+#ifdef COMMON_PROFILE
+  if (!renderer_) {
+    return;
+  }
+  auto& tizen_shell = TizenWindowSystemShell::GetInstance();
+  tizen_shell.InitializeSoftkey(renderer_->GetWindowId());
+
+  if (tizen_shell.IsSoftkeyShown()) {
+    tizen_shell.ShowSoftkey();
+  } else {
+    tizen_shell.HideSoftkey();
+  }
+#else
+  FT_UNIMPLEMENTED();
+#endif
+}
+
+void PlatformChannel::SetEnabledSystemUIOverlays(
+    const std::vector<std::string>& overlays) {
+#ifdef COMMON_PROFILE
+  if (!renderer_) {
+    return;
+  }
+  auto& tizen_shell = TizenWindowSystemShell::GetInstance();
+  tizen_shell.InitializeSoftkey(renderer_->GetWindowId());
+
+  if (std::find(overlays.begin(), overlays.end(), "SystemUiOverlay.bottom") !=
+      overlays.end()) {
+    tizen_shell.ShowSoftkey();
+  } else {
+    tizen_shell.HideSoftkey();
+  }
+#else
+  FT_UNIMPLEMENTED();
+#endif
+}
+
 void PlatformChannel::SetPreferredOrientations(
     const std::vector<std::string>& orientations) {
   if (!renderer_) {
@@ -110,7 +231,7 @@ void PlatformChannel::SetPreferredOrientations(
       {kLandscapeRight, 270},
   };
   std::vector<int> rotations;
-  for (auto orientation : orientations) {
+  for (const auto& orientation : orientations) {
     rotations.push_back(orientation_mapping.at(orientation));
   }
   if (rotations.size() == 0) {

--- a/shell/platform/tizen/channels/platform_channel_tizen.cc
+++ b/shell/platform/tizen/channels/platform_channel_tizen.cc
@@ -97,8 +97,6 @@ class TizenWindowSystemShell {
   TizenWindowSystemShell(const TizenWindowSystemShell&) = delete;
   TizenWindowSystemShell& operator=(const TizenWindowSystemShell&) = delete;
 
-  bool IsSoftkeyShown() { return is_softkey_shown_; }
-
   void InitializeSoftkey(uint32_t window_id) {
     if (tizen_shell_softkey_ || !tizen_shell_) {
       return;
@@ -117,6 +115,8 @@ class TizenWindowSystemShell {
     }
   }
 
+  bool IsSoftkeyShown() { return is_softkey_shown_; }
+
   void ShowSoftkey() {
     if (!tizen_shell_softkey_) {
       return;
@@ -125,6 +125,7 @@ class TizenWindowSystemShell {
     if (ret != TZSH_ERROR_NONE) {
       FT_LOG(Error) << "tzsh_softkey_global_show() failed with error: "
                     << get_error_message(ret);
+      return;
     }
     is_softkey_shown_ = true;
   }
@@ -139,6 +140,7 @@ class TizenWindowSystemShell {
     if (ret != TZSH_ERROR_NONE) {
       FT_LOG(Error) << "tzsh_softkey_global_hide() failed with error: "
                     << get_error_message(ret);
+      return;
     }
     is_softkey_shown_ = false;
   }


### PR DESCRIPTION
Contributes to https://github.sec.samsung.net/f-project/home/issues/47 (internal repo).

Partially implements
- [SystemChrome.setEnabledSystemUIOverlays](https://api.flutter.dev/flutter/services/SystemChrome/setEnabledSystemUIOverlays.html) (deprecated)
- [SystemChrome.setEnabledSystemUIMode](https://api.flutter.dev/flutter/services/SystemChrome/setEnabledSystemUIMode.html) (only `SystemUiMode.manual` is allowed)
- [SystemChrome.restoreSystemUIOverlays](https://api.flutter.dev/flutter/services/SystemChrome/restoreSystemUIOverlays.html)

This change only implements the navigation bar (softkey) part of the system overlays (supports only `SystemUiOverlay.bottom`). The status bar (indicator) part will be implemented in a later commit.

TZSH-Softkey API information: https://docs.tizen.org/application/native/guides/ui/tizen-ws-shell/tzsh-softkey (since Tizen 5.5)

Additional notes:
- Only works for the common profile, because it's the only profile that has a software navigation bar.
- You need to add the following to your `tizen-manifest.xml` and use a platform level distributor certificate to sign the app.<p>
  ```xml
  <feature name="http://tizen.org/feature/ui_service.softkey"/>
  <privileges>
      <privilege>http://tizen.org/privilege/windowsystem.admin</privilege>
  </privileges>
  ```
- Use [WidgetsBindingObserver.didChangeAppLifecycleState](https://api.flutter.dev/flutter/widgets/WidgetsBindingObserver/didChangeAppLifecycleState.html) if you want to restore system UI overlays on app resume.

The `AZURE_BUILD_ID` for this PR is `674`.