### PR TITLE
[ci] Build flutter_tizen_unittests conditionally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,12 @@ jobs:
             --no-build-embedder-examples \
             --embedder-for-target \
             --build-tizen-shell
-          ninja -C src/out/$OUTPUT_NAME tizen flutter_tizen_unittests
+          ninja -C src/out/$OUTPUT_NAME tizen
+
+          # Build unittests.
+          if [[ "$OUTPUT_NAME" == "linux_release_arm" ]]; then
+            ninja -C src/out/$OUTPUT_NAME flutter_tizen_unittests
+          fi
 
           src/flutter/ci/tizen/cache-checksum.sh save src/out/$OUTPUT_NAME
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -6,6 +6,7 @@ import("//flutter/common/config.gni")
 import("//flutter/examples/examples.gni")
 import("//flutter/shell/platform/config.gni")
 import("//flutter/shell/platform/glfw/config.gni")
+import("//flutter/shell/platform/tizen/config.gni")
 import("//flutter/testing/testing.gni")
 import("//third_party/dart/build/dart/copy_tree.gni")
 
@@ -133,6 +134,10 @@ group("flutter") {
   if (is_android) {
     public_deps +=
         [ "//flutter/shell/platform/android:flutter_shell_native_unittests" ]
+  }
+
+  if (build_tizen_shell) {
+    public_deps += [ "//flutter/shell/platform/tizen:flutter_tizen_unittests" ]
   }
 
   # Compile all unittests targets if enabled.


### PR DESCRIPTION
- Add `flutter_tizen_unittests` to default build dependencies. This fixes the following error (in VS Code) which has been caused by https://github.com/flutter-tizen/engine/pull/244:<p>
  ```
  "flutter_tizen_engine_unittest.cc" not found in "${workspaceFolder}/../out/linux_release_arm/compile_commands.json". 'includePath' from c_cpp_properties.json in folder 'flutter' will be used for this file instead.
  "flutter_tizen_texture_registrar_unittests.cc" not found in "${workspaceFolder}/../out/linux_release_arm/compile_commands.json". 'includePath' from c_cpp_properties.json in folder 'flutter' will be used for this file instead.
  ```
- Let `flutter_tizen_unittests` be only built for arm-release in the CI.

Related to https://github.com/flutter-tizen/engine/issues/239.