### PR TITLE
Fix key events propagation

### DIFF
--- a/shell/platform/tizen/channels/platform_view_channel.cc
+++ b/shell/platform/tizen/channels/platform_view_channel.cc
@@ -79,7 +79,7 @@ void PlatformViewChannel::ClearViewFactories() {
   view_factories_.clear();
 }
 
-void PlatformViewChannel::SendKey(const char* key,
+bool PlatformViewChannel::SendKey(const char* key,
                                   const char* string,
                                   const char* compose,
                                   uint32_t modifiers,
@@ -87,8 +87,9 @@ void PlatformViewChannel::SendKey(const char* key,
                                   bool is_down) {
   PlatformView* view = FindFocusedView();
   if (view) {
-    view->SendKey(key, string, compose, modifiers, scan_code, is_down);
+    return view->SendKey(key, string, compose, modifiers, scan_code, is_down);
   }
+  return false;
 }
 
 void PlatformViewChannel::HandleMethodCall(

--- a/shell/platform/tizen/channels/platform_view_channel.h
+++ b/shell/platform/tizen/channels/platform_view_channel.h
@@ -28,7 +28,7 @@ class PlatformViewChannel {
     return view_factories_;
   }
 
-  void SendKey(const char* key,
+  bool SendKey(const char* key,
                const char* string,
                const char* compose,
                uint32_t modifiers,

--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -119,10 +119,10 @@ bool TextInputChannel::SendKey(const char* key,
   }
 
   if (is_down) {
-    HandleKey(key, string, modifiers);
+    return HandleKey(key, string, modifiers);
   }
 
-  return true;
+  return false;
 }
 
 void TextInputChannel::HandleMethodCall(
@@ -300,7 +300,7 @@ void TextInputChannel::SendStateUpdate() {
   channel_->InvokeMethod(kUpdateEditingStateMethod, std::move(args));
 }
 
-void TextInputChannel::HandleKey(const char* key,
+bool TextInputChannel::HandleKey(const char* key,
                                  const char* string,
                                  uint32_t modifires) {
   bool shift = modifires & ECORE_SHIFT;
@@ -344,19 +344,21 @@ void TextInputChannel::HandleKey(const char* key,
     needs_update = true;
   } else if (key_str == "Return") {
     EnterPressed();
-    return;
+    return true;
 #ifdef TV_PROFILE
   } else if (key_str == "Select") {
     SelectPressed();
-    return;
-  } else {
+    return true;
 #endif
-    FT_LOG(Warn) << "Key[" << key << "] is unhandled.";
+  } else {
+    FT_LOG(Info) << "Key[" << key << "] is unhandled.";
+    return false;
   }
 
   if (needs_update) {
     SendStateUpdate();
   }
+  return true;
 }
 
 void TextInputChannel::EnterPressed() {

--- a/shell/platform/tizen/channels/text_input_channel.h
+++ b/shell/platform/tizen/channels/text_input_channel.h
@@ -46,7 +46,7 @@ class TextInputChannel {
   // Sends the current state of |active_model_| to the Flutter engine.
   void SendStateUpdate();
 
-  void HandleKey(const char* key, const char* string, uint32_t modifiers);
+  bool HandleKey(const char* key, const char* string, uint32_t modifiers);
 
   // Sends an action triggered by the Enter key to the Flutter engine.
   void EnterPressed();

--- a/shell/platform/tizen/flutter_tizen_view.cc
+++ b/shell/platform/tizen/flutter_tizen_view.cc
@@ -212,8 +212,10 @@ void FlutterTizenView::OnKey(const char* key,
   }
 
   if (engine_->platform_view_channel()) {
-    engine_->platform_view_channel()->SendKey(key, string, compose, modifiers,
-                                              scan_code, is_down);
+    if (engine_->platform_view_channel()->SendKey(
+            key, string, compose, modifiers, scan_code, is_down)) {
+      return;
+    }
   }
 
   if (engine_->key_event_channel()) {

--- a/shell/platform/tizen/public/flutter_platform_view.h
+++ b/shell/platform/tizen/public/flutter_platform_view.h
@@ -45,7 +45,7 @@ class PlatformView {
 
   bool IsFocused() { return is_focused_; }
 
-  virtual void SendKey(const char* key,
+  virtual bool SendKey(const char* key,
                        const char* string,
                        const char* compose,
                        uint32_t modifiers,


### PR DESCRIPTION
This PR contains the following various fixes.

- Fix a typo at line 353 of `text_input_channel.cc` (the `else` statement should come after `#endif`).
- Let `TextInputChannel::SendKey` return `false` by default and check if the given key is actually handled by `HandleKey`. This fixes a problem of back button not responding when a TextField has a focus and a software keyboard is closed.
- Change the return type of `PlatformViewChannel::SendKey` to `bool` to allow platform views to intercept key events without propagating to other handlers.

Note: `TextInputChannel::HandleKey` handles only key down events and thus some key up events (`Left`, `Home`, and etc.) are still redundantly propagated to `PlatformViewChannel` and `KeyEventChannel`.