### PR TITLE
Fixes errors from static analysis

### DIFF
--- a/shell/common/shell_test_external_view_embedder.cc
+++ b/shell/common/shell_test_external_view_embedder.cc
@@ -64,7 +64,9 @@ SkCanvas* ShellTestExternalViewEmbedder::CompositeEmbeddedView(int view_id) {
 void ShellTestExternalViewEmbedder::SubmitFrame(
     GrDirectContext* context,
     std::unique_ptr<SurfaceFrame> frame) {
-  frame->Submit();
+  if (frame) {
+    frame->Submit();
+  }
   if (frame && frame->SkiaSurface()) {
     last_submitted_frame_size_ = SkISize::Make(frame->SkiaSurface()->width(),
                                                frame->SkiaSurface()->height());

--- a/shell/platform/embedder/embedder_task_runner.cc
+++ b/shell/platform/embedder/embedder_task_runner.cc
@@ -14,6 +14,7 @@ EmbedderTaskRunner::EmbedderTaskRunner(DispatchTable table,
     : TaskRunner(nullptr /* loop implemenation*/),
       embedder_identifier_(embedder_identifier),
       dispatch_table_(std::move(table)),
+      last_baton_(0),
       placeholder_id_(
           fml::MessageLoopTaskQueues::GetInstance()->CreateTaskQueue()) {
   FML_DCHECK(dispatch_table_.post_task_callback);

--- a/shell/platform/glfw/text_input_plugin.cc
+++ b/shell/platform/glfw/text_input_plugin.cc
@@ -101,7 +101,8 @@ TextInputPlugin::TextInputPlugin(flutter::BinaryMessenger* messenger)
           messenger,
           kChannelName,
           &flutter::JsonMethodCodec::GetInstance())),
-      active_model_(nullptr) {
+      active_model_(nullptr),
+      client_id_(0) {
   channel_->SetMethodCallHandler(
       [this](
           const flutter::MethodCall<rapidjson::Document>& call,


### PR DESCRIPTION
Fixes three errors from static analysis:
- check if `frame` is `nullptr` before `frame->Submit();` (there is a similar check on the next lines)
- initialize `last_baton_` (it is used but never initialized)
- initialize `client_id_` (it is set in another method but I believe it should be initialized)
