### PR TITLE
Use the Ecore Wl2 renderer by default for unit testing

### DIFF
--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -257,7 +257,7 @@ embedder("flutter_tizen_common") {
 
 embedder("flutter_tizen_source") {
   target_type = "source_set"
-  use_evas_gl_renderer = true
+  use_evas_gl_renderer = false
 
   defines = []
 }

--- a/shell/platform/tizen/flutter_tizen_engine_unittest.cc
+++ b/shell/platform/tizen/flutter_tizen_engine_unittest.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 
+#include <Ecore.h>
+
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
 #include "flutter/shell/platform/tizen/testing/engine_modifier.h"
 #include "gtest/gtest.h"
@@ -13,10 +15,7 @@ namespace testing {
 
 class FlutterTizenEngineTest : public ::testing::Test {
  public:
-  FlutterTizenEngineTest() {
-    ecore_init();
-    elm_init(0, nullptr);
-  }
+  FlutterTizenEngineTest() { ecore_init(); }
 
  protected:
   void SetUp() {

--- a/shell/platform/tizen/flutter_tizen_texture_registrar_unittests.cc
+++ b/shell/platform/tizen/flutter_tizen_texture_registrar_unittests.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/shell/platform/tizen/flutter_tizen_texture_registrar.h"
 
+#include <Ecore.h>
+
 #include <iostream>
 
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
@@ -16,10 +18,7 @@ namespace testing {
 
 class FlutterTizenTextureRegistrarTest : public ::testing::Test {
  public:
-  FlutterTizenTextureRegistrarTest() {
-    ecore_init();
-    elm_init(0, nullptr);
-  }
+  FlutterTizenTextureRegistrarTest() { ecore_init(); }
 
  protected:
   void SetUp() {


### PR DESCRIPTION
Set `use_evas_gl_renderer` to false and remove calls to `elm_init`.

Suggested by @bbrto21 in https://github.com/flutter-tizen/engine/pull/242#discussion_r808606184. Part of https://github.com/flutter-tizen/engine/issues/239.