### PR TITLE
Clean up flutter_platform_view.h

### DIFF
--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -30,6 +30,10 @@ _public_headers = [
   "public/flutter_tizen.h",
 ]
 
+config("relative_client_wrapper_headers") {
+  include_dirs = [ "//flutter/shell/platform/common/client_wrapper/include" ]
+}
+
 # Tizen native headers assume that the following include dirs are already
 # added to the compiler's search paths. Since we are not using the Tizen CLI
 # builder, we have to add them manually.
@@ -160,6 +164,7 @@ template("embedder") {
         [ "//flutter/shell/platform/common:desktop_library_implementation" ]
 
     public_configs = [
+      ":relative_client_wrapper_headers",
       ":rootstrap_include_dirs",
       "//flutter:config",
     ]

--- a/shell/platform/tizen/channels/platform_view_channel.cc
+++ b/shell/platform/tizen/channels/platform_view_channel.cc
@@ -4,8 +4,6 @@
 
 #include "platform_view_channel.h"
 
-#include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
-#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
 #include "flutter/shell/platform/common/json_method_codec.h"
 #include "flutter/shell/platform/tizen/channels/encodable_value_holder.h"

--- a/shell/platform/tizen/public/flutter_platform_view.h
+++ b/shell/platform/tizen/public/flutter_platform_view.h
@@ -5,30 +5,32 @@
 #ifndef FLUTTER_SHELL_PLATFORM_TIZEN_PUBLIC_FLUTTER_PLATFORM_VIEW_H_
 #define FLUTTER_SHELL_PLATFORM_TIZEN_PUBLIC_FLUTTER_PLATFORM_VIEW_H_
 
-#include <Ecore_IMF.h>
 #include <Ecore_Input.h>
-#include <stddef.h>
+#include <flutter/plugin_registrar.h>
+#include <flutter/standard_message_codec.h>
 #include <stdint.h>
 
 #include "flutter_export.h"
-
-using ByteMessage = std::vector<uint8_t>;
 
 class PlatformView {
  public:
   PlatformView(flutter::PluginRegistrar* registrar,
                int view_id,
                void* platform_window)
-      : registrar_(registrar),
-        view_id_(view_id),
-        texture_id_(0),
-        is_focused_(false) {}
+      : registrar_(registrar), view_id_(view_id) {}
+
   virtual ~PlatformView() {}
+
   int GetViewId() { return view_id_; }
+
   int GetTextureId() { return texture_id_; }
+
   void SetTextureId(int texture_id) { texture_id_ = texture_id; }
+
   flutter::PluginRegistrar* GetPluginRegistrar() { return registrar_; }
+
   virtual void Dispose() = 0;
+
   virtual void Resize(double width, double height) = 0;
   virtual void Touch(int type,
                      int button,
@@ -37,35 +39,43 @@ class PlatformView {
                      double dx,
                      double dy) = 0;
   virtual void SetDirection(int direction) = 0;
+
   virtual void ClearFocus() = 0;
-  void SetFocus(bool f) { is_focused_ = f; }
+
+  void SetFocus(bool focused) { is_focused_ = focused; }
+
   bool IsFocused() { return is_focused_; }
 
-  // Key input event
-  virtual void DispatchKeyDownEvent(Ecore_Event_Key* key) = 0;
-  virtual void DispatchKeyUpEvent(Ecore_Event_Key* key) = 0;
+  virtual void DispatchKeyDownEvent(Ecore_Event_Key* event) = 0;
+  virtual void DispatchKeyUpEvent(Ecore_Event_Key* event) = 0;
 
  private:
   flutter::PluginRegistrar* registrar_;
   int view_id_;
-  int texture_id_;
-  bool is_focused_;
+  int texture_id_ = 0;
+  bool is_focused_ = false;
 };
+
+using ByteMessage = std::vector<uint8_t>;
 
 class PlatformViewFactory {
  public:
   PlatformViewFactory(flutter::PluginRegistrar* registrar)
       : registrar_(registrar),
         codec_(flutter::StandardMessageCodec::GetInstance(nullptr)) {}
+
   virtual ~PlatformViewFactory() {}
+
   flutter::PluginRegistrar* GetPluginRegistrar() { return registrar_; }
+
   const flutter::MessageCodec<flutter::EncodableValue>& GetCodec() {
     return codec_;
   }
+
   virtual PlatformView* Create(int view_id,
                                double width,
                                double height,
-                               const ByteMessage& parameters) = 0;
+                               const ByteMessage& params) = 0;
   virtual void Dispose() = 0;
 
  private:


### PR DESCRIPTION
- Add missing includes: `plugin_registrar.h` and `standard_message_codec.h`.
  - Add `shell/platform/common/client_wrapper/include` to the include dirs so that the headers can be resolved during plugin build.
  - Remove unused includes from `platform_view_channel.cc` accordingly.
- Remove unused include: `Ecore_IMF.h`.
- Minor cleanups. (line breaks and etc.)

This change should land after https://github.com/flutter-tizen/plugins/pull/336 is published.