### PR TITLE
Add glGetFloatv to TizenRendererEgl

### DIFF
--- a/shell/platform/tizen/tizen_renderer_egl.cc
+++ b/shell/platform/tizen/tizen_renderer_egl.cc
@@ -331,6 +331,7 @@ void* TizenRendererEgl::OnProcResolver(const char* name) {
   GL_FUNC(glGenTextures)
   GL_FUNC(glGetBufferParameteriv)
   GL_FUNC(glGetError)
+  GL_FUNC(glGetFloatv)
   GL_FUNC(glGetFramebufferAttachmentParameteriv)
   GL_FUNC(glGetIntegerv)
   GL_FUNC(glGetProgramInfoLog)


### PR DESCRIPTION
* Fixes a bug that fails to set up Skia Gr context on TM1.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>
