### PR TITLE
Refactor TizenRenderers

### DIFF
--- a/shell/platform/tizen/tizen_renderer.h
+++ b/shell/platform/tizen/tizen_renderer.h
@@ -57,6 +57,7 @@ class TizenRenderer {
                                   int32_t height,
                                   int32_t degree) = 0;
   virtual void SetPreferredOrientations(const std::vector<int>& rotations) = 0;
+
   virtual bool IsSupportedExtension(const char* name) = 0;
 
  protected:

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.h
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.h
@@ -36,7 +36,8 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
   Geometry GetScreenGeometry() override;
   int32_t GetDpi() override;
   uintptr_t GetWindowId() override;
-  void* GetWindowHandle() override;
+
+  void* GetWindowHandle() override { return ecore_wl2_window_; }
 
   void SetRotate(int angle) override;
   void SetGeometry(int32_t x,
@@ -49,36 +50,31 @@ class TizenRendererEcoreWl2 : public TizenRenderer {
                           int32_t height,
                           int32_t angle) override;
   void SetPreferredOrientations(const std::vector<int>& rotations) override;
+
   bool IsSupportedExtension(const char* name) override;
 
  private:
-  bool InitializeRenderer();
   void Show();
-  void DestroyRenderer();
 
-  bool SetupDisplay(int32_t* width, int32_t* height);
-  bool SetupEcoreWlWindow(int32_t width, int32_t height);
-  bool SetupEglWindow(int32_t width, int32_t height);
-  EGLDisplay GetEGLDisplay();
-  EGLNativeWindowType GetEGLNativeWindowType();
-  void DestroyEglWindow();
-  void DestroyEcoreWlWindow();
-  void ShutdownDisplay();
+  bool SetupEcoreWl2();
+  bool SetupEGL();
 
-  bool SetupEglSurface();
   bool ChooseEGLConfiguration();
   void PrintEGLError();
-  void DestroyEglSurface();
-  void SetTizenPolicyNotificationLevel(int level);
+
+  void DestroyEcoreWl2();
+  void DestroyEGL();
 
   static Eina_Bool RotationEventCb(void* data, int type, void* event);
   void SendRotationChangeDone();
+
+  void SetTizenPolicyNotificationLevel(int level);
 
   Ecore_Wl2_Display* ecore_wl2_display_ = nullptr;
   Ecore_Wl2_Window* ecore_wl2_window_ = nullptr;
   Ecore_Wl2_Egl_Window* ecore_wl2_egl_window_ = nullptr;
 
-  EGLConfig egl_config_;
+  EGLConfig egl_config_ = nullptr;
   EGLDisplay egl_display_ = EGL_NO_DISPLAY;
   EGLContext egl_context_ = EGL_NO_CONTEXT;
   EGLSurface egl_surface_ = EGL_NO_SURFACE;

--- a/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -34,7 +34,8 @@ class TizenRendererEvasGL : public TizenRenderer {
   Geometry GetScreenGeometry() override;
   int32_t GetDpi() override;
   uintptr_t GetWindowId() override;
-  void* GetWindowHandle() override;
+
+  void* GetWindowHandle() override { return evas_window_; }
 
   void SetRotate(int angle) override;
   void SetGeometry(int32_t x,
@@ -47,36 +48,31 @@ class TizenRendererEvasGL : public TizenRenderer {
                           int32_t height,
                           int32_t angle) override;
   void SetPreferredOrientations(const std::vector<int>& rotations) override;
+
   bool IsSupportedExtension(const char* name) override;
 
-  Evas_Object* GetImageHandle();
+  Evas_Object* GetImageHandle() { return graphics_adapter_; }
 
  private:
-  void ClearColor(float r, float g, float b, float a);
-
-  bool InitializeRenderer();
   void Show();
-  void DestroyRenderer();
 
+  bool SetupEvasWindow();
   bool SetupEvasGL();
-  Evas_Object* SetupEvasWindow(int32_t* width, int32_t* height);
-  void DestroyEvasGL();
   void DestroyEvasWindow();
+  void DestroyEvasGL();
 
   static void RotationEventCb(void* data, Evas_Object* obj, void* event_info);
   void SendRotationChangeDone();
 
-  Evas_Object* evas_window_{nullptr};
-  Evas_Object* graphics_adapter_{nullptr};
+  Evas_Object* evas_window_ = nullptr;
+  Evas_Object* graphics_adapter_ = nullptr;
 
-  Evas_GL_Config* gl_config_{nullptr};
-  Evas_GL* evas_gl_{nullptr};
-
-  Evas_GL_Context* gl_context_{nullptr};
-  Evas_GL_Context* gl_resource_context_{nullptr};
-
-  Evas_GL_Surface* gl_surface_{nullptr};
-  Evas_GL_Surface* gl_resource_surface_{nullptr};
+  Evas_GL* evas_gl_ = nullptr;
+  Evas_GL_Config* gl_config_ = nullptr;
+  Evas_GL_Context* gl_context_ = nullptr;
+  Evas_GL_Context* gl_resource_context_ = nullptr;
+  Evas_GL_Surface* gl_surface_ = nullptr;
+  Evas_GL_Surface* gl_resource_surface_ = nullptr;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Common
- Merge `InitializeRenderer` and `DestroyRenderer` into constructors and destructors.
- Inline `GetWindowHandle`.
- Code cleanups.

Ecore Wl2
- Combine `SetupDisplay` and `SetupEcoreWlWindow` into a single function `SetupEcoreWl2`.
- Combine `SetupEglWindow` and `SetupEglSurface` into a single function `SetupEGL`.
- Remove unnecessary private methods.
- Add additional error descriptions for EGL errors.

Evas GL
- Let `SetupEvasWindow` return bool to make the calling order consistent with Ecore Wl2.