### PR TITLE
Static analysis fixes

### DIFF
--- a/common/graphics/gl_context_switch.cc
+++ b/common/graphics/gl_context_switch.cc
@@ -24,7 +24,7 @@ GLContextDefaultResult::GLContextDefaultResult(bool static_result)
 GLContextDefaultResult::~GLContextDefaultResult() = default;
 
 GLContextSwitch::GLContextSwitch(std::unique_ptr<SwitchableGLContext> context)
-    : GLContextResult(context_->SetCurrent()),
+    : GLContextResult(context->SetCurrent()),
     context_(std::move(context)) {
   FML_CHECK(context_ != nullptr);
 };

--- a/common/graphics/gl_context_switch.cc
+++ b/common/graphics/gl_context_switch.cc
@@ -10,8 +10,6 @@ SwitchableGLContext::SwitchableGLContext() = default;
 
 SwitchableGLContext::~SwitchableGLContext() = default;
 
-GLContextResult::GLContextResult() = default;
-
 GLContextResult::~GLContextResult() = default;
 
 GLContextResult::GLContextResult(bool static_result) : result_(static_result){};
@@ -26,9 +24,9 @@ GLContextDefaultResult::GLContextDefaultResult(bool static_result)
 GLContextDefaultResult::~GLContextDefaultResult() = default;
 
 GLContextSwitch::GLContextSwitch(std::unique_ptr<SwitchableGLContext> context)
-    : context_(std::move(context)) {
+    : GLContextResult(context_->SetCurrent()),
+    context_(std::move(context)) {
   FML_CHECK(context_ != nullptr);
-  result_ = context_->SetCurrent();
 };
 
 GLContextSwitch::~GLContextSwitch() {

--- a/common/graphics/gl_context_switch.h
+++ b/common/graphics/gl_context_switch.h
@@ -49,7 +49,6 @@ class SwitchableGLContext {
 // that doesn't require context switching.
 class GLContextResult {
  public:
-  GLContextResult();
   virtual ~GLContextResult();
 
   //----------------------------------------------------------------------------

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -195,8 +195,6 @@ class MutatorsStack {
 
 class EmbeddedViewParams {
  public:
-  EmbeddedViewParams() = default;
-
   EmbeddedViewParams(SkMatrix matrix,
                      SkSize size_points,
                      MutatorsStack mutators_stack)

--- a/shell/platform/embedder/tests/embedder_unittests_util.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_util.cc
@@ -44,14 +44,13 @@ static sk_sp<SkData> NormalizeImage(sk_sp<SkImage> image) {
   sk_sp<SkData> data = SkData::MakeUninitialized(size);
   if (!data) {
     FML_CHECK(false) << "Unable to allocate data.";
+  }else{
+    bool success = image->readPixels(norm_image_info, data->writable_data(),
+                                    row_bytes, 0, 0);
+    if (!success) {
+      FML_CHECK(false) << "Unable to read pixels.";
+    }
   }
-
-  bool success = image->readPixels(norm_image_info, data->writable_data(),
-                                   row_bytes, 0, 0);
-  if (!success) {
-    FML_CHECK(false) << "Unable to read pixels.";
-  }
-
   return data;
 }
 


### PR DESCRIPTION
Removed default constructor from `GLContextSwitch` and initialize `context_` from `GLContextSwitch(std::unique_ptr<SwitchableGLContext> context)`

Prevent `data` dereference when null.

Removed `GLContextResult()`
