### PR TITLE
Fix an invalid engine handle error

### DIFF
--- a/shell/platform/tizen/flutter_tizen_view.cc
+++ b/shell/platform/tizen/flutter_tizen_view.cc
@@ -63,8 +63,6 @@ void FlutterTizenView::SetEngine(std::unique_ptr<FlutterTizenEngine> engine) {
   text_input_channel_ = std::make_unique<TextInputChannel>(
       internal_plugin_registrar_->messenger(),
       std::make_unique<TizenInputMethodContext>(window_.get()));
-
-  OnRotate(window_->GetRotation());
 }
 
 void FlutterTizenView::CreateRenderSurface() {


### PR DESCRIPTION
* To send something to the engine, the engine must be running.
* FlutterTizenView::SendInitialGeometry is used to send the geometry
  after running the engine

Signed-off-by: Boram Bae <boram21.bae@samsung.com>

Fixes https://github.com/flutter-tizen/flutter-tizen/issues/361.