### PR TITLE
Move BindKeys to TizenWindow

### DIFF
--- a/shell/platform/tizen/flutter_tizen_view.cc
+++ b/shell/platform/tizen/flutter_tizen_view.cc
@@ -45,7 +45,11 @@ namespace flutter {
 FlutterTizenView::FlutterTizenView(std::unique_ptr<TizenViewBase> tizen_view)
     : tizen_view_(std::move(tizen_view)) {
   tizen_view_->SetView(this);
-  tizen_view_->BindKeys(kBindableSystemKeys);
+
+  if (tizen_view_->GetType() == TizenViewType::kWindow) {
+    auto* window = reinterpret_cast<TizenWindow*>(tizen_view_.get());
+    window->BindKeys(kBindableSystemKeys);
+  }
 }
 
 FlutterTizenView::~FlutterTizenView() {}

--- a/shell/platform/tizen/tizen_view_base.h
+++ b/shell/platform/tizen/tizen_view_base.h
@@ -46,8 +46,6 @@ class TizenViewBase {
   // view such as key presses, mouse position updates etc.
   void SetView(FlutterTizenView* view) { view_ = view; }
 
-  virtual void BindKeys(const std::vector<std::string>& keys) = 0;
-
   virtual void ResizeWithRotation(TizenGeometry geometry, int32_t degree) = 0;
 
   // FIXME

--- a/shell/platform/tizen/tizen_view_elementary.cc
+++ b/shell/platform/tizen/tizen_view_elementary.cc
@@ -314,16 +314,6 @@ void TizenViewElementary::ResizeWithRotation(TizenGeometry geometry,
   renderer_evas_gl->ResizeSurface(geometry.width, geometry.height);
 }
 
-void TizenViewElementary::BindKeys(const std::vector<std::string>& keys) {
-  Evas_Object* elm_win = static_cast<Evas_Object*>(ecore_evas_data_get(
-      ecore_evas_ecore_evas_get(evas_object_evas_get(parent_)), "elm_win"));
-  if (elm_win) {
-    for (const std::string& key : keys) {
-      eext_win_keygrab_set(elm_win, key.c_str());
-    }
-  }
-}
-
 void TizenViewElementary::Show() {
   evas_object_show(container_);
   evas_object_show(image_);

--- a/shell/platform/tizen/tizen_view_elementary.h
+++ b/shell/platform/tizen/tizen_view_elementary.h
@@ -38,8 +38,6 @@ class TizenViewElementary : public TizenView {
 
   void ResizeWithRotation(TizenGeometry geometry, int32_t angle) override;
 
-  void BindKeys(const std::vector<std::string>& keys) override;
-
   void Show() override;
 
   void OnGeometryChanged(TizenGeometry geometry) override;

--- a/shell/platform/tizen/tizen_window.h
+++ b/shell/platform/tizen/tizen_window.h
@@ -30,6 +30,8 @@ class TizenWindow : public TizenViewBase {
   // Returns the geometry of the display screen.
   virtual TizenGeometry GetScreenGeometry() = 0;
 
+  virtual void BindKeys(const std::vector<std::string>& keys) = 0;
+
   TizenViewType GetType() override { return TizenViewType::kWindow; };
 
  protected:


### PR DESCRIPTION
* Calls BindKeys only when the View type is window.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>
