### PR TITLE
[ci] Publish debug symbols

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,13 @@ jobs:
           if-no-files-found: error
 
       - uses: actions/upload-artifact@v2
+        if: github.event_name == 'push'
+        with:
+          name: tizen-${{ matrix.arch }}-${{ matrix.mode }}_symbols
+          path: src/out/${{ env.OUTPUT_NAME }}/so.unstripped/libflutter_*.so
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v2
         if: matrix.arch == 'arm' && matrix.mode == 'release'
         with:
           name: tizen-common


### PR DESCRIPTION
Publish unstripped artifacts so that they can be used for symbolicating native stack traces (for live debugging and debugging crash dumps).

By default level 0 (g0) symbols are generated from optimized builds. If you want to use the symbols for general purpose debugging rather than just symbolication, it is recommended to use level 2 (g2) symbols (which have more than 5 times the size) by manually configuring the build.

The detailed instructions on how to use the symbols will be provided later.
