### PR TITLE
Add the view's GetWidth/Height APIs

### DIFF
--- a/shell/platform/tizen/flutter_tizen_ecore.cc
+++ b/shell/platform/tizen/flutter_tizen_ecore.cc
@@ -69,3 +69,13 @@ void FlutterDesktopViewResize(FlutterDesktopViewRef view_ref,
                               int32_t height) {
   FT_LOG(Warn) << "Not applicable!";
 }
+
+int32_t FlutterDesktopViewGetWidth(FlutterDesktopViewRef view_ref) {
+  FT_LOG(Warn) << "Not applicable!";
+  return 0;
+}
+
+int32_t FlutterDesktopViewGetHeight(FlutterDesktopViewRef view_ref) {
+  FT_LOG(Warn) << "Not applicable!";
+  return 0;
+}

--- a/shell/platform/tizen/flutter_tizen_elementary.cc
+++ b/shell/platform/tizen/flutter_tizen_elementary.cc
@@ -95,3 +95,21 @@ void FlutterDesktopViewResize(FlutterDesktopViewRef view_ref,
   flutter::TizenGeometry view_geometry = {0, 0, width, height};
   view->tizen_view()->OnGeometryChanged(view_geometry);
 }
+
+int32_t FlutterDesktopViewGetWidth(FlutterDesktopViewRef view_ref) {
+  auto* view = reinterpret_cast<flutter::FlutterTizenView*>(view_ref);
+  if (view->tizen_view()->GetType() == flutter::TizenViewType::kView) {
+    flutter::TizenGeometry geometry = view->tizen_view()->GetGeometry();
+    return geometry.width;
+  }
+  return 0;
+}
+
+int32_t FlutterDesktopViewGetHeight(FlutterDesktopViewRef view_ref) {
+  auto* view = reinterpret_cast<flutter::FlutterTizenView*>(view_ref);
+  if (view->tizen_view()->GetType() == flutter::TizenViewType::kView) {
+    flutter::TizenGeometry geometry = view->tizen_view()->GetGeometry();
+    return geometry.height;
+  }
+  return 0;
+}

--- a/shell/platform/tizen/public/flutter_tizen.h
+++ b/shell/platform/tizen/public/flutter_tizen.h
@@ -165,6 +165,14 @@ FLUTTER_EXPORT void FlutterDesktopViewResize(FlutterDesktopViewRef view,
                                              int32_t width,
                                              int32_t height);
 
+// Returns the width of the view.
+// @warning This API is a work-in-progress and may change.
+FLUTTER_EXPORT int32_t FlutterDesktopViewGetWidth(FlutterDesktopViewRef view);
+
+// Returns the height of the view.
+// @warning This API is a work-in-progress and may change.
+FLUTTER_EXPORT int32_t FlutterDesktopViewGetHeight(FlutterDesktopViewRef view);
+
 // ========== Plugin Registrar (extensions) ==========
 
 // Returns the window associated with this registrar's engine instance.


### PR DESCRIPTION
Add an API that returns the width and height of
the evas image the view is drawn on.

related PR : https://github.com/flutter-tizen/flutter-tizen/pull/379