### PR TITLE
[ci] Upgrade actions/cache to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,13 @@ jobs:
           path: src/flutter
           fetch-depth: 0
 
+      - uses: actions/cache@v3
+        with:
+          path: src/out/${{ env.OUTPUT_NAME }}
+          key: out-build-${{ env.OUTPUT_NAME }}-${{ github.sha }}
+          restore-keys: |
+            out-build-${{ env.OUTPUT_NAME }}-
+
       - name: gclient sync
         run: |
           src/flutter/ci/tizen/gclient-prepare-sync.sh --reduce-deps --shallow-sync
@@ -194,6 +201,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: src/flutter
+
+      - uses: actions/cache@v3
+        with:
+          path: src/out/${{ env.OUTPUT_NAME }}
+          key: out-macos-build-${{ env.OUTPUT_NAME }}-${{ github.sha }}
+          restore-keys: |
+            out-macos-build-${{ env.OUTPUT_NAME }}-
 
       - name: install depot_tools
         run: |


### PR DESCRIPTION
Upgrade `actions/cache` to v3. 

Related Issue: https://github.com/actions/cache/issues/811