### PR TITLE
TizenViewElementary: Change the size of view when the size of container changes

### DIFF
--- a/shell/platform/tizen/flutter_tizen_elementary.cc
+++ b/shell/platform/tizen/flutter_tizen_elementary.cc
@@ -92,6 +92,5 @@ void FlutterDesktopViewResize(FlutterDesktopViewRef view_ref,
                               int32_t width,
                               int32_t height) {
   auto* view = reinterpret_cast<flutter::FlutterTizenView*>(view_ref);
-  flutter::TizenGeometry view_geometry = {0, 0, width, height};
-  view->tizen_view()->OnGeometryChanged(view_geometry);
+  view->OnResize(0, 0, width, height);
 }

--- a/shell/platform/tizen/tizen_view_base.h
+++ b/shell/platform/tizen/tizen_view_base.h
@@ -48,10 +48,6 @@ class TizenViewBase {
 
   virtual void ResizeWithRotation(TizenGeometry geometry, int32_t degree) = 0;
 
-  // FIXME
-  // This is a temporary implementation that is only used by the window channel.
-  virtual void OnGeometryChanged(TizenGeometry geometry) = 0;
-
   virtual void Show() = 0;
 
   virtual TizenViewType GetType() = 0;

--- a/shell/platform/tizen/tizen_view_elementary.cc
+++ b/shell/platform/tizen/tizen_view_elementary.cc
@@ -125,7 +125,8 @@ void TizenViewElementary::RegisterEventHandlers() {
           if (self->container_ == object) {
             int32_t width = 0, height = 0;
             evas_object_geometry_get(object, nullptr, nullptr, &width, &height);
-            self->OnGeometryChanged(TizenGeometry{0, 0, width, height});
+
+            self->view_->OnResize(0, 0, width, height);
           }
         }
       };
@@ -331,6 +332,8 @@ uintptr_t TizenViewElementary::GetWindowId() {
 
 void TizenViewElementary::ResizeWithRotation(TizenGeometry geometry,
                                              int32_t angle) {
+  SetGeometry(geometry);
+
   TizenRendererEvasGL* renderer_evas_gl =
       reinterpret_cast<TizenRendererEvasGL*>(view_->engine()->renderer());
   renderer_evas_gl->ResizeSurface(geometry.width, geometry.height);
@@ -340,11 +343,6 @@ void TizenViewElementary::Show() {
   evas_object_show(container_);
   evas_object_show(image_);
   evas_object_show(event_layer_);
-}
-
-void TizenViewElementary::OnGeometryChanged(TizenGeometry geometry) {
-  SetGeometry(geometry);
-  view_->OnResize(geometry.left, geometry.top, geometry.width, geometry.height);
 }
 
 void TizenViewElementary::PrepareInputMethod() {

--- a/shell/platform/tizen/tizen_view_elementary.h
+++ b/shell/platform/tizen/tizen_view_elementary.h
@@ -40,8 +40,6 @@ class TizenViewElementary : public TizenView {
 
   void Show() override;
 
-  void OnGeometryChanged(TizenGeometry geometry) override;
-
  private:
   bool CreateView();
 

--- a/shell/platform/tizen/tizen_window.h
+++ b/shell/platform/tizen/tizen_window.h
@@ -30,6 +30,8 @@ class TizenWindow : public TizenViewBase {
   // Returns the geometry of the display screen.
   virtual TizenGeometry GetScreenGeometry() = 0;
 
+  virtual void OnGeometryChanged(TizenGeometry geometry) = 0;
+
   virtual void BindKeys(const std::vector<std::string>& keys) = 0;
 
   TizenViewType GetType() override { return TizenViewType::kWindow; };


### PR DESCRIPTION
When the size of the container is changed from the outside,
the size of FlutterView and the size of the image are changed together.

+)
Basically, the size of the container is set according to the size of the image.
It was enough to set min/max size only for images.
After setting the image size for an unknown reason,
the container resize callback is called once again.
At this time, evas_object_geometry_get() of container_ returns
the initially set value and the size backs to the original size.
Therefore, we set min/max of container_ together.
