### PR TITLE
Remove deprecated APIs in AppControlChannel

### DIFF
--- a/shell/platform/tizen/channels/app_control.cc
+++ b/shell/platform/tizen/channels/app_control.cc
@@ -20,7 +20,7 @@ int32_t NativeCreateAppControl(Dart_Handle handle) {
   Dart_NewFinalizableHandle_DL(
       handle, app_control.get(), 64,
       [](void* isolate_callback_data, void* peer) {
-        auto app_control = reinterpret_cast<flutter::AppControl*>(peer);
+        auto* app_control = reinterpret_cast<flutter::AppControl*>(peer);
         flutter::AppControlManager::GetInstance().Remove(app_control->id());
       });
   flutter::AppControlManager::GetInstance().Insert(std::move(app_control));
@@ -28,13 +28,13 @@ int32_t NativeCreateAppControl(Dart_Handle handle) {
 }
 
 bool NativeAttachAppControl(int32_t id, Dart_Handle handle) {
-  auto app_control = flutter::AppControlManager::GetInstance().FindById(id);
+  auto* app_control = flutter::AppControlManager::GetInstance().FindById(id);
   if (!app_control || !app_control->handle()) {
     return false;
   }
   Dart_NewFinalizableHandle_DL(
       handle, app_control, 64, [](void* isolate_callback_data, void* peer) {
-        auto app_control = reinterpret_cast<flutter::AppControl*>(peer);
+        auto* app_control = reinterpret_cast<flutter::AppControl*>(peer);
         flutter::AppControlManager::GetInstance().Remove(app_control->id());
       });
   return true;
@@ -160,7 +160,7 @@ AppControlResult AppControl::SetLaunchMode(const std::string& launch_mode) {
 bool OnAppControlExtraDataCallback(app_control_h handle,
                                    const char* key,
                                    void* user_data) {
-  auto extra_data = static_cast<EncodableMap*>(user_data);
+  auto* extra_data = static_cast<EncodableMap*>(user_data);
 
   bool is_array = false;
   int ret = app_control_is_extra_data_array(handle, key, &is_array);
@@ -306,7 +306,7 @@ AppControlResult AppControl::GetMatchedAppIds(EncodableList& list) {
       handle_,
       [](app_control_h app_control, const char* app_id,
          void* user_data) -> bool {
-        auto app_ids = static_cast<EncodableList*>(user_data);
+        auto* app_ids = static_cast<EncodableList*>(user_data);
         app_ids->push_back(EncodableValue(app_id));
         return true;
       },
@@ -325,7 +325,7 @@ AppControlResult AppControl::SendLaunchRequestWithReply(
     ReplyCallback on_reply) {
   auto reply_callback = [](app_control_h request, app_control_h reply,
                            app_control_result_e result, void* user_data) {
-    auto app_control = static_cast<AppControl*>(user_data);
+    auto* app_control = static_cast<AppControl*>(user_data);
     auto reply_app_control = std::make_unique<AppControl>(reply);
     EncodableMap map;
     map[EncodableValue("reply")] = reply_app_control->SerializeToMap();

--- a/shell/platform/tizen/channels/app_control.cc
+++ b/shell/platform/tizen/channels/app_control.cc
@@ -16,7 +16,7 @@ int32_t NativeCreateAppControl(Dart_Handle handle) {
   if (!app_control->handle()) {
     return -1;
   }
-  auto id = app_control->id();
+  int32_t id = app_control->id();
   Dart_NewFinalizableHandle_DL(
       handle, app_control.get(), 64,
       [](void* isolate_callback_data, void* peer) {

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -79,7 +79,7 @@ void AppControlChannel::HandleMethodCall(
     return;
   }
 
-  auto arguments = std::get_if<EncodableMap>(method_call.arguments());
+  auto* arguments = std::get_if<EncodableMap>(method_call.arguments());
   if (!arguments) {
     result->Error("Invalid arguments");
     return;
@@ -89,7 +89,7 @@ void AppControlChannel::HandleMethodCall(
     result->Error("Invalid arguments", "No ID provided.");
     return;
   }
-  auto app_control = AppControlManager::GetInstance().FindById(*id);
+  auto* app_control = AppControlManager::GetInstance().FindById(*id);
   if (!app_control) {
     result->Error("Invalid arguments",
                   "No instance of AppControl matches the given ID.");
@@ -147,7 +147,7 @@ void AppControlChannel::Reply(
 
   EncodableValueHolder<int32_t> reply_id(arguments, "replyId");
   if (reply_id) {
-    auto reply_app_control =
+    auto* reply_app_control =
         AppControlManager::GetInstance().FindById(*reply_id);
     if (!reply_app_control) {
       result->Error("Invalid arguments",
@@ -170,7 +170,7 @@ void AppControlChannel::Reply(
                   "Either replyId or requestId must be provided.");
     return;
   }
-  auto request_app_control =
+  auto* request_app_control =
       AppControlManager::GetInstance().FindById(*request_id);
   if (!request_app_control) {
     result->Error("Invalid arguments",
@@ -191,7 +191,7 @@ void AppControlChannel::SendLaunchRequest(
     std::unique_ptr<MethodResult<EncodableValue>> result) {
   EncodableValueHolder<bool> wait_for_reply(arguments, "waitForReply");
   if (wait_for_reply && *wait_for_reply) {
-    auto result_ptr = result.release();
+    auto* result_ptr = result.release();
     auto on_reply = [result_ptr](const EncodableValue& response) {
       result_ptr->Success(response);
       delete result_ptr;

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -21,9 +21,11 @@ constexpr char kEventChannelName[] = "tizen/internal/app_control_event";
 AppControlChannel::AppControlChannel(BinaryMessenger* messenger) {
   method_channel_ = std::make_unique<MethodChannel<EncodableValue>>(
       messenger, kChannelName, &StandardMethodCodec::GetInstance());
-  method_channel_->SetMethodCallHandler([this](const auto& call, auto result) {
-    this->HandleMethodCall(call, std::move(result));
-  });
+  method_channel_->SetMethodCallHandler(
+      [this](const MethodCall<EncodableValue>& call,
+             std::unique_ptr<MethodResult<EncodableValue>> result) {
+        this->HandleMethodCall(call, std::move(result));
+      });
 
   event_channel_ = std::make_unique<EventChannel<EncodableValue>>(
       messenger, kEventChannelName, &StandardMethodCodec::GetInstance());
@@ -65,7 +67,7 @@ void AppControlChannel::HandleMethodCall(
     std::unique_ptr<MethodResult<EncodableValue>> result) {
   const auto& method_name = method_call.method_name();
 
-  auto* arguments = std::get_if<EncodableMap>(method_call.arguments());
+  const auto* arguments = std::get_if<EncodableMap>(method_call.arguments());
   if (!arguments) {
     result->Error("Invalid arguments");
     return;
@@ -75,7 +77,7 @@ void AppControlChannel::HandleMethodCall(
     result->Error("Invalid arguments", "No ID provided.");
     return;
   }
-  auto* app_control = AppControlManager::GetInstance().FindById(*id);
+  AppControl* app_control = AppControlManager::GetInstance().FindById(*id);
   if (!app_control) {
     result->Error("Invalid arguments",
                   "No instance of AppControl matches the given ID.");
@@ -133,7 +135,7 @@ void AppControlChannel::Reply(
     result->Error("Invalid arguments", "No replyId provided.");
     return;
   }
-  auto* reply_app_control =
+  AppControl* reply_app_control =
       AppControlManager::GetInstance().FindById(*reply_id);
   if (!reply_app_control) {
     result->Error("Invalid arguments",

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -65,20 +65,6 @@ void AppControlChannel::HandleMethodCall(
     std::unique_ptr<MethodResult<EncodableValue>> result) {
   const auto& method_name = method_call.method_name();
 
-  // The methods "create" and "dispose" are deprecated and will be removed in
-  // the future.
-  if (method_name == "create") {
-    auto app_control = std::make_unique<AppControl>();
-    if (app_control->handle()) {
-      result->Success(EncodableValue(app_control->id()));
-      AppControlManager::GetInstance().Insert(std::move(app_control));
-    } else {
-      result->Error("Internal error",
-                    "Could not create an instance of AppControl.");
-    }
-    return;
-  }
-
   auto* arguments = std::get_if<EncodableMap>(method_call.arguments());
   if (!arguments) {
     result->Error("Invalid arguments");
@@ -96,10 +82,7 @@ void AppControlChannel::HandleMethodCall(
     return;
   }
 
-  if (method_name == "dispose") {
-    AppControlManager::GetInstance().Remove(app_control->id());
-    result->Success();
-  } else if (method_name == "getMatchedAppIds") {
+  if (method_name == "getMatchedAppIds") {
     EncodableList app_ids;
     AppControlResult ret = app_control->GetMatchedAppIds(app_ids);
     if (ret) {
@@ -146,38 +129,18 @@ void AppControlChannel::Reply(
   }
 
   EncodableValueHolder<int32_t> reply_id(arguments, "replyId");
-  if (reply_id) {
-    auto* reply_app_control =
-        AppControlManager::GetInstance().FindById(*reply_id);
-    if (!reply_app_control) {
-      result->Error("Invalid arguments",
-                    "No instance of AppControl matches the given ID.");
-      return;
-    }
-    AppControlResult ret = app_control->Reply(reply_app_control, *result_str);
-    if (ret) {
-      result->Success();
-    } else {
-      result->Error(ret.code(), ret.message());
-    }
+  if (!reply_id) {
+    result->Error("Invalid arguments", "No replyId provided.");
     return;
   }
-
-  // Deprecated. Use replyId instead.
-  EncodableValueHolder<int32_t> request_id(arguments, "requestId");
-  if (!request_id) {
-    result->Error("Invalid arguments",
-                  "Either replyId or requestId must be provided.");
-    return;
-  }
-  auto* request_app_control =
-      AppControlManager::GetInstance().FindById(*request_id);
-  if (!request_app_control) {
+  auto* reply_app_control =
+      AppControlManager::GetInstance().FindById(*reply_id);
+  if (!reply_app_control) {
     result->Error("Invalid arguments",
                   "No instance of AppControl matches the given ID.");
     return;
   }
-  AppControlResult ret = request_app_control->Reply(app_control, *result_str);
+  AppControlResult ret = app_control->Reply(reply_app_control, *result_str);
   if (ret) {
     result->Success();
   } else {


### PR DESCRIPTION
- Remove support for the `create` and `dispose` methods and the `requestId` argument of the `reply` method which are deprecated as of https://github.com/flutter-tizen/engine/pull/183 and https://github.com/flutter-tizen/engine/pull/184.
- Avoid type deduction (`auto`) and use explicit types when appropriate. (Ground rule: https://google.github.io/styleguide/cppguide.html#Type_deduction)