### PR TITLE
[ci] Update gn arguments

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,6 +66,8 @@ jobs:
         --target-triple $(targetTriple) \
         --runtime-mode $(mode) \
         --enable-fontconfig \
+        --no-full-dart-sdk \
+        --no-build-embedder-examples \
         --embedder-for-target \
         --build-tizen-shell
       ninja -C out/linux_$(mode)_$(arch)

--- a/ci/tizen/build-engine.sh
+++ b/ci/tizen/build-engine.sh
@@ -52,7 +52,7 @@ if [[ "$BUILD_OS" == "host" ]]; then
     ninja -C src/out/${BUILD_OS}_${BUILD_MODE} ${BUILD_TARGET}
 else
     if [[ -z "$BUILD_ARCH" || -z "$BUILD_TRIPLE" ]]; then
-        echo "required arguments are missing."
+        echo "Required arguments are missing."
         exit 1
     fi
 
@@ -71,8 +71,9 @@ else
         --target-triple $BUILD_TRIPLE \
         --runtime-mode $BUILD_MODE \
         --enable-fontconfig \
+        --no-full-dart-sdk \
+        --no-build-embedder-examples \
         --embedder-for-target \
-        --disable-desktop-embeddings \
         --build-tizen-shell
     ninja -C src/out/${BUILD_OS}_${BUILD_MODE}_${BUILD_ARCH} ${BUILD_TARGET}
 fi

--- a/ci/tizen/gclient-prepare-sync.sh
+++ b/ci/tizen/gclient-prepare-sync.sh
@@ -65,7 +65,8 @@ fi
 
 cat >.gclient <<EOF
 solutions = [
-  { "name"        : 'src/flutter',
+  {
+    "name"        : 'src/flutter',
     "url"         : 'https://github.com/flutter-tizen/engine.git',
     "deps_file"   : 'DEPS',
     "managed"     : False,
@@ -76,7 +77,6 @@ EOF
 if [[ "$FLAG_REDUCE_DEPS" == "true" ]]; then
     gclient setdep --var=download_android_deps=False --deps-file=$DEPS
     sed -i -e '/src\/ios_tools/,+2d' $DEPS
-    sed -i -e '/src\/third_party\/vulkan/,+2d' $DEPS
     sed -i -e '/src\/third_party\/angle/,+2d' $DEPS
     sed -i -e '/src\/fuchsia\/sdk\/linux/,+9d' $DEPS
 fi


### PR DESCRIPTION
Flutter 2.10's new `build-embedder-examples` flag should be explicitly disabled for our builds.