### PR TITLE
Fix segmentation faults in TizenEventLoop

### DIFF
--- a/shell/platform/tizen/flutter_tizen_shell.cc
+++ b/shell/platform/tizen/flutter_tizen_shell.cc
@@ -114,6 +114,6 @@ class FlutterApp {
 };
 
 int main(int argc, char* argv[]) {
-  auto app = new FlutterApp();
-  return app->Run(argc, argv);
+  FlutterApp app;
+  return app.Run(argc, argv);
 }

--- a/shell/platform/tizen/tizen_event_loop.h
+++ b/shell/platform/tizen/tizen_event_loop.h
@@ -10,7 +10,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <condition_variable>
 #include <deque>
 #include <functional>
 #include <mutex>
@@ -40,8 +39,7 @@ class TizenEventLoop {
 
   bool RunsTasksOnCurrentThread() const;
 
-  void ExcuteTaskEvents(
-      std::chrono::nanoseconds max_wait = std::chrono::nanoseconds::max());
+  void ExecuteTaskEvents();
 
   // Post a Flutter engine tasks to the event loop for delayed execution.
   void PostTask(FlutterTask flutter_task, uint64_t flutter_target_time_nanos);
@@ -71,8 +69,7 @@ class TizenEventLoop {
   TaskExpiredCallback on_task_expired_;
   std::mutex task_queue_mutex_;
   std::priority_queue<Task, std::deque<Task>, Task::Comparer> task_queue_;
-  std::condition_variable task_queue_cv_;
-  std::vector<FlutterTask> expired_tasks_;
+  std::vector<Task> expired_tasks_;
   std::mutex expired_tasks_mutex_;
   std::atomic<std::uint64_t> task_order_{0};
 
@@ -81,10 +78,6 @@ class TizenEventLoop {
 
   // Returns a TaskTimePoint computed from the given target time from Flutter.
   TaskTimePoint TimePointFromFlutterTime(uint64_t flutter_target_time_nanos);
-
-  static void ExcuteTaskEvents(void* data, void* buffer, unsigned int nbyte);
-
-  static Eina_Bool TaskTimerCallback(void* data);
 };
 
 class TizenPlatformEventLoop : public TizenEventLoop {


### PR DESCRIPTION
The video_player example app often crashes with SIGSEGV in release mode
```
(lldb) Process 4901 stopped
* thread #1, name = 'Runner.dll', stop reason = signal SIGSEGV: invalid address (fault address: 0x8)
    frame #0: 0xecd259f2 libflutter_tizen.so`flutter::TizenEventLoop::ExcuteTaskEvents(void*, void*, unsigned int) + 18
libflutter_tizen.so`flutter::TizenEventLoop::ExcuteTaskEvents:
->  0xecd259f2 <+18>: ldrd   r0, r1, [r1, #8]
    0xecd259f6 <+22>: blx    0xecd17a3c                ; symbol stub for: pthread_create
    0xecd259fa <+26>: ldr    r2, [r4, #0x8]
    0xecd259fc <+28>: vmov   d8, r0, r1
```
because of the following code (`task` is a local variable but its address is written to ecore_pipe).
```cpp
void TizenEventLoop::PostTask(FlutterTask flutter_task,
                              uint64_t flutter_target_time_nanos) {
  Task task;
  task.order = ++task_order_;
  task.fire_time = TimePointFromFlutterTime(flutter_target_time_nanos);
  task.task = flutter_task;
  if (ecore_pipe_) {
    ecore_pipe_write(ecore_pipe_, &task, sizeof(task));
  }
}
```

Additional changes:
- Inline `ecore_pipe_add` and `ecore_timer_add` callbacks for simplicity.
- Typo fix and small cleanups.