### PR TITLE
Enable compressed pointers for arm64

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -423,8 +423,8 @@ def to_gn_args(args):
       gn_args['enable_vulkan_validation_layers'] = True
 
 
-    # Enable pointer compression on 64-bit mobile targets.
-    if args.target_os in ['android', 'ios'] and gn_args['target_cpu'] in ['x64' , 'arm64']:
+    # Enable pointer compression on 64-bit targets.
+    if args.target_os in ['android', 'ios', 'linux'] and gn_args['target_cpu'] in ['x64' , 'arm64']:
       gn_args['dart_use_compressed_pointers'] = True
 
     if args.fuchsia_target_api_level is not None:


### PR DESCRIPTION
Closes https://github.com/flutter-tizen/engine/issues/220.

The feature now seems stable enough to land to Tizen arm64 targets.

Memory footprint comparison:

```
Application                          PSS (KB)                RSS (KB)
io.flutter.demo.gallery        126567  123072   -2.8%  144614  141859   -1.9%
```

This change should not be released until the next stable framework release, because snapshot compilation (generating `libapp.so`) will be skipped for already compiled apps even with updated `gen_snapshot`s (caused by [this](https://github.com/flutter/flutter/blob/0b97874895eb3e14c1cf0e65bd7fca3a17c62b02/packages/flutter_tools/lib/src/build_system/source.dart#L169-L171)).