### PR TITLE
Remove navigation key handling

### DIFF
--- a/shell/platform/tizen/channels/key_event_channel.cc
+++ b/shell/platform/tizen/channels/key_event_channel.cc
@@ -62,11 +62,10 @@ uint64_t GetLogicalKey(const char* key) {
   return ApplyPlaneToId(0, kTizenPlane);
 }
 
-uint32_t GetFallbackScanCodeFromKey(std::string key) {
-  // Some of the scan codes are 0 when keys event occur from the software
-  // keyboard. then the key_event_channel cannot handle the key event.
-  // to avoid this, use a valid scan codes.
-  int scan_code = 0;
+uint32_t GetFallbackScanCodeFromKey(const std::string& key) {
+  // Some of scan codes are 0 when key events occur from the software
+  // keyboard, and key_event_channel cannot handle the key events.
+  // To avoid this, use a valid scan code.
 
   // The following keys can be emitted from the software keyboard and have a
   // scan code with 0 value.
@@ -75,12 +74,11 @@ uint32_t GetFallbackScanCodeFromKey(std::string key) {
       {"Right", 0x00000072},     {"Down", 0x00000074},
   };
 
-  auto iter1 = kKeyToScanCode.find(key);
-  if (iter1 != kKeyToScanCode.end()) {
-    scan_code = iter1->second;
+  auto iter = kKeyToScanCode.find(key);
+  if (iter != kKeyToScanCode.end()) {
+    return iter->second;
   }
-
-  return scan_code;
+  return 0;
 }
 
 }  // namespace

--- a/shell/platform/tizen/channels/key_event_channel.cc
+++ b/shell/platform/tizen/channels/key_event_channel.cc
@@ -62,6 +62,27 @@ uint64_t GetLogicalKey(const char* key) {
   return ApplyPlaneToId(0, kTizenPlane);
 }
 
+uint32_t GetFallbackScanCodeFromKey(std::string key) {
+  // Some of the scan codes are 0 when keys event occur from the software
+  // keyboard. then the key_event_channel cannot handle the key event.
+  // to avoid this, use a valid scan codes.
+  int scan_code = 0;
+
+  // The following keys can be emitted from the software keyboard and have a
+  // scan code with 0 value.
+  const std::map<std::string, uint32_t> kKeyToScanCode = {
+      {"BackSpace", 0x00000016}, {"Up", 0x0000006f},   {"Left", 0x00000071},
+      {"Right", 0x00000072},     {"Down", 0x00000074},
+  };
+
+  auto iter1 = kKeyToScanCode.find(key);
+  if (iter1 != kKeyToScanCode.end()) {
+    scan_code = iter1->second;
+  }
+
+  return scan_code;
+}
+
 }  // namespace
 
 KeyEventChannel::KeyEventChannel(BinaryMessenger* messenger,
@@ -98,6 +119,10 @@ void KeyEventChannel::SendKey(const char* key,
         << "framework. Are responses being sent?";
   }
   pending_events_[sequence_id] = std::make_unique<PendingEvent>(pending);
+
+  if (scan_code == 0) {
+    scan_code = GetFallbackScanCodeFromKey(key);
+  }
 
   SendEmbedderEvent(key, string, compose, modifiers, scan_code, is_down,
                     sequence_id);

--- a/shell/platform/tizen/channels/text_input_channel.cc
+++ b/shell/platform/tizen/channels/text_input_channel.cc
@@ -303,43 +303,11 @@ void TextInputChannel::SendStateUpdate() {
 bool TextInputChannel::HandleKey(const char* key,
                                  const char* string,
                                  uint32_t modifires) {
-  bool shift = modifires & ECORE_SHIFT;
   bool needs_update = false;
   std::string key_str = key;
 
-  if (key_str == "Left") {
-    if (shift) {
-      TextRange selection = active_model_->selection();
-      needs_update = active_model_->SetSelection(
-          TextRange(selection.base(), selection.extent() - 1));
-    } else {
-      needs_update = active_model_->MoveCursorBack();
-    }
-  } else if (key_str == "Right") {
-    if (shift) {
-      TextRange selection = active_model_->selection();
-      needs_update = active_model_->SetSelection(
-          TextRange(selection.base(), selection.extent() + 1));
-    } else {
-      needs_update = active_model_->MoveCursorForward();
-    }
-  } else if (key_str == "End") {
-    if (shift) {
-      needs_update = active_model_->SelectToEnd();
-    } else {
-      needs_update = active_model_->MoveCursorToEnd();
-    }
-  } else if (key_str == "Home") {
-    if (shift) {
-      needs_update = active_model_->SelectToBeginning();
-    } else {
-      needs_update = active_model_->MoveCursorToBeginning();
-    }
-  } else if (key_str == "BackSpace") {
-    needs_update = active_model_->Backspace();
-  } else if (key_str == "Delete") {
-    needs_update = active_model_->Delete();
-  } else if (string && strlen(string) == 1 && IsAsciiPrintableKey(string[0])) {
+  if (string && strlen(string) == 1 && IsAsciiPrintableKey(string[0])) {
+    // This is a fallback for printable keys not handled by IMF.
     active_model_->AddCodePoint(string[0]);
     needs_update = true;
   } else if (key_str == "Return") {

--- a/shell/platform/tizen/tizen_input_method_context.cc
+++ b/shell/platform/tizen/tizen_input_method_context.cc
@@ -347,13 +347,14 @@ void TizenInputMethodContext::SetInputPanelOptions() {
 }
 
 bool TizenInputMethodContext::ShouldIgnoreKey(std::string key, bool is_ime) {
-  // The keys below should be handled in the text_input_channel.
+  // The below keys should be handled by the flutter framework.
   if (is_ime && (key == "Left" || key == "Right" || key == "Up" ||
                  key == "Down" || key == "End" || key == "Home" ||
                  key == "BackSpace" || key == "Delete")) {
     return true;
   }
 #ifdef TV_PROFILE
+  // The Select key should be handled in the TextInputChannel.
   if (is_ime && key == "Select") {
     return true;
   }

--- a/shell/platform/tizen/tizen_view_elementary.cc
+++ b/shell/platform/tizen/tizen_view_elementary.cc
@@ -215,7 +215,7 @@ void TizenViewElementary::RegisterEventHandlers() {
     if (self->view_) {
       if (self->event_layer_ == object) {
         auto* key_event = reinterpret_cast<Evas_Event_Key_Down*>(event_info);
-        int handled = false;
+        bool handled = false;
         key_event->event_flags =
             Evas_Event_Flags(key_event->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
         if (self->input_method_context_->IsInputPanelShown()) {
@@ -241,7 +241,7 @@ void TizenViewElementary::RegisterEventHandlers() {
         if (self->view_) {
           if (self->event_layer_ == object) {
             auto* key_event = reinterpret_cast<Evas_Event_Key_Up*>(event_info);
-            int handled = false;
+            bool handled = false;
             key_event->event_flags = Evas_Event_Flags(key_event->event_flags |
                                                       EVAS_EVENT_FLAG_ON_HOLD);
             if (self->input_method_context_->IsInputPanelShown()) {

--- a/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -313,7 +313,7 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
         if (self->view_) {
           auto* key_event = reinterpret_cast<Ecore_Event_Key*>(event);
           if (key_event->window == self->GetWindowId()) {
-            int handled = false;
+            bool handled = false;
             if (self->input_method_context_->IsInputPanelShown()) {
               handled = self->input_method_context_->HandleEcoreEventKey(
                   key_event, true);
@@ -337,7 +337,7 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
         if (self->view_) {
           auto* key_event = reinterpret_cast<Ecore_Event_Key*>(event);
           if (key_event->window == self->GetWindowId()) {
-            int handled = false;
+            bool handled = false;
             if (self->input_method_context_->IsInputPanelShown()) {
               handled = self->input_method_context_->HandleEcoreEventKey(
                   key_event, false);

--- a/shell/platform/tizen/tizen_window_elementary.cc
+++ b/shell/platform/tizen/tizen_window_elementary.cc
@@ -238,7 +238,7 @@ void TizenWindowElementary::RegisterEventHandlers() {
     if (self->view_) {
       if (self->elm_win_ == object) {
         auto* key_event = reinterpret_cast<Evas_Event_Key_Down*>(event_info);
-        int handled = false;
+        bool handled = false;
         if (self->input_method_context_->IsInputPanelShown()) {
           handled =
               self->input_method_context_->HandleEvasEventKeyDown(key_event);
@@ -262,7 +262,7 @@ void TizenWindowElementary::RegisterEventHandlers() {
         if (self->view_) {
           if (self->elm_win_ == object) {
             auto* key_event = reinterpret_cast<Evas_Event_Key_Up*>(event_info);
-            int handled = false;
+            bool handled = false;
             if (self->input_method_context_->IsInputPanelShown()) {
               handled =
                   self->input_method_context_->HandleEvasEventKeyUp(key_event);


### PR DESCRIPTION
* Navigation key event should be handled by the flutter framework.
* Update related comments.
* Fix incorrect type usage.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>