### PR TITLE
[ci] Fix artifact upload failure and hash mismatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,11 +100,13 @@ jobs:
         with:
           name: tizen-arm-unittests
           path: src/out/${{ env.OUTPUT_NAME }}/*_unittests
+          if-no-files-found: error
 
       - uses: actions/upload-artifact@v2
         with:
           name: tizen-${{ matrix.arch }}-${{ matrix.mode }}
           path: src/out/${{ env.OUTPUT_NAME }}/libflutter_*.so
+          if-no-files-found: error
 
       - uses: actions/upload-artifact@v2
         if: matrix.arch == 'arm' && matrix.mode == 'release'
@@ -115,12 +117,14 @@ jobs:
             src/out/linux_release_arm/public
             src/out/linux_release_arm/cpp_client_wrapper
             !src/out/linux_release_arm/cpp_client_wrapper/engine_method_result.cc
+          if-no-files-found: error
 
       - uses: actions/upload-artifact@v2
         if: (matrix.arch == 'arm' || matrix.arch == 'arm64') && matrix.mode != 'debug'
         with:
           name: tizen-${{ matrix.arch }}-${{ matrix.mode }}_linux-x64
           path: src/out/${{ env.OUTPUT_NAME }}/clang_x64/gen_snapshot
+          if-no-files-found: error
 
   windows-build:
     runs-on: windows-2019
@@ -178,6 +182,7 @@ jobs:
         with:
           name: tizen-${{ matrix.arch }}-${{ matrix.mode }}_windows-x64
           path: C:\workspace\engine\src\out\${{ env.OUTPUT_NAME }}\gen_snapshot.exe
+          if-no-files-found: error
 
   macos-build:
     runs-on: macos-11
@@ -241,6 +246,7 @@ jobs:
         with:
           name: tizen-${{ matrix.arch }}-${{ matrix.mode }}_darwin-x64
           path: src/out/${{ env.OUTPUT_NAME }}/clang_x64/gen_snapshot
+          if-no-files-found: error
 
   test:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,10 @@ jobs:
             --build-tizen-shell
           ninja -C src/out/$OUTPUT_NAME tizen
 
+          if [ "${{ matrix.mode }}" != "debug" ]; then
+            ninja -C src/out/$OUTPUT_NAME clang_x64/gen_snapshot
+          fi
+
           # Build unittests.
           if [ "$OUTPUT_NAME" = "linux_release_arm" ]; then
             ninja -C src/out/$OUTPUT_NAME flutter_tizen_unittests
@@ -294,7 +298,7 @@ jobs:
         with:
           name: ${{ env.VERSION }} (${{ env.TAG_NAME }})
           tag_name: ${{ env.TAG_NAME }}
-          target_commitish: ${{ github.ref_name }}
+          target_commitish: ${{ github.sha }}
           files: tizen-*.zip
           body: |
             Flutter engine ${{ env.VERSION }} for Tizen


### PR DESCRIPTION
- Fix the Linux build job not uploading gen_snapshot artifacts.
- Fix release tag and hash mismatches caused by merging multiple PRs without enough time interval.
  ![image](https://user-images.githubusercontent.com/40190588/158127203-0c92130d-61ed-4ffd-a759-f626a926e7a4.png)
- Fail rather than warning if no artifact could be found.