### PR TITLE
[ci] Do not disable compile options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,11 @@ jobs:
         mode: [debug, release, profile]
         include:
           - arch: arm
-            triple: armv7l-tizen-linux-gnueabi
+            triple: arm-linux-gnueabi
           - arch: arm64
-            triple: aarch64-tizen-linux-gnu
+            triple: aarch64-linux-gnu
           - arch: x86
-            triple: i586-tizen-linux-gnueabi
+            triple: i686-linux-gnu
         exclude:
           - arch: x86
             mode: release
@@ -63,12 +63,6 @@ jobs:
       - name: build
         run: |
           src/flutter/ci/tizen/cache-checksum.sh restore src/out/$OUTPUT_NAME
-
-          # FIXME: Disable compile options unsupported by the Tizen toolchain.
-          sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' src/build/config/compiler/BUILD.gn
-          sed -i 's/"-Wno-psabi",//g' src/build/config/compiler/BUILD.gn
-          sed -i 's/"-Wno-unused-but-set-parameter",//g' src/build/config/compiler/BUILD.gn
-          sed -i 's/"-Wno-unused-but-set-variable",//g' src/build/config/compiler/BUILD.gn
 
           src/flutter/tools/gn \
             --target-os linux --linux-cpu ${{ matrix.arch }} \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,9 @@ jobs:
     path: src/flutter
   - bash: |
       gclient sync -f -D
+    displayName: Run gclient sync
+    workingDirectory: $(Pipeline.Workspace)/src
+  - bash: |
       flutter/tools/gn \
         --target-os linux \
         --linux-cpu $(arch) \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,31 +14,31 @@ jobs:
       tizen-arm-release:
         arch: arm
         mode: release
-        targetTriple: armv7l-tizen-linux-gnueabi
+        targetTriple: arm-linux-gnueabi
       tizen-arm-profile:
         arch: arm
         mode: profile
-        targetTriple: armv7l-tizen-linux-gnueabi
+        targetTriple: arm-linux-gnueabi
       tizen-arm-debug:
         arch: arm
         mode: debug
-        targetTriple: armv7l-tizen-linux-gnueabi
+        targetTriple: arm-linux-gnueabi
       tizen-arm64-release:
         arch: arm64
         mode: release
-        targetTriple: aarch64-tizen-linux-gnu
+        targetTriple: aarch64-linux-gnu
       tizen-arm64-profile:
         arch: arm64
         mode: profile
-        targetTriple: aarch64-tizen-linux-gnu
+        targetTriple: aarch64-linux-gnu
       tizen-arm64-debug:
         arch: arm64
         mode: debug
-        targetTriple: aarch64-tizen-linux-gnu
+        targetTriple: aarch64-linux-gnu
       tizen-x86-debug:
         arch: x86
         mode: debug
-        targetTriple: i586-tizen-linux-gnueabi
+        targetTriple: i686-linux-gnu
   pool:
     name: Default
     demands: agent.os -equals Linux
@@ -49,13 +49,6 @@ jobs:
     path: src/flutter
   - bash: |
       gclient sync -f -D
-      sed -i 's/"-Wno-non-c-typedef-for-linkage",//g' build/config/compiler/BUILD.gn
-      sed -i 's/"-Wno-psabi",//g' build/config/compiler/BUILD.gn
-      sed -i 's/"-Wno-unused-but-set-parameter",//g' build/config/compiler/BUILD.gn
-      sed -i 's/"-Wno-unused-but-set-variable",//g' build/config/compiler/BUILD.gn
-    displayName: Disable build flags
-    workingDirectory: $(Pipeline.Workspace)/src
-  - bash: |
       flutter/tools/gn \
         --target-os linux \
         --linux-cpu $(arch) \


### PR DESCRIPTION
Part of https://github.com/flutter-tizen/engine/issues/271.

- Re-enable disabled compile options.
- Do not use Tizen-specific target triples.

These changes should be applied to your local builds as well. I already updated [our wiki](https://github.com/flutter-tizen/flutter-tizen/wiki/Building-the-engine-from-source).

This change depends on https://github.com/flutter-tizen/tizen_tools/pull/25.