### PR TITLE
[ci] Publish Tizen Docker image for unit testing

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -5,12 +5,13 @@ on:
     branches:
       - "flutter-*-tizen"
     paths:
+      - ".github/workflows/build-docker.yml"
       - "ci/tizen/docker/**"
       - "DEPS"
   workflow_dispatch:
 
 jobs:
-  build:
+  builder:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,11 +21,31 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v2
         with:
           context: ci/tizen/docker
           file: ci/tizen/docker/Dockerfile
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/build-engine:latest
+          tags: ghcr.io/${{ github.repository_owner }}/build-engine:latest
+
+  testbed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: build and push
+        env:
+          REPO_URL: http://download.tizen.org/releases/milestone/tizen/unified
+          BUILD_ID: tizen-unified_20211014.1
+          IMAGE: tizen-headed-armv7l
+        run: |
+          wget -q ${REPO_URL}/${BUILD_ID}/images/standard/${IMAGE}/${BUILD_ID}_${IMAGE}.tar.gz
+          tar -zxf ${BUILD_ID}_${IMAGE}.tar.gz
+          mkdir rootfs
+          sudo mount rootfs.img rootfs
+          sudo tar -cC rootfs . | docker import - ghcr.io/${{ github.repository_owner }}/${IMAGE}
+          sudo umount rootfs
+          docker push ghcr.io/${{ github.repository_owner }}/${IMAGE}:latest


### PR DESCRIPTION
Part of https://github.com/flutter-tizen/engine/issues/239.

Publish a Tizen Docker image (`tizen-headed-armv7l`) on GitHub Container Registry to enable unit testing of the embedder on non-x64 environment.

A  rootfs is extracted from the latest (`tizen-unified_20211014.1`) stable armv7l Tizen image and converted into a Docker image. Note that the [docker/build-push-action](https://github.com/docker/build-push-action) is not applicable for this case because no Dockerfile exists.