### PR TITLE
Cleanup some comments

### DIFF
--- a/shell/platform/tizen/channels/window_channel.h
+++ b/shell/platform/tizen/channels/window_channel.h
@@ -14,6 +14,7 @@
 
 namespace flutter {
 
+// Channel to get/set application's window size and device's screen size.
 class WindowChannel {
  public:
   explicit WindowChannel(BinaryMessenger* messenger,

--- a/shell/platform/tizen/external_texture.h
+++ b/shell/platform/tizen/external_texture.h
@@ -40,9 +40,7 @@ class ExternalTexture : public std::enable_shared_from_this<ExternalTexture> {
   }
   virtual ~ExternalTexture() = default;
 
-  /**
-   * Returns the unique id for the ExternalTextureGL instance.
-   */
+  // Returns the unique id for the ExternalTextureGL instance.
   int64_t TextureId() { return (int64_t)texture_id_; }
 
   virtual bool PopulateTexture(size_t width,

--- a/shell/platform/tizen/external_texture_surface_gl.h
+++ b/shell/platform/tizen/external_texture_surface_gl.h
@@ -22,14 +22,13 @@ class ExternalTextureSurfaceGL : public ExternalTexture {
 
   virtual ~ExternalTextureSurfaceGL();
 
-  /**
-   * Accepts texture buffer copy request from the Flutter engine.
-   * When the user side marks the texture_id as available, the Flutter engine
-   * will callback to this method and ask for populate the |opengl_texture|
-   * object, such as the texture type and the format of the pixel buffer and the
-   * texture object.
-   * Returns true on success, false on failure.
-   */
+  // Accepts texture buffer copy request from the Flutter engine.
+  // When the user side marks the texture_id as available, the Flutter engine
+  // will callback to this method and ask to populate the |opengl_texture|
+  // object, such as the texture type and the format of the pixel buffer and the
+  // texture object.
+  //
+  // Returns true on success, false on failure.
   bool PopulateTexture(size_t width,
                        size_t height,
                        FlutterOpenGLTexture* opengl_texture) override;

--- a/shell/platform/tizen/flutter_tizen_texture_registrar.h
+++ b/shell/platform/tizen/flutter_tizen_texture_registrar.h
@@ -22,19 +22,23 @@ class FlutterTizenTextureRegistrar {
   explicit FlutterTizenTextureRegistrar(FlutterTizenEngine* engine);
 
   // Registers a texture described by the given |texture_info| object.
-  // Returns the non-zero, positive texture id or -1 on error.
+  //
+  // Returns a non-zero positive texture id, or -1 on error.
   int64_t RegisterTexture(const FlutterDesktopTextureInfo* texture_info);
 
   // Attempts to unregister the texture identified by |texture_id|.
+  //
   // Returns true if the texture was successfully unregistered.
   bool UnregisterTexture(int64_t texture_id);
 
   // Notifies the engine about a new frame being available.
+  //
   // Returns true on success.
   bool MarkTextureFrameAvailable(int64_t texture_id);
 
   // Attempts to populate the given |texture| by copying the
   // contents of the texture identified by |texture_id|.
+  //
   // Returns true on success.
   bool PopulateTexture(int64_t texture_id,
                        size_t width,

--- a/shell/platform/tizen/public/flutter_tizen.h
+++ b/shell/platform/tizen/public/flutter_tizen.h
@@ -91,12 +91,10 @@ FlutterDesktopGetPluginRegistrar(FlutterDesktopEngineRef engine,
 FLUTTER_EXPORT FlutterDesktopMessengerRef
 FlutterDesktopEngineGetMessenger(FlutterDesktopEngineRef engine);
 
-/**
- * Return backing window for manipulation in host application.
- *
- * If run engine on a wearable device, need cast void* to Evas_Objct*,
- * otherwise cast void* to Ecore_Wl2_Window*.
- */
+// Returns the window object associated with the Flutter app for manipulation.
+//
+// If the engine runs on a wearable device, cast void* to Evas_Object*,
+// otherwise cast it to Ecore_Wl2_Window*.
 FLUTTER_EXPORT void* FlutterDesktopGetWindow(
     FlutterDesktopPluginRegistrarRef registrar);
 

--- a/shell/platform/tizen/public/flutter_tizen.h
+++ b/shell/platform/tizen/public/flutter_tizen.h
@@ -91,7 +91,7 @@ FlutterDesktopGetPluginRegistrar(FlutterDesktopEngineRef engine,
 FLUTTER_EXPORT FlutterDesktopMessengerRef
 FlutterDesktopEngineGetMessenger(FlutterDesktopEngineRef engine);
 
-// Returns a window for manipulation in host application.
+// Returns the window associated with this registrar's engine instance.
 //
 // If the app runs on a wearable device, cast void* to Evas_Object*,
 // otherwise cast it to Ecore_Wl2_Window*.

--- a/shell/platform/tizen/public/flutter_tizen.h
+++ b/shell/platform/tizen/public/flutter_tizen.h
@@ -91,9 +91,9 @@ FlutterDesktopGetPluginRegistrar(FlutterDesktopEngineRef engine,
 FLUTTER_EXPORT FlutterDesktopMessengerRef
 FlutterDesktopEngineGetMessenger(FlutterDesktopEngineRef engine);
 
-// Returns the window object associated with the Flutter app for manipulation.
+// Returns a window for manipulation in host application.
 //
-// If the engine runs on a wearable device, cast void* to Evas_Object*,
+// If the app runs on a wearable device, cast void* to Evas_Object*,
 // otherwise cast it to Ecore_Wl2_Window*.
 FLUTTER_EXPORT void* FlutterDesktopGetWindow(
     FlutterDesktopPluginRegistrarRef registrar);


### PR DESCRIPTION
- Use single line comment style for consistency.
- Fix typo in public header, `flutter_tizen.h`: `Evas_Objct` -> `Evas_Object`.
- Minor formattings.