### PR TITLE
[ci] Change the release tag format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,13 +300,13 @@ jobs:
 
       - name: set variables
         run: |
-          echo "TAG_NAME=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+          echo "SHORT_SHA=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
           echo "VERSION=$(echo "${{ github.ref_name }}" | cut -d'-' -f2)" >> $GITHUB_ENV
 
       - uses: softprops/action-gh-release@v1
         with:
-          name: ${{ env.VERSION }} (${{ env.TAG_NAME }})
-          tag_name: ${{ env.TAG_NAME }}
+          name: ${{ env.VERSION }} (${{ env.SHORT_SHA }})
+          tag_name: ${{ env.VERSION }}-${{ env.SHORT_SHA }}
           target_commitish: ${{ github.sha }}
           files: tizen-*.zip
           body: |


### PR DESCRIPTION
As GitHub doesn't any more support a release tag name identical to the target commit hash ([404 Not Found error](https://github.com/flutter-tizen/plugins/pull/387#issuecomment-1128314187)), we need to use a different format for the tag name.

Old: Short commit hash (e.g. `abcdefg`)
New: Engine version + short commit hash (e.g. `3.0.0-abcdefg`)

Any suggestion? @flutter-tizen/maintainers