### PR TITLE
Minimize use of autos

### DIFF
--- a/shell/platform/tizen/accessibility_bridge_delegate_tizen.cc
+++ b/shell/platform/tizen/accessibility_bridge_delegate_tizen.cc
@@ -16,13 +16,14 @@ AccessibilityBridgeDelegateTizen::AccessibilityBridgeDelegateTizen(
 
 void AccessibilityBridgeDelegateTizen::OnAccessibilityEvent(
     ui::AXEventGenerator::TargetedEvent targeted_event) {
-  auto bridge = engine_->accessibility_bridge().lock();
+  std::shared_ptr<AccessibilityBridge> bridge =
+      engine_->accessibility_bridge().lock();
   if (!bridge) {
     FT_LOG(Error) << "Accessibility bridge is deallocated";
     return;
   }
 
-  auto platform_node_delegate =
+  std::shared_ptr<FlutterPlatformNodeDelegate> platform_node_delegate =
       bridge->GetFlutterPlatformNodeDelegateFromID(targeted_event.node->id())
           .lock();
   if (!platform_node_delegate) {

--- a/shell/platform/tizen/channels/accessibility_channel.cc
+++ b/shell/platform/tizen/channels/accessibility_channel.cc
@@ -39,7 +39,7 @@ AccessibilityChannel::AccessibilityChannel(BinaryMessenger* messenger)
         }
       }
     }
-    reply(flutter::EncodableValue());
+    reply(EncodableValue());
   });
 }
 

--- a/shell/platform/tizen/channels/app_control.cc
+++ b/shell/platform/tizen/channels/app_control.cc
@@ -232,13 +232,13 @@ AppControlResult AppControl::AddExtraData(std::string key,
 }
 
 AppControlResult AppControl::SetExtraData(const EncodableMap& map) {
-  for (const auto& v : map) {
-    if (!std::holds_alternative<std::string>(v.first)) {
+  for (const auto& element : map) {
+    if (!std::holds_alternative<std::string>(element.first)) {
       FT_LOG(Error) << "Invalid key. Omitting.";
       continue;
     }
-    const auto& key = std::get<std::string>(v.first);
-    AppControlResult ret = AddExtraData(key, v.second);
+    const auto& key = std::get<std::string>(element.first);
+    AppControlResult ret = AddExtraData(key, element.second);
     if (!ret) {
       FT_LOG(Error)
           << "The value for the key " << key

--- a/shell/platform/tizen/channels/app_control_channel.cc
+++ b/shell/platform/tizen/channels/app_control_channel.cc
@@ -65,7 +65,7 @@ void AppControlChannel::NotifyAppControl(void* handle) {
 void AppControlChannel::HandleMethodCall(
     const MethodCall<EncodableValue>& method_call,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
-  const auto& method_name = method_call.method_name();
+  const std::string& method_name = method_call.method_name();
 
   const auto* arguments = std::get_if<EncodableMap>(method_call.arguments());
   if (!arguments) {

--- a/shell/platform/tizen/channels/key_event_channel.cc
+++ b/shell/platform/tizen/channels/key_event_channel.cc
@@ -238,7 +238,7 @@ const std::map<int, int> kEcoreModifierToGtkModifier = {
 
 uint32_t Utf8ToUtf32CodePoint(const char* utf8) {
   std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
-  for (auto wchar : converter.from_bytes(utf8)) {
+  for (wchar_t wchar : converter.from_bytes(utf8)) {
     return wchar;
   }
   return 0;
@@ -282,7 +282,7 @@ void KeyEventChannel::SendKeyEvent(Ecore_Event_Key* key,
   }
 
   rapidjson::Document event(rapidjson::kObjectType);
-  auto& allocator = event.GetAllocator();
+  rapidjson::MemoryPoolAllocator<>& allocator = event.GetAllocator();
   event.AddMember(kKeyMapKey, kLinuxKeyMap, allocator);
   event.AddMember(kToolkitKey, kGtkToolkit, allocator);
   event.AddMember(kUnicodeScalarValuesKey, unicode_scalar_values, allocator);
@@ -297,7 +297,7 @@ void KeyEventChannel::SendKeyEvent(Ecore_Event_Key* key,
   channel_->Send(event, [callback = std::move(callback)](const uint8_t* reply,
                                                          size_t reply_size) {
     if (reply != nullptr) {
-      auto decoded =
+      std::unique_ptr<rapidjson::Document> decoded =
           JsonMessageCodec::GetInstance().DecodeMessage(reply, reply_size);
       bool handled = (*decoded)[kHandledKey].GetBool();
       callback(handled);

--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -74,8 +74,8 @@ PlatformChannel::~PlatformChannel() {}
 void PlatformChannel::HandleMethodCall(
     const MethodCall<rapidjson::Document>& method_call,
     std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-  const auto& method = method_call.method_name();
-  const auto* arguments = method_call.arguments();
+  const std::string& method = method_call.method_name();
+  const rapidjson::Document* arguments = method_call.arguments();
 
   if (method == kSystemNavigatorPopMethod) {
     SystemNavigatorPop();
@@ -125,7 +125,7 @@ void PlatformChannel::HandleMethodCall(
     RestoreSystemUiOverlays();
     result->Success();
   } else if (method == kSetEnabledSystemUiOverlaysMethod) {
-    const auto& list = arguments[0];
+    const rapidjson::Document& list = arguments[0];
     std::vector<std::string> overlays;
     for (auto iter = list.Begin(); iter != list.End(); ++iter) {
       overlays.push_back(iter->GetString());
@@ -134,7 +134,7 @@ void PlatformChannel::HandleMethodCall(
     result->Success();
 #endif
   } else if (method == kSetPreferredOrientationsMethod) {
-    const auto& list = arguments[0];
+    const rapidjson::Document& list = arguments[0];
     std::vector<std::string> orientations;
     for (auto iter = list.Begin(); iter != list.End(); ++iter) {
       orientations.push_back(iter->GetString());

--- a/shell/platform/tizen/channels/platform_view_channel.cc
+++ b/shell/platform/tizen/channels/platform_view_channel.cc
@@ -39,9 +39,9 @@ void PlatformViewChannel::Dispose() {
 }
 
 PlatformView* PlatformViewChannel::FindViewById(int view_id) {
-  auto it = views_.find(view_id);
-  if (it != views_.end()) {
-    return it->second;
+  auto iter = views_.find(view_id);
+  if (iter != views_.end()) {
+    return iter->second;
   }
   return nullptr;
 }
@@ -139,14 +139,14 @@ void PlatformViewChannel::OnCreate(
   if (params) {
     byte_message = *params;
   }
-  auto it = view_factories_.find(*view_type);
-  if (it != view_factories_.end()) {
+  auto iter = view_factories_.find(*view_type);
+  if (iter != view_factories_.end()) {
     PlatformView* focused_view = FindFocusedView();
     if (focused_view) {
       focused_view->SetFocus(false);
     }
     PlatformView* view =
-        it->second->Create(*view_id, *width, *height, byte_message);
+        iter->second->Create(*view_id, *width, *height, byte_message);
     if (view) {
       views_[*view_id] = view;
       result->Success(EncodableValue(view->GetTextureId()));

--- a/shell/platform/tizen/channels/settings_channel.cc
+++ b/shell/platform/tizen/channels/settings_channel.cc
@@ -50,7 +50,7 @@ SettingsChannel::~SettingsChannel() {
 
 void SettingsChannel::SendSettingsEvent() {
   rapidjson::Document event(rapidjson::kObjectType);
-  auto& allocator = event.GetAllocator();
+  rapidjson::MemoryPoolAllocator<>& allocator = event.GetAllocator();
   event.AddMember(kTextScaleFactorKey, GetTextScaleFactor(), allocator);
   event.AddMember(kAlwaysUse24HourFormatKey, Prefer24HourTime(), allocator);
   event.AddMember(kPlatformBrightnessKey, "light", allocator);

--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -272,8 +272,8 @@ void TextInputChannel::HandleMethodCall(
       size_t cursor_offset = selection_base_value - composing_start;
 
       active_model_->SetComposingRange(
-          flutter::TextRange(static_cast<size_t>(composing_base_value),
-                             static_cast<size_t>(composing_extent_value)),
+          TextRange(static_cast<size_t>(composing_base_value),
+                    static_cast<size_t>(composing_extent_value)),
           cursor_offset);
     }
     SendStateUpdate(*active_model_);

--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -248,8 +248,8 @@ void TextInputChannel::HandleMethodCall(
                     "Selection base/extent values invalid.");
       return;
     }
-    auto selection_base_value = selection_base->value.GetInt();
-    auto selection_extent_value = selection_extent->value.GetInt();
+    int selection_base_value = selection_base->value.GetInt();
+    int selection_extent_value = selection_extent->value.GetInt();
 
     active_model_->SetText(text->value.GetString());
     active_model_->SetSelection(
@@ -257,12 +257,12 @@ void TextInputChannel::HandleMethodCall(
 
     auto composing_base = args.FindMember(kComposingBaseKey);
     auto composing_extent = args.FindMember(kComposingBaseKey);
-    auto composing_base_value = composing_base != args.MemberEnd()
-                                    ? composing_base->value.GetInt()
-                                    : -1;
-    auto composing_extent_value = composing_extent != args.MemberEnd()
-                                      ? composing_extent->value.GetInt()
-                                      : -1;
+    int composing_base_value = composing_base != args.MemberEnd()
+                                   ? composing_base->value.GetInt()
+                                   : -1;
+    int composing_extent_value = composing_extent != args.MemberEnd()
+                                     ? composing_extent->value.GetInt()
+                                     : -1;
 
     if (composing_base_value == -1 && composing_extent_value == -1) {
       active_model_->EndComposing();
@@ -288,7 +288,7 @@ void TextInputChannel::HandleMethodCall(
 
 void TextInputChannel::SendStateUpdate(const TextInputModel& model) {
   auto args = std::make_unique<rapidjson::Document>(rapidjson::kArrayType);
-  auto& allocator = args->GetAllocator();
+  rapidjson::MemoryPoolAllocator<>& allocator = args->GetAllocator();
   args->PushBack(client_id_, allocator);
 
   TextRange selection = model.selection();
@@ -326,7 +326,7 @@ bool TextInputChannel::FilterEvent(Ecore_Event_Key* event, bool is_down) {
     FT_LOG(Debug) << "Entering select mode.";
   }
 #else
-  auto device_name = ecore_device_name_get(event->dev);
+  const char* device_name = ecore_device_name_get(event->dev);
   bool is_ime = device_name ? strcmp(device_name, "ime") == 0 : true;
 #endif
 
@@ -422,7 +422,7 @@ void TextInputChannel::EnterPressed(TextInputModel* model, bool select) {
     SendStateUpdate(*model);
   }
   auto args = std::make_unique<rapidjson::Document>(rapidjson::kArrayType);
-  auto& allocator = args->GetAllocator();
+  rapidjson::MemoryPoolAllocator<>& allocator = args->GetAllocator();
   args->PushBack(client_id_, allocator);
   args->PushBack(rapidjson::Value(input_action_, allocator).Move(), allocator);
 

--- a/shell/platform/tizen/channels/window_channel.cc
+++ b/shell/platform/tizen/channels/window_channel.cc
@@ -34,7 +34,7 @@ WindowChannel::~WindowChannel() {}
 void WindowChannel::HandleMethodCall(
     const MethodCall<EncodableValue>& method_call,
     std::unique_ptr<MethodResult<EncodableValue>> result) {
-  const auto& method_name = method_call.method_name();
+  const std::string& method_name = method_call.method_name();
 
   if (method_name == "getWindowGeometry") {
     TizenRenderer::Geometry geometry = renderer_->GetWindowGeometry();

--- a/shell/platform/tizen/flutter_project_bundle.cc
+++ b/shell/platform/tizen/flutter_project_bundle.cc
@@ -21,7 +21,7 @@ namespace {
 // Returns the path of the directory containing the app binary, or an empty
 // string if the directory cannot be found.
 std::filesystem::path GetBinDirectory() {
-  auto* res_path = app_get_resource_path();
+  char* res_path = app_get_resource_path();
   if (!res_path) {
     return GetExecutableDirectory();
   }
@@ -109,7 +109,7 @@ UniqueAotDataPtr FlutterProjectBundle::LoadAotData(
   source.type = kFlutterEngineAOTDataSourceTypeElfPath;
   source.elf_path = path_string.c_str();
   FlutterEngineAOTData data = nullptr;
-  auto result = engine_procs.CreateAOTData(&source, &data);
+  FlutterEngineResult result = engine_procs.CreateAOTData(&source, &data);
   if (result != kSuccess) {
     FT_LOG(Error) << "Failed to load AOT data from: " << path_string;
     return UniqueAotDataPtr(nullptr, nullptr);

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -69,7 +69,7 @@ FlutterDesktopEngineRef FlutterDesktopRunEngine(
 void FlutterDesktopShutdownEngine(FlutterDesktopEngineRef engine_ref) {
   flutter::Logger::Stop();
 
-  auto* engine = EngineFromHandle(engine_ref);
+  flutter::FlutterTizenEngine* engine = EngineFromHandle(engine_ref);
   engine->StopEngine();
   delete engine;
 }

--- a/shell/platform/tizen/flutter_tizen_texture_registrar.cc
+++ b/shell/platform/tizen/flutter_tizen_texture_registrar.cc
@@ -39,7 +39,8 @@ int64_t FlutterTizenTextureRegistrar::RegisterTexture(
       return -1;
     }
   }
-  auto texture_gl = CreateExternalTexture(texture_info);
+  std::unique_ptr<ExternalTexture> texture_gl =
+      CreateExternalTexture(texture_info);
   int64_t texture_id = texture_gl->TextureId();
 
   {
@@ -54,11 +55,11 @@ int64_t FlutterTizenTextureRegistrar::RegisterTexture(
 bool FlutterTizenTextureRegistrar::UnregisterTexture(int64_t texture_id) {
   {
     std::lock_guard<std::mutex> lock(map_mutex_);
-    auto it = textures_.find(texture_id);
-    if (it == textures_.end()) {
+    auto iter = textures_.find(texture_id);
+    if (iter == textures_.end()) {
       return false;
     }
-    textures_.erase(it);
+    textures_.erase(iter);
   }
   return engine_->UnregisterExternalTexture(texture_id);
 }
@@ -76,11 +77,11 @@ bool FlutterTizenTextureRegistrar::PopulateTexture(
   ExternalTexture* texture;
   {
     std::lock_guard<std::mutex> lock(map_mutex_);
-    auto it = textures_.find(texture_id);
-    if (it == textures_.end()) {
+    auto iter = textures_.find(texture_id);
+    if (iter == textures_.end()) {
       return false;
     }
-    texture = it->second.get();
+    texture = iter->second.get();
   }
   return texture->PopulateTexture(width, height, opengl_texture);
 }

--- a/shell/platform/tizen/flutter_tizen_texture_registrar_unittests.cc
+++ b/shell/platform/tizen/flutter_tizen_texture_registrar_unittests.cc
@@ -90,7 +90,7 @@ TEST_F(FlutterTizenTextureRegistrarTest, RegisterUnregisterTexture) {
                          return kSuccess;
                        }));
 
-  auto texture_id = registrar.RegisterTexture(&texture_info);
+  int64_t texture_id = registrar.RegisterTexture(&texture_info);
   EXPECT_TRUE(register_called);
   EXPECT_NE(texture_id, -1);
   EXPECT_EQ(texture_id, registered_texture_id);
@@ -110,7 +110,7 @@ TEST_F(FlutterTizenTextureRegistrarTest, RegisterUnknownTextureType) {
   FlutterDesktopTextureInfo texture_info = {};
   texture_info.type = static_cast<FlutterDesktopTextureType>(1234);
 
-  auto texture_id = registrar.RegisterTexture(&texture_info);
+  int64_t texture_id = registrar.RegisterTexture(&texture_info);
 
   EXPECT_EQ(texture_id, -1);
 }
@@ -118,7 +118,7 @@ TEST_F(FlutterTizenTextureRegistrarTest, RegisterUnknownTextureType) {
 TEST_F(FlutterTizenTextureRegistrarTest, PopulateInvalidTexture) {
   FlutterTizenTextureRegistrar registrar(engine_);
 
-  auto result = registrar.PopulateTexture(1, 640, 480, nullptr);
+  bool result = registrar.PopulateTexture(1, 640, 480, nullptr);
   EXPECT_FALSE(result);
 }
 

--- a/shell/platform/tizen/key_event_handler.cc
+++ b/shell/platform/tizen/key_event_handler.cc
@@ -47,7 +47,7 @@ KeyEventHandler::KeyEventHandler(FlutterTizenEngine* engine) : engine_(engine) {
 }
 
 KeyEventHandler::~KeyEventHandler() {
-  for (auto handler : key_event_handlers_) {
+  for (Ecore_Event_Handler* handler : key_event_handlers_) {
     ecore_event_handler_del(handler);
   }
   key_event_handlers_.clear();
@@ -56,7 +56,7 @@ KeyEventHandler::~KeyEventHandler() {
 Eina_Bool KeyEventHandler::OnKey(void* data, int type, void* raw_event) {
   auto* self = reinterpret_cast<KeyEventHandler*>(data);
   auto* event = reinterpret_cast<Ecore_Event_Key*>(raw_event);
-  auto* engine = self->engine_;
+  FlutterTizenEngine* engine = self->engine_;
   bool is_down = type == ECORE_EVENT_KEY_DOWN;
 
   if (engine->renderer()->GetWindowId() != event->window) {

--- a/shell/platform/tizen/tizen_input_method_context.cc
+++ b/shell/platform/tizen/tizen_input_method_context.cc
@@ -150,13 +150,13 @@ bool TizenInputMethodContext::FilterEvent(Ecore_Event_Key* event,
   FT_ASSERT(dev_name);
 
   if (is_down) {
-    auto imf_event =
+    Ecore_IMF_Event_Key_Down imf_event =
         EcoreEventKeyToEcoreImfEvent<Ecore_IMF_Event_Key_Down>(event, dev_name);
     return ecore_imf_context_filter_event(
         imf_context_, ECORE_IMF_EVENT_KEY_DOWN,
         reinterpret_cast<Ecore_IMF_Event*>(&imf_event));
   } else {
-    auto imf_event =
+    Ecore_IMF_Event_Key_Up imf_event =
         EcoreEventKeyToEcoreImfEvent<Ecore_IMF_Event_Key_Up>(event, dev_name);
     return ecore_imf_context_filter_event(
         imf_context_, ECORE_IMF_EVENT_KEY_UP,
@@ -192,7 +192,8 @@ void TizenInputMethodContext::HideInputPanel() {
 void TizenInputMethodContext::SetInputPanelLayout(
     const std::string& input_type) {
   FT_ASSERT(imf_context_);
-  auto panel_layout = TextInputTypeToEcoreImfInputPanelLayout(input_type);
+  Ecore_IMF_Input_Panel_Layout panel_layout =
+      TextInputTypeToEcoreImfInputPanelLayout(input_type);
   ecore_imf_context_input_panel_layout_set(imf_context_, panel_layout);
 }
 

--- a/shell/platform/tizen/tizen_input_method_context.cc
+++ b/shell/platform/tizen/tizen_input_method_context.cc
@@ -218,8 +218,7 @@ void TizenInputMethodContext::RegisterEventCallbacks() {
   // commit callback
   event_callbacks_[ECORE_IMF_CALLBACK_COMMIT] =
       [](void* data, Ecore_IMF_Context* ctx, void* event_info) {
-        flutter::TizenInputMethodContext* self =
-            static_cast<flutter::TizenInputMethodContext*>(data);
+        auto* self = static_cast<TizenInputMethodContext*>(data);
         char* str = static_cast<char*>(event_info);
         if (self->on_commit_) {
           self->on_commit_(str);
@@ -232,8 +231,7 @@ void TizenInputMethodContext::RegisterEventCallbacks() {
   // pre-edit start callback
   event_callbacks_[ECORE_IMF_CALLBACK_PREEDIT_START] =
       [](void* data, Ecore_IMF_Context* ctx, void* event_info) {
-        flutter::TizenInputMethodContext* self =
-            static_cast<flutter::TizenInputMethodContext*>(data);
+        auto* self = static_cast<TizenInputMethodContext*>(data);
         if (self->on_preedit_start_) {
           self->on_preedit_start_();
         }
@@ -245,8 +243,7 @@ void TizenInputMethodContext::RegisterEventCallbacks() {
   // pre-edit end callback
   event_callbacks_[ECORE_IMF_CALLBACK_PREEDIT_END] =
       [](void* data, Ecore_IMF_Context* ctx, void* event_info) {
-        flutter::TizenInputMethodContext* self =
-            static_cast<flutter::TizenInputMethodContext*>(data);
+        auto* self = static_cast<TizenInputMethodContext*>(data);
         if (self->on_preedit_end_) {
           self->on_preedit_end_();
         }
@@ -258,8 +255,7 @@ void TizenInputMethodContext::RegisterEventCallbacks() {
   // pre-edit changed callback
   event_callbacks_[ECORE_IMF_CALLBACK_PREEDIT_CHANGED] =
       [](void* data, Ecore_IMF_Context* ctx, void* event_info) {
-        flutter::TizenInputMethodContext* self =
-            static_cast<flutter::TizenInputMethodContext*>(data);
+        auto* self = static_cast<TizenInputMethodContext*>(data);
         if (self->on_preedit_changed_) {
           char* str = nullptr;
           int cursor_pos = 0;
@@ -278,8 +274,7 @@ void TizenInputMethodContext::RegisterEventCallbacks() {
   ecore_imf_context_input_panel_event_callback_add(
       imf_context_, ECORE_IMF_INPUT_PANEL_STATE_EVENT,
       [](void* data, Ecore_IMF_Context* context, int value) {
-        flutter::TizenInputMethodContext* self =
-            static_cast<flutter::TizenInputMethodContext*>(data);
+        auto* self = static_cast<TizenInputMethodContext*>(data);
         if (self->on_input_panel_state_changed_) {
           self->on_input_panel_state_changed_(value);
         }

--- a/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_renderer_ecore_wl2.cc
@@ -235,7 +235,7 @@ TizenRenderer::Geometry TizenRendererEcoreWl2::GetScreenGeometry() {
 }
 
 int32_t TizenRendererEcoreWl2::GetDpi() {
-  auto* output = ecore_wl2_window_output_find(ecore_wl2_window_);
+  Ecore_Wl2_Output* output = ecore_wl2_window_output_find(ecore_wl2_window_);
   if (!output) {
     FT_LOG(Error) << "Could not find an output associated with the window.";
     return 0;
@@ -612,7 +612,7 @@ void TizenRendererEcoreWl2::SetTizenPolicyNotificationLevel(int level) {
 }
 
 void TizenRendererEcoreWl2::BindKeys(const std::vector<std::string>& keys) {
-  for (const auto& key : keys) {
+  for (const std::string& key : keys) {
     ecore_wl2_window_keygrab_set(ecore_wl2_window_, key.c_str(), 0, 0, 0,
                                  ECORE_WL2_WINDOW_KEYGRAB_TOPMOST);
   }

--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -563,7 +563,7 @@ TizenRenderer::Geometry TizenRendererEvasGL::GetWindowGeometry() {
 
 TizenRenderer::Geometry TizenRendererEvasGL::GetScreenGeometry() {
   Geometry result = {};
-  auto* ecore_evas =
+  Ecore_Evas* ecore_evas =
       ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_));
   ecore_evas_screen_geometry_get(ecore_evas, nullptr, nullptr, &result.w,
                                  &result.h);
@@ -571,7 +571,7 @@ TizenRenderer::Geometry TizenRendererEvasGL::GetScreenGeometry() {
 }
 
 int32_t TizenRendererEvasGL::GetDpi() {
-  auto* ecore_evas =
+  Ecore_Evas* ecore_evas =
       ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_));
   int32_t xdpi, ydpi;
   ecore_evas_screen_dpi_get(ecore_evas, &xdpi, &ydpi);
@@ -649,7 +649,7 @@ bool TizenRendererEvasGL::SetupEvasWindow() {
   // Tizen 5.5 or later was chosen as default.
   // elm_win_aux_hint_add(evas_window_, "wm.policy.win.user.geometry", "1");
 
-  auto* ecore_evas =
+  Ecore_Evas* ecore_evas =
       ecore_evas_ecore_evas_get(evas_object_evas_get(evas_window_));
 
   int32_t width, height;
@@ -781,7 +781,7 @@ bool TizenRendererEvasGL::IsSupportedExtension(const char* name) {
 }
 
 void TizenRendererEvasGL::BindKeys(const std::vector<std::string>& keys) {
-  for (const auto& key : keys) {
+  for (const std::string& key : keys) {
     eext_win_keygrab_set(evas_window_, key.c_str());
   }
 }

--- a/shell/platform/tizen/touch_event_handler.cc
+++ b/shell/platform/tizen/touch_event_handler.cc
@@ -27,7 +27,7 @@ TouchEventHandler::TouchEventHandler(FlutterTizenEngine* engine)
 }
 
 TouchEventHandler::~TouchEventHandler() {
-  for (auto handler : touch_event_handlers_) {
+  for (Ecore_Event_Handler* handler : touch_event_handlers_) {
     ecore_event_handler_del(handler);
   }
   touch_event_handlers_.clear();
@@ -41,7 +41,7 @@ void TouchEventHandler::SendFlutterPointerEvent(FlutterPointerPhase phase,
                                                 size_t timestamp,
                                                 int device_id = 0) {
   // Correct errors caused by window rotation.
-  auto geometry = engine_->renderer()->GetWindowGeometry();
+  TizenRenderer::Geometry geometry = engine_->renderer()->GetWindowGeometry();
   double new_x = x, new_y = y;
 
   if (rotation == 90) {
@@ -74,7 +74,7 @@ void TouchEventHandler::SendFlutterPointerEvent(FlutterPointerPhase phase,
 
 Eina_Bool TouchEventHandler::OnTouch(void* data, int type, void* event) {
   auto* self = reinterpret_cast<TouchEventHandler*>(data);
-  auto window_id = self->engine_->renderer()->GetWindowId();
+  uintptr_t window_id = self->engine_->renderer()->GetWindowId();
 
   if (type == ECORE_EVENT_MOUSE_BUTTON_DOWN) {
     auto* button_event = reinterpret_cast<Ecore_Event_Mouse_Button*>(event);


### PR DESCRIPTION
- Use type deduction in a consistent manner.
  - Based on https://google.github.io/styleguide/cppguide.html#Type_deduction.
  - Avoid use of `auto` whenever possible.
  - Some exceptions:
    - The type can clearly be inferred from r-value (e.g. used with `make_unique<>`, `get_if<>`, `reinterpret_cast<>`, `static_pointer_cast<>`).
    - Arguments in a lambda expression.
    - Lambda expression assigned to a local variable.
    - Simple iterator.
    - `std::pair<>` in foreach loop.
- Consistent variable naming.
  - `v` → `element` (in foreach loop)
  - `it` → `iter` (iterators)
- Remove unnecessary `flutter::`.