### PR TITLE
[ci] Do not fail on standard error

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,6 @@ jobs:
       sed -i 's/"-Wno-unused-but-set-variable",//g' build/config/compiler/BUILD.gn
     displayName: Disable build flags
     workingDirectory: $(Pipeline.Workspace)/src
-    failOnStderr: true
   - bash: |
       flutter/tools/gn \
         --target-os linux \
@@ -71,40 +70,9 @@ jobs:
         --embedder-for-target \
         --build-tizen-shell
       ninja -C out/linux_$(mode)_$(arch)
+      cp out/linux_$(mode)_$(arch)/libflutter_*.so $(Build.StagingDirectory)
     displayName: Build
-    workingDirectory: $(Pipeline.Workspace)/src
-    failOnStderr: true
-  - bash: |
-      OUTDIR=$(Build.StagingDirectory)
-      cp out/linux_$(mode)_$(arch)/libflutter_*.so $OUTDIR
-      if [[ $(System.JobName) == "tizen-arm-release" ]]; then
-        mkdir $OUTDIR/tizen-common
-        cp -r out/linux_$(mode)_$(arch)/{cpp_client_wrapper,icu,public} $OUTDIR/tizen-common
-        rm $OUTDIR/tizen-common/cpp_client_wrapper/engine_method_result.cc
-      fi
-    displayName: Copy artifacts
     workingDirectory: $(Pipeline.Workspace)/src
     failOnStderr: true
   - publish: $(Build.StagingDirectory)
     artifact: $(System.JobName)
-- job: release
-  dependsOn: build
-  pool:
-    name: Default
-    demands: agent.os -equals Linux
-  workspace:
-    clean: outputs
-  steps:
-  - download: current
-  - bash: |
-      mv $(Pipeline.Workspace)/tizen-arm-release/tizen-common .
-      mv $(Pipeline.Workspace)/tizen-* .
-      for x in $(ls -d1 tizen-*); do
-        echo "Archiving $x.zip..."
-        (cd $x; zip -rq $(Build.StagingDirectory)/$x.zip *)
-      done
-    displayName: Create releases
-    workingDirectory: $(Build.BinariesDirectory)
-    failOnStderr: true
-  - publish: $(Build.StagingDirectory)
-    artifact: release


### PR DESCRIPTION
Fixes the CI build error in https://github.com/flutter-tizen/engine/pull/266 which has been caused by:

- [Let user know when depot_tools is being updated.](https://chromium.googlesource.com/chromium/tools/depot_tools/+/f560d36bbaf8805dff797502b7f4c33c718b21e1)
- [Print updating depot_tools in stderr](https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/0213e4b2d80793e359f52b809fbb9dc34ebdde46)

Only Azure Pipelines is affected because GitHub Actions doesn't fail on stderr by default.

Also removes unused job and step ("Copy artifacts" and "release").