### PR TITLE
Add invert colors accessibility support

### DIFF
--- a/shell/platform/tizen/accessibility_settings.h
+++ b/shell/platform/tizen/accessibility_settings.h
@@ -17,8 +17,8 @@ class AccessibilitySettings {
   virtual ~AccessibilitySettings();
 
  private:
-  static void OnHighContrastStateChanged(system_settings_key_e key,
-                                         void* user_data);
+  static void OnAccessibilityFeatureStateChanged(system_settings_key_e key,
+                                                 void* user_data);
   static void OnScreenReaderStateChanged(system_settings_key_e key,
                                          void* user_data);
 


### PR DESCRIPTION
Add support for the [invertColors](https://api.flutter.dev/flutter/dart-ui/AccessibilityFeatures/invertColors.html) accessibility feature for TV devices.

Other minor changes:
- Shorten `system_settings_key_e(SYSTEM_SETTINGS_KEY_MENU_SYSTEM_ACCESSIBILITY_HIGHCONTRAST)` for better readability and consistency.
- Rename `result` to `ret` (it's common practice in this repo).

Closes https://github.com/flutter-tizen/flutter-tizen/issues/151.