### PR TITLE
Cleanup when destroying view and engine

### DIFF
--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -92,7 +92,6 @@ FlutterTizenEngine::FlutterTizenEngine(const FlutterProjectBundle& project)
 
 FlutterTizenEngine::~FlutterTizenEngine() {
   StopEngine();
-  renderer_ = nullptr;
 }
 
 bool FlutterTizenEngine::RunEngine() {

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -91,6 +91,7 @@ FlutterTizenEngine::FlutterTizenEngine(const FlutterProjectBundle& project)
 }
 
 FlutterTizenEngine::~FlutterTizenEngine() {
+  StopEngine();
   renderer_ = nullptr;
 }
 

--- a/shell/platform/tizen/flutter_tizen_view.cc
+++ b/shell/platform/tizen/flutter_tizen_view.cc
@@ -52,7 +52,9 @@ FlutterTizenView::FlutterTizenView(std::unique_ptr<TizenViewBase> tizen_view)
   }
 }
 
-FlutterTizenView::~FlutterTizenView() {}
+FlutterTizenView::~FlutterTizenView() {
+  DestroyRenderSurface();
+}
 
 void FlutterTizenView::SetEngine(std::unique_ptr<FlutterTizenEngine> engine) {
   engine_ = std::move(engine);


### PR DESCRIPTION
* The view should be responsible for the life cycle of the engine, and
  the engine should stop naturally when the view is destroyed.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>

