### PR TITLE
Rework the high contrast accessibility feature

### DIFF
--- a/shell/platform/tizen/accessibility_settings.cc
+++ b/shell/platform/tizen/accessibility_settings.cc
@@ -41,7 +41,7 @@ AccessibilitySettings::AccessibilitySettings(FlutterTizenEngine* engine)
           SYSTEM_SETTINGS_KEY_MENU_SYSTEM_ACCESSIBILITY_HIGHCONTRAST),
       &high_contrast_enabled);
   if (result == SYSTEM_SETTINGS_ERROR_NONE) {
-    engine_->EnableAccessibilityFeature(high_contrast_enabled);
+    engine_->UpdateAccessibilityFeatures(false, high_contrast_enabled);
   } else {
     FT_LOG(Error) << "Failed to get value of accessibility high contrast.";
   }
@@ -79,7 +79,7 @@ void AccessibilitySettings::OnHighContrastStateChanged(
     return;
   }
 
-  self->engine_->EnableAccessibilityFeature(enabled);
+  self->engine_->UpdateAccessibilityFeatures(false, enabled);
 #endif
 }
 

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -485,26 +485,15 @@ bool FlutterTizenEngine::MarkExternalTextureFrameAvailable(int64_t texture_id) {
               engine_, texture_id) == kSuccess);
 }
 
-// Set bold font when accessibility high contrast state is
-// changed.
-void FlutterTizenEngine::EnableAccessibilityFeature(bool bold_text) {
-  if (engine_ == nullptr) {
-    return;
-  }
-
-  if (bold_text) {
-    embedder_api_.UpdateAccessibilityFeatures(
-        engine_, kFlutterAccessibilityFeatureBoldText);
-  } else {
-    embedder_api_.UpdateAccessibilityFeatures(engine_,
-                                              FlutterAccessibilityFeature(0));
-  }
+void FlutterTizenEngine::UpdateAccessibilityFeatures(bool invert_colors,
+                                                     bool high_contrast) {
+  int32_t flags = 0;
+  flags |= invert_colors ? kFlutterAccessibilityFeatureInvertColors : 0;
+  flags |= high_contrast ? kFlutterAccessibilityFeatureHighContrast : 0;
+  embedder_api_.UpdateAccessibilityFeatures(engine_,
+                                            FlutterAccessibilityFeature(flags));
 }
 
-// The Flutter Engine calls out to this function when new platform messages
-// are available.
-
-// Converts a FlutterPlatformMessage to an equivalent FlutterDesktopMessage.
 FlutterDesktopMessage FlutterTizenEngine::ConvertToDesktopMessage(
     const FlutterPlatformMessage& engine_message) {
   FlutterDesktopMessage message = {};

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -186,8 +186,8 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
   void SetSemanticsEnabled(bool enabled);
 #endif
 
-  // Set bold font when accessibility high contrast state is changed.
-  void EnableAccessibilityFeature(bool bold_text);
+  // Notifies the engine about enabled accessibility features.
+  void UpdateAccessibilityFeatures(bool invert_colors, bool high_contrast);
 
  private:
   friend class EngineModifier;
@@ -195,6 +195,7 @@ class FlutterTizenEngine : public TizenRenderer::Delegate {
   // Whether the engine is running in headed or headless mode.
   bool IsHeaded() { return renderer_ != nullptr; }
 
+  // Converts a FlutterPlatformMessage to an equivalent FlutterDesktopMessage.
   FlutterDesktopMessage ConvertToDesktopMessage(
       const FlutterPlatformMessage& engine_message);
 


### PR DESCRIPTION
Currently a [boldText](https://api.flutter.dev/flutter/dart-ui/AccessibilityFeatures/boldText.html) flag is being passed to the engine when the High Contrast option is set in the TV settings. A [highContrast](https://api.flutter.dev/flutter/dart-ui/AccessibilityFeatures/highContrast.html) flag must used instead.

Contributes to https://github.com/flutter-tizen/flutter-tizen/issues/151. Should be rebased upon https://github.com/flutter-tizen/engine/pull/264.

The [invertColors](https://api.flutter.dev/flutter/dart-ui/AccessibilityFeatures/invertColors.html) feature support will be added after this change.

Code example:
```dart
return MaterialApp(
  theme: ThemeData(colorScheme: const ColorScheme.light()),
  highContrastTheme:
      ThemeData(colorScheme: const ColorScheme.highContrastLight()),
  ...
);
```