### PR TITLE
[ci] Unset PYTHONPATH on gclient sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,8 +165,9 @@ jobs:
         working-directory: C:\workspace\engine
         run: |
           gclient config --name=src\flutter --unmanaged https://github.com/flutter-tizen/engine
-          $env:PYTHONPATH="C:\workspace\depot_tools"
+          $Env:PYTHONPATH="C:\workspace\depot_tools"
           python3 src\flutter\ci\tizen\gclient-shallow-sync.py src\flutter\DEPS
+          $Env:PYTHONPATH=""
           gclient sync -v --no-history --shallow
 
       - name: build


### PR DESCRIPTION
Fixes the recent gclient sync error (Windows build).

The `utils.py` script has been added to `depot_tools` as of [`0399e17`](https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/0399e1762c52f02f5f6171eb94ff9782ff3241be) and it conflicts with a script with the same name used by `download_dart_sdk.py`.
