### PR TITLE
[ci] Inject host_os value when parsing DEPS file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,8 @@ jobs:
             --target-toolchain _ \
             --target-sysroot _ \
             --target-triple _ \
-            --runtime-mode=${{ matrix.mode }}
+            --runtime-mode=${{ matrix.mode }} \
+            --disable-desktop-embeddings
           ninja -C src/out/$OUTPUT_NAME clang_x64/gen_snapshot
 
           src/flutter/ci/tizen/cache-checksum.sh save src/out/$OUTPUT_NAME

--- a/ci/tizen/gclient-shallow-sync.py
+++ b/ci/tizen/gclient-shallow-sync.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import platform
 import sys
 import subprocess
 import concurrent.futures
@@ -10,7 +11,7 @@ import gclient_utils
 
 def run_git(args, cwd):
     if not args:
-        raise Exception('Please provide a git command to run')
+        raise Exception('Please provide a git command to run.')
     return subprocess.call(['git'] + args, cwd=cwd) == 0
 
 
@@ -42,12 +43,21 @@ def checkout_deps(deps):
 
 def main(argv):
     if (len(argv) < 1):
-        raise Exception('Please provide a DEPS file to update')
+        raise Exception('Please provide a DEPS file to update.')
     deps_file = argv[0]
     if not os.path.exists(deps_file):
-        raise Exception('DEPS file does not exist')
+        raise Exception('The DEPS file does not exist.')
+
+    host_os = 'linux'
+    if platform.system() == 'Windows':
+        host_os = 'win'
+    if platform.system() == 'Darwin':
+        host_os = 'mac'
+
     deps_contents = gclient_utils.FileRead(deps_file)
-    local_scope = gclient_eval.Parse(deps_contents, deps_file)
+    local_scope = gclient_eval.Parse(
+        deps_contents, deps_file, builtin_vars={'host_os': host_os})
+
     checkout_deps(local_scope['deps'])
 
 


### PR DESCRIPTION
`gclient-shallow-sync.py` fails if `host_os` is not specified during `gclient_eval.Parse()`.

```python
Traceback (most recent call last):
  File "src/flutter/ci/tizen/gclient-shallow-sync.py", line 55, in <module>
    sys.exit(main(sys.argv[1:]))
  File "src/flutter/ci/tizen/gclient-shallow-sync.py", line 50, in main
    local_scope = gclient_eval.Parse(deps_contents, deps_file)
  File "/usr/share/depot_tools/gclient_eval.py", line 50[9](https://github.com/flutter-tizen/engine/runs/6434530758?check_suite_focus=true#step:5:9), in Parse
    result = Exec(content, filename, vars_override, builtin_vars)
  File "/usr/share/depot_tools/gclient_eval.py", line 4[15](https://github.com/flutter-tizen/engine/runs/6434530758?check_suite_focus=true#step:5:15), in Exec
    value = _gclient_eval(node, filename, vars_dict)
  File "/usr/share/depot_tools/gclient_eval.py", line 339, in _gclient_eval
    return _convert(node_or_string)
  File "/usr/share/depot_tools/gclient_eval.py", line 276, in _convert
    return list(map(_convert, node.elts))
  File "/usr/share/depot_tools/gclient_eval.py", line 285, in _convert
    node_dict.SetNode(key, _convert(value_node), value_node)
  File "/usr/share/depot_tools/gclient_eval.py", line 276, in _convert
    return list(map(_convert, node.elts))
  File "/usr/share/depot_tools/gclient_eval.py", line 3[22](https://github.com/flutter-tizen/engine/runs/6434530758?check_suite_focus=true#step:5:22), in _convert
    raise KeyError(
KeyError: "host_os was used as a variable, but was not declared in the vars dict (file 'src/flutter/DEPS', line 739)"
Error: Process completed with exit code 1.
```

Also the `--disable-desktop-embeddings` option must be passed to `gn` to explicitly skip embedder build on macOS. Otherwise, the following error is generated.

```
The file:
  //out/linux_release_arm64/libflutter_mac_gtk.so
is listed as an input or source for the target:
  //flutter/shell/platform/linux:flutter_gtk
but no targets in the build generate that file.
```

Contributes to https://github.com/flutter-tizen/flutter-tizen/issues/365.