### PR TITLE
Refactor PlatformViewChannel

### DIFF
--- a/shell/platform/tizen/channels/platform_view_channel.cc
+++ b/shell/platform/tizen/channels/platform_view_channel.cc
@@ -7,16 +7,16 @@
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
-#include "flutter/shell/platform/common/json_method_codec.h"
 #include "flutter/shell/platform/tizen/channels/encodable_value_holder.h"
-#include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/public/flutter_platform_view.h"
 
 namespace flutter {
 
 namespace {
+
 constexpr char kChannelName[] = "flutter/platform_views";
+
 }  // namespace
 
 PlatformViewChannel::PlatformViewChannel(BinaryMessenger* messenger)
@@ -43,7 +43,7 @@ void PlatformViewChannel::Dispose() {
 void PlatformViewChannel::RemoveViewInstanceIfNeeded(int view_id) {
   auto it = view_instances_.find(view_id);
   if (view_id >= 0 && it != view_instances_.end()) {
-    auto view_instance = it->second;
+    auto* view_instance = it->second;
     view_instance->Dispose();
     delete view_instance;
     view_instances_.erase(it);
@@ -51,8 +51,7 @@ void PlatformViewChannel::RemoveViewInstanceIfNeeded(int view_id) {
 }
 
 void PlatformViewChannel::ClearViewInstances() {
-  // Clean-up view_instances_
-  for (auto const& [view_id, view_instance] : view_instances_) {
+  for (const auto& [view_id, view_instance] : view_instances_) {
     view_instance->Dispose();
     delete view_instance;
   }
@@ -60,21 +59,20 @@ void PlatformViewChannel::ClearViewInstances() {
 }
 
 void PlatformViewChannel::ClearViewFactories() {
-  // Clean-up view_factories_
-  for (auto const& [view_type, view_factory] : view_factories_) {
+  for (const auto& [view_type, view_factory] : view_factories_) {
     view_factory->Dispose();
   }
   view_factories_.clear();
 }
 
-void PlatformViewChannel::SendKeyEvent(Ecore_Event_Key* key, bool is_down) {
+void PlatformViewChannel::SendKeyEvent(Ecore_Event_Key* event, bool is_down) {
   auto instances = ViewInstances();
   auto it = instances.find(CurrentFocusedViewId());
   if (it != instances.end()) {
     if (is_down) {
-      it->second->DispatchKeyDownEvent(key);
+      it->second->DispatchKeyDownEvent(event);
     } else {
-      it->second->DispatchKeyUpEvent(key);
+      it->second->DispatchKeyUpEvent(event);
     }
   }
 }
@@ -91,8 +89,8 @@ int PlatformViewChannel::CurrentFocusedViewId() {
 void PlatformViewChannel::HandleMethodCall(
     const MethodCall<EncodableValue>& call,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
-  const auto method = call.method_name();
-  const auto arguments = call.arguments();
+  const auto& method = call.method_name();
+  const auto* arguments = call.arguments();
 
   if (method == "create") {
     OnCreate(arguments, std::move(result));
@@ -113,7 +111,7 @@ void PlatformViewChannel::HandleMethodCall(
 void PlatformViewChannel::OnCreate(
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>>&& result) {
-  auto map_ptr = std::get_if<EncodableMap>(arguments);
+  auto* map_ptr = std::get_if<EncodableMap>(arguments);
   if (!map_ptr) {
     result->Error("Invalid arguments");
     return;
@@ -129,7 +127,7 @@ void PlatformViewChannel::OnCreate(
     return;
   }
 
-  FT_LOG(Info) << "Creating a platform view: " << *view_type.value;
+  FT_LOG(Info) << "Creating a platform view: " << view_type.value;
   RemoveViewInstanceIfNeeded(*view_id);
 
   EncodableValueHolder<ByteMessage> params(map_ptr, "params");
@@ -143,14 +141,13 @@ void PlatformViewChannel::OnCreate(
     if (focused_view != view_instances_.end()) {
       focused_view->second->SetFocus(false);
     }
-    auto view_instance =
+    auto* view_instance =
         it->second->Create(*view_id, *width, *height, byte_message);
     if (view_instance) {
-      view_instances_.insert(
-          std::pair<int, PlatformView*>(*view_id, view_instance));
+      view_instances_[*view_id] = view_instance;
       result->Success(EncodableValue(view_instance->GetTextureId()));
     } else {
-      result->Error("Can't create a webview instance!!");
+      result->Error("Can't create view instance");
     }
   } else {
     FT_LOG(Error) << "Can't find view type: " << *view_type;
@@ -161,7 +158,7 @@ void PlatformViewChannel::OnCreate(
 void PlatformViewChannel::OnClearFocus(
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>>&& result) {
-  auto view_id_ptr = std::get_if<int>(arguments);
+  const int* view_id_ptr = std::get_if<int>(arguments);
   if (!view_id_ptr) {
     result->Error("Invalid arguments");
     return;
@@ -181,14 +178,13 @@ void PlatformViewChannel::OnClearFocus(
 void PlatformViewChannel::OnDispose(
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>>&& result) {
-  auto map_ptr = std::get_if<EncodableMap>(arguments);
+  auto* map_ptr = std::get_if<EncodableMap>(arguments);
   if (!map_ptr) {
     result->Error("Invalid arguments");
     return;
   }
 
   EncodableValueHolder<int> view_id(map_ptr, "id");
-
   if (!view_id) {
     result->Error("Invalid arguments");
     return;
@@ -206,7 +202,7 @@ void PlatformViewChannel::OnDispose(
 void PlatformViewChannel::OnResize(
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>>&& result) {
-  auto map_ptr = std::get_if<EncodableMap>(arguments);
+  auto* map_ptr = std::get_if<EncodableMap>(arguments);
   if (!map_ptr) {
     result->Error("Invalid arguments");
     return;
@@ -234,7 +230,7 @@ void PlatformViewChannel::OnResize(
 void PlatformViewChannel::OnTouch(
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>>&& result) {
-  auto map_ptr = std::get_if<EncodableMap>(arguments);
+  auto* map_ptr = std::get_if<EncodableMap>(arguments);
   if (!map_ptr) {
     result->Error("Invalid arguments");
     return;
@@ -247,7 +243,7 @@ void PlatformViewChannel::OnTouch(
   EncodableValueHolder<int> view_id(map_ptr, "id");
 
   if (!view_id || !event || event->size() != 6) {
-    result->Error("Invalid Arguments");
+    result->Error("Invalid arguments");
     return;
   }
 

--- a/shell/platform/tizen/channels/platform_view_channel.cc
+++ b/shell/platform/tizen/channels/platform_view_channel.cc
@@ -36,26 +36,42 @@ PlatformViewChannel::~PlatformViewChannel() {
 }
 
 void PlatformViewChannel::Dispose() {
-  ClearViewInstances();
+  ClearViews();
   ClearViewFactories();
 }
 
-void PlatformViewChannel::RemoveViewInstanceIfNeeded(int view_id) {
-  auto it = view_instances_.find(view_id);
-  if (view_id >= 0 && it != view_instances_.end()) {
-    PlatformView* view_instance = it->second;
-    view_instance->Dispose();
-    delete view_instance;
-    view_instances_.erase(it);
+PlatformView* PlatformViewChannel::FindViewById(int view_id) {
+  auto it = views_.find(view_id);
+  if (it != views_.end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
+PlatformView* PlatformViewChannel::FindFocusedView() {
+  for (const auto& [view_id, view] : views_) {
+    if (view->IsFocused()) {
+      return view;
+    }
+  }
+  return nullptr;
+}
+
+void PlatformViewChannel::RemoveViewIfExists(int view_id) {
+  PlatformView* view = FindViewById(view_id);
+  if (view) {
+    view->Dispose();
+    delete view;
+    views_.erase(view_id);
   }
 }
 
-void PlatformViewChannel::ClearViewInstances() {
-  for (const auto& [view_id, view_instance] : view_instances_) {
-    view_instance->Dispose();
-    delete view_instance;
+void PlatformViewChannel::ClearViews() {
+  for (const auto& [view_id, view] : views_) {
+    view->Dispose();
+    delete view;
   }
-  view_instances_.clear();
+  views_.clear();
 }
 
 void PlatformViewChannel::ClearViewFactories() {
@@ -66,23 +82,14 @@ void PlatformViewChannel::ClearViewFactories() {
 }
 
 void PlatformViewChannel::SendKeyEvent(Ecore_Event_Key* event, bool is_down) {
-  PlatformView* view_instance = FocusedViewInstance();
-  if (view_instance) {
+  PlatformView* view = FindFocusedView();
+  if (view) {
     if (is_down) {
-      view_instance->DispatchKeyDownEvent(event);
+      view->DispatchKeyDownEvent(event);
     } else {
-      view_instance->DispatchKeyUpEvent(event);
+      view->DispatchKeyUpEvent(event);
     }
   }
-}
-
-PlatformView* PlatformViewChannel::FocusedViewInstance() {
-  for (const auto& [view_id, view_instance] : view_instances_) {
-    if (view_instance->IsFocused()) {
-      return view_instance;
-    }
-  }
-  return nullptr;
 }
 
 void PlatformViewChannel::HandleMethodCall(
@@ -110,16 +117,16 @@ void PlatformViewChannel::HandleMethodCall(
 void PlatformViewChannel::OnCreate(
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>>&& result) {
-  auto* map_ptr = std::get_if<EncodableMap>(arguments);
-  if (!map_ptr) {
+  auto* map = std::get_if<EncodableMap>(arguments);
+  if (!map) {
     result->Error("Invalid arguments");
     return;
   }
 
-  EncodableValueHolder<std::string> view_type(map_ptr, "viewType");
-  EncodableValueHolder<int> view_id(map_ptr, "id");
-  EncodableValueHolder<double> width(map_ptr, "width");
-  EncodableValueHolder<double> height(map_ptr, "height");
+  EncodableValueHolder<std::string> view_type(map, "viewType");
+  EncodableValueHolder<int> view_id(map, "id");
+  EncodableValueHolder<double> width(map, "width");
+  EncodableValueHolder<double> height(map, "height");
 
   if (!view_type || !view_id || !width || !height) {
     result->Error("Invalid arguments");
@@ -127,25 +134,24 @@ void PlatformViewChannel::OnCreate(
   }
 
   FT_LOG(Info) << "Creating a platform view: " << view_type.value;
-  RemoveViewInstanceIfNeeded(*view_id);
+  RemoveViewIfExists(*view_id);
 
-  EncodableValueHolder<ByteMessage> params(map_ptr, "params");
+  EncodableValueHolder<ByteMessage> params(map, "params");
   ByteMessage byte_message;
   if (params) {
     byte_message = *params;
   }
   auto it = view_factories_.find(*view_type);
   if (it != view_factories_.end()) {
-    PlatformView* focused_view = FocusedViewInstance();
+    PlatformView* focused_view = FindFocusedView();
     if (focused_view) {
       focused_view->SetFocus(false);
     }
-    PlatformViewFactory* view_factory = it->second.get();
-    PlatformView* view_instance =
-        view_factory->Create(*view_id, *width, *height, byte_message);
-    if (view_instance) {
-      view_instances_[*view_id] = view_instance;
-      result->Success(EncodableValue(view_instance->GetTextureId()));
+    PlatformView* view =
+        it->second->Create(*view_id, *width, *height, byte_message);
+    if (view) {
+      views_[*view_id] = view;
+      result->Success(EncodableValue(view->GetTextureId()));
     } else {
       result->Error("Can't create view instance");
     }
@@ -158,80 +164,81 @@ void PlatformViewChannel::OnCreate(
 void PlatformViewChannel::OnClearFocus(
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>>&& result) {
-  const int* view_id_ptr = std::get_if<int>(arguments);
-  if (!view_id_ptr) {
+  const int* view_id = std::get_if<int>(arguments);
+  if (!view_id) {
     result->Error("Invalid arguments");
     return;
   }
 
-  auto it = view_instances_.find(*view_id_ptr);
-  if (it == view_instances_.end()) {
+  PlatformView* view = FindViewById(*view_id);
+  if (!view) {
     result->Error("Can't find view id");
     return;
   }
+  view->SetFocus(false);
+  view->ClearFocus();
 
-  it->second->SetFocus(false);
-  it->second->ClearFocus();
   result->Success();
 }
 
 void PlatformViewChannel::OnDispose(
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>>&& result) {
-  auto* map_ptr = std::get_if<EncodableMap>(arguments);
-  if (!map_ptr) {
+  auto* map = std::get_if<EncodableMap>(arguments);
+  if (!map) {
     result->Error("Invalid arguments");
     return;
   }
 
-  EncodableValueHolder<int> view_id(map_ptr, "id");
+  EncodableValueHolder<int> view_id(map, "id");
   if (!view_id) {
     result->Error("Invalid arguments");
     return;
   }
 
-  if (view_instances_.find(*view_id) == view_instances_.end()) {
+  PlatformView* view = FindViewById(*view_id);
+  if (!view) {
     result->Error("Can't find view id");
     return;
   }
+  RemoveViewIfExists(*view_id);
 
-  RemoveViewInstanceIfNeeded(*view_id);
   result->Success();
 }
 
 void PlatformViewChannel::OnResize(
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>>&& result) {
-  auto* map_ptr = std::get_if<EncodableMap>(arguments);
-  if (!map_ptr) {
+  auto* map = std::get_if<EncodableMap>(arguments);
+  if (!map) {
     result->Error("Invalid arguments");
     return;
   }
 
-  EncodableValueHolder<int> view_id(map_ptr, "id");
-  EncodableValueHolder<double> width(map_ptr, "width");
-  EncodableValueHolder<double> height(map_ptr, "height");
+  EncodableValueHolder<int> view_id(map, "id");
+  EncodableValueHolder<double> width(map, "width");
+  EncodableValueHolder<double> height(map, "height");
 
   if (!view_id || !width || !height) {
     result->Error("Invalid arguments");
     return;
   }
 
-  auto it = view_instances_.find(*view_id);
-  if (it == view_instances_.end()) {
+  PlatformView* view = FindViewById(*view_id);
+  if (!view) {
     result->Error("Can't find view id");
     return;
   }
+  view->Resize(*width, *height);
 
-  it->second->Resize(*width, *height);
   result->Success();
 }
 
 void PlatformViewChannel::OnTouch(
     const EncodableValue* arguments,
     std::unique_ptr<MethodResult<EncodableValue>>&& result) {
-  auto* map_ptr = std::get_if<EncodableMap>(arguments);
-  if (!map_ptr) {
+  auto* map = std::get_if<EncodableMap>(arguments);
+  if (!map) {
     result->Error("Invalid arguments");
     return;
   }
@@ -239,17 +246,11 @@ void PlatformViewChannel::OnTouch(
   int type = 0, button = 0;
   double x = 0.0, y = 0.0, dx = 0.0, dy = 0.0;
 
-  EncodableValueHolder<EncodableList> event(map_ptr, "event");
-  EncodableValueHolder<int> view_id(map_ptr, "id");
+  EncodableValueHolder<EncodableList> event(map, "event");
+  EncodableValueHolder<int> view_id(map, "id");
 
   if (!view_id || !event || event->size() != 6) {
     result->Error("Invalid arguments");
-    return;
-  }
-
-  auto it = view_instances_.find(*view_id);
-  if (it == view_instances_.end()) {
-    result->Error("Can't find view id");
     return;
   }
 
@@ -260,19 +261,23 @@ void PlatformViewChannel::OnTouch(
   dx = std::get<double>(event->at(4));
   dy = std::get<double>(event->at(5));
 
-  PlatformView* view_instance = it->second;
-  view_instance->Touch(type, button, x, y, dx, dy);
+  PlatformView* view = FindViewById(*view_id);
+  if (!view) {
+    result->Error("Can't find view id");
+    return;
+  }
+  view->Touch(type, button, x, y, dx, dy);
 
-  if (!view_instance->IsFocused()) {
-    PlatformView* focused_view = FocusedViewInstance();
+  if (!view->IsFocused()) {
+    PlatformView* focused_view = FindFocusedView();
     if (focused_view) {
       focused_view->SetFocus(false);
     }
 
-    view_instance->SetFocus(true);
+    view->SetFocus(true);
     if (channel_ != nullptr) {
-      auto id = std::make_unique<EncodableValue>(*view_id);
-      channel_->InvokeMethod("viewFocused", std::move(id));
+      auto args = std::make_unique<EncodableValue>(*view_id);
+      channel_->InvokeMethod("viewFocused", std::move(args));
     }
   }
 

--- a/shell/platform/tizen/channels/platform_view_channel.cc
+++ b/shell/platform/tizen/channels/platform_view_channel.cc
@@ -43,7 +43,7 @@ void PlatformViewChannel::Dispose() {
 void PlatformViewChannel::RemoveViewInstanceIfNeeded(int view_id) {
   auto it = view_instances_.find(view_id);
   if (view_id >= 0 && it != view_instances_.end()) {
-    auto* view_instance = it->second;
+    PlatformView* view_instance = it->second;
     view_instance->Dispose();
     delete view_instance;
     view_instances_.erase(it);
@@ -66,31 +66,30 @@ void PlatformViewChannel::ClearViewFactories() {
 }
 
 void PlatformViewChannel::SendKeyEvent(Ecore_Event_Key* event, bool is_down) {
-  auto instances = ViewInstances();
-  auto it = instances.find(CurrentFocusedViewId());
-  if (it != instances.end()) {
+  PlatformView* view_instance = FocusedViewInstance();
+  if (view_instance) {
     if (is_down) {
-      it->second->DispatchKeyDownEvent(event);
+      view_instance->DispatchKeyDownEvent(event);
     } else {
-      it->second->DispatchKeyUpEvent(event);
+      view_instance->DispatchKeyUpEvent(event);
     }
   }
 }
 
-int PlatformViewChannel::CurrentFocusedViewId() {
-  for (auto it = view_instances_.begin(); it != view_instances_.end(); it++) {
-    if (it->second->IsFocused()) {
-      return it->second->GetViewId();
+PlatformView* PlatformViewChannel::FocusedViewInstance() {
+  for (const auto& [view_id, view_instance] : view_instances_) {
+    if (view_instance->IsFocused()) {
+      return view_instance;
     }
   }
-  return -1;
+  return nullptr;
 }
 
 void PlatformViewChannel::HandleMethodCall(
     const MethodCall<EncodableValue>& call,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
-  const auto& method = call.method_name();
-  const auto* arguments = call.arguments();
+  const std::string& method = call.method_name();
+  const EncodableValue* arguments = call.arguments();
 
   if (method == "create") {
     OnCreate(arguments, std::move(result));
@@ -137,12 +136,13 @@ void PlatformViewChannel::OnCreate(
   }
   auto it = view_factories_.find(*view_type);
   if (it != view_factories_.end()) {
-    auto focused_view = view_instances_.find(CurrentFocusedViewId());
-    if (focused_view != view_instances_.end()) {
-      focused_view->second->SetFocus(false);
+    PlatformView* focused_view = FocusedViewInstance();
+    if (focused_view) {
+      focused_view->SetFocus(false);
     }
-    auto* view_instance =
-        it->second->Create(*view_id, *width, *height, byte_message);
+    PlatformViewFactory* view_factory = it->second.get();
+    PlatformView* view_instance =
+        view_factory->Create(*view_id, *width, *height, byte_message);
     if (view_instance) {
       view_instances_[*view_id] = view_instance;
       result->Success(EncodableValue(view_instance->GetTextureId()));
@@ -260,15 +260,16 @@ void PlatformViewChannel::OnTouch(
   dx = std::get<double>(event->at(4));
   dy = std::get<double>(event->at(5));
 
-  it->second->Touch(type, button, x, y, dx, dy);
+  PlatformView* view_instance = it->second;
+  view_instance->Touch(type, button, x, y, dx, dy);
 
-  if (!it->second->IsFocused()) {
-    auto focused_view = view_instances_.find(CurrentFocusedViewId());
-    if (focused_view != view_instances_.end()) {
-      focused_view->second->SetFocus(false);
+  if (!view_instance->IsFocused()) {
+    PlatformView* focused_view = FocusedViewInstance();
+    if (focused_view) {
+      focused_view->SetFocus(false);
     }
 
-    it->second->SetFocus(true);
+    view_instance->SetFocus(true);
     if (channel_ != nullptr) {
       auto id = std::make_unique<EncodableValue>(*view_id);
       channel_->InvokeMethod("viewFocused", std::move(id));

--- a/shell/platform/tizen/channels/platform_view_channel.h
+++ b/shell/platform/tizen/channels/platform_view_channel.h
@@ -13,7 +13,6 @@
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
-#include "rapidjson/document.h"
 
 class PlatformView;
 class PlatformViewFactory;
@@ -33,9 +32,11 @@ class PlatformViewChannel {
   std::map<std::string, std::unique_ptr<PlatformViewFactory>>& ViewFactories() {
     return view_factories_;
   }
+
   std::map<int, PlatformView*>& ViewInstances() { return view_instances_; }
 
-  void SendKeyEvent(Ecore_Event_Key* key, bool is_down);
+  void SendKeyEvent(Ecore_Event_Key* event, bool is_down);
+
   int CurrentFocusedViewId();
 
  private:

--- a/shell/platform/tizen/channels/platform_view_channel.h
+++ b/shell/platform/tizen/channels/platform_view_channel.h
@@ -25,21 +25,19 @@ class PlatformViewChannel {
   virtual ~PlatformViewChannel();
 
   void Dispose();
-  void RemoveViewInstanceIfNeeded(int view_id);
-  void ClearViewInstances();
-  void ClearViewFactories();
 
   std::map<std::string, std::unique_ptr<PlatformViewFactory>>& ViewFactories() {
     return view_factories_;
   }
 
-  std::map<int, PlatformView*>& ViewInstances() { return view_instances_; }
-
   void SendKeyEvent(Ecore_Event_Key* event, bool is_down);
 
-  int CurrentFocusedViewId();
-
  private:
+  void RemoveViewInstanceIfNeeded(int view_id);
+  void ClearViewInstances();
+  void ClearViewFactories();
+  PlatformView* FocusedViewInstance();
+
   void HandleMethodCall(const MethodCall<EncodableValue>& call,
                         std::unique_ptr<MethodResult<EncodableValue>> result);
 

--- a/shell/platform/tizen/channels/platform_view_channel.h
+++ b/shell/platform/tizen/channels/platform_view_channel.h
@@ -33,10 +33,12 @@ class PlatformViewChannel {
   void SendKeyEvent(Ecore_Event_Key* event, bool is_down);
 
  private:
-  void RemoveViewInstanceIfNeeded(int view_id);
-  void ClearViewInstances();
+  PlatformView* FindViewById(int view_id);
+  PlatformView* FindFocusedView();
+
+  void RemoveViewIfExists(int view_id);
+  void ClearViews();
   void ClearViewFactories();
-  PlatformView* FocusedViewInstance();
 
   void HandleMethodCall(const MethodCall<EncodableValue>& call,
                         std::unique_ptr<MethodResult<EncodableValue>> result);
@@ -54,7 +56,7 @@ class PlatformViewChannel {
 
   std::unique_ptr<MethodChannel<EncodableValue>> channel_;
   std::map<std::string, std::unique_ptr<PlatformViewFactory>> view_factories_;
-  std::map<int, PlatformView*> view_instances_;
+  std::map<int, PlatformView*> views_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
- Remove unused imports.
- Rename variables and methods: `view_instance` → `view`.
- Rename `RemoveViewInstanceIfNeeded` to `RemoveViewIfExists`.
- Replace `CurrentFocusedViewId` with `FindFocusedView`.
- Create `FindViewById`.
- Avoid type deduction (`auto`).
- Rename `*_ptr` variables (e.g. `map_ptr` to `map`).
- Make public methods private.
- Minor cleanups.