### PR TITLE
[ci] Create a release after build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           ninja -C src/out/$OUTPUT_NAME tizen
 
           # Build unittests.
-          if [[ "$OUTPUT_NAME" == "linux_release_arm" ]]; then
+          if [ "$OUTPUT_NAME" = "linux_release_arm" ]; then
             ninja -C src/out/$OUTPUT_NAME flutter_tizen_unittests
           fi
 
@@ -263,3 +263,36 @@ jobs:
         run: |
           chmod +x flutter_tizen_unittests
           docker run --rm -t -v `pwd`:/root ${IMAGE_TAG} /root/flutter_tizen_unittests
+
+  release:
+    needs: [windows-build, macos-build, test]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+
+      - name: create archives
+        run: |
+          rm -r *-unittests
+          for name in tizen-*; do
+            7z a $name.zip ./$name/*
+          done
+
+      - name: set variables
+        run: |
+          echo "TAG_NAME=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+          echo "VERSION=$(echo "${{ github.ref_name }}" | cut -d'-' -f2)" >> $GITHUB_ENV
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ env.VERSION }} (${{ env.TAG_NAME }})
+          tag_name: ${{ env.TAG_NAME }}
+          target_commitish: ${{ github.ref_name }}
+          files: tizen-*.zip
+          body: |
+            Flutter engine ${{ env.VERSION }} for Tizen
+
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
             !src/out/linux_release_arm/cpp_client_wrapper/engine_method_result.cc
 
       - uses: actions/upload-artifact@v2
-        if: (matrix.arch == 'arm' || matrix.arch == 'arm64') && (matrix.mode == 'release' || matrix.mode == 'profile')
+        if: (matrix.arch == 'arm' || matrix.arch == 'arm64') && matrix.mode != 'debug'
         with:
           name: tizen-${{ matrix.arch }}-${{ matrix.mode }}_linux-x64
           path: src/out/${{ env.OUTPUT_NAME }}/clang_x64/gen_snapshot
@@ -125,6 +125,9 @@ jobs:
       matrix:
         arch: [arm, arm64]
         mode: [release, profile]
+
+    env:
+      OUTPUT_NAME: linux_${{ matrix.mode }}_${{ matrix.arch }}
 
     steps:
       - name: checkout engine
@@ -165,12 +168,12 @@ jobs:
             --linux --linux-cpu=${{ matrix.arch }} `
             --runtime-mode=${{ matrix.mode }} `
             --no-goma
-          ninja -C .\out\linux_${{ matrix.mode }}_${{ matrix.arch }} gen_snapshot
+          ninja -C .\out\${{ env.OUTPUT_NAME }} gen_snapshot
 
       - uses: actions/upload-artifact@v2
         with:
           name: tizen-${{ matrix.arch }}-${{ matrix.mode }}_windows-x64
-          path: C:\workspace\engine\src\out\linux_${{ matrix.mode }}_${{ matrix.arch }}\gen_snapshot.exe
+          path: C:\workspace\engine\src\out\${{ env.OUTPUT_NAME }}\gen_snapshot.exe
 
   macos-build:
     runs-on: macos-11
@@ -233,7 +236,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: tizen-${{ matrix.arch }}-${{ matrix.mode }}_darwin-x64
-          path: src/out/linux_${{ matrix.mode }}_${{ matrix.arch }}/clang_x64/gen_snapshot
+          path: src/out/${{ env.OUTPUT_NAME }}/clang_x64/gen_snapshot
 
   test:
     needs: build

--- a/.github/workflows/check-symbol.yml
+++ b/.github/workflows/check-symbol.yml
@@ -2,7 +2,8 @@ name: Check Symbols
 
 on:
   workflow_run:
-    workflows: ["Build"]
+    workflows:
+      - Build
     types:
       - completed
 
@@ -10,6 +11,7 @@ jobs:
   check:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2
@@ -43,7 +45,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: context.payload.workflow_run.head_sha,
-              context: "Check Symbols",
+              context: 'Check Symbols',
               state: 'success',
               description: 'All symbols are valid'
             });
@@ -57,7 +59,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: context.payload.workflow_run.head_sha,
-              context: "Check Symbols",
+              context: 'Check Symbols',
               state: 'failure',
               description: 'Failed in checking symbols',
               target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}',


### PR DESCRIPTION
Fixes https://github.com/flutter-tizen/engine/issues/230.

- Add the `release` job. The job should be added to the same workflow as the `build` job in order to use `download-artifact`.
- Minor cleanups.
  - Support non-bash shell. I found that the Linux `build` step [runs in non-bash shell](https://github.com/swift-kim/engine/runs/5305881126?check_suite_focus=true) and generates an error (not detected by GA runner as a failure) since https://github.com/flutter-tizen/engine/pull/247.<p>
    ```
    [1/9] CXX obj/flutter/shell/version/version.version.o
    [2/9] STAMP obj/flutter/shell/version/version.stamp
    [3/9] SOLINK ./libflutter_engine.so
    /__w/_temp/60f4062e-3cb9-4b1e-9ef0-7e336789af2d.sh: 24: [[: not found
    ```
  - Make expressions simple and consistent.

Test: https://github.com/swift-kim/engine/actions/runs/1891287349
