### PR TITLE
[ci] Add the format step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: src/flutter
+          fetch-depth: 0
 
       - uses: actions/cache@v2
         with:
@@ -66,6 +67,13 @@ jobs:
         run: |
           src/flutter/ci/tizen/gclient-prepare-sync.sh --reduce-deps --shallow-sync
           gclient sync -v --no-history --shallow
+
+      - name: verify formatting
+        if: matrix.arch == 'arm' && matrix.mode == 'release'
+        working-directory: src/flutter
+        run: |
+          git remote add upstream https://github.com/flutter/engine.git
+          ci/format.sh
 
       - name: build
         run: |


### PR DESCRIPTION
Currently code formatting check is automatically done by [githooks](https://github.com/flutter-tizen/engine/tree/flutter-2.10.1-tizen/tools/githooks) when pushing a commit to a remote repository, but the process often takes too long so I'd like to be able to disable the hook.

This change makes the code verification be performed during CI runs so that a user can safely disable their hook locally. Note that it is not a good idea to add the step as a separate job or workflow because the formatter must be run after `gclient sync` to ensure its dependencies are properly fetched.

Contributes to https://github.com/flutter-tizen/engine/issues/239.