### PR TITLE
Remove background and set alpha as true on Evas gl

### DIFF
--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -685,19 +685,13 @@ Evas_Object* TizenRendererEvasGL::SetupEvasWindow(int32_t* width,
   int32_t x = initial_geometry_.x;
   int32_t y = initial_geometry_.y;
 
-  elm_win_alpha_set(evas_window_, EINA_FALSE);
+  elm_win_alpha_set(evas_window_, EINA_TRUE);
   evas_object_move(evas_window_, x, y);
   evas_object_resize(evas_window_, *width, *height);
   evas_object_raise(evas_window_);
 
   elm_win_indicator_mode_set(evas_window_, ELM_WIN_INDICATOR_SHOW);
   elm_win_indicator_opacity_set(evas_window_, ELM_WIN_INDICATOR_OPAQUE);
-
-  Evas_Object* bg = elm_bg_add(evas_window_);
-  evas_object_color_set(bg, 0x00, 0x00, 0x00, 0x00);
-
-  evas_object_size_hint_weight_set(bg, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
-  elm_win_resize_object_add(evas_window_, bg);
 
   graphics_adapter_ =
       evas_object_image_filled_add(evas_object_evas_get(evas_window_));


### PR DESCRIPTION
* This patch fix a blank screen issue when launching time.
  What was shown as a blank screen is the background color of the elm_win.
* Restriction:
  This patch doesn't fix the blank screen issue between the splash screen and the first frame.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>
