### PR TITLE
PlatformChannel: Do not quit app from SystemNavigatorPop unless it is window

### DIFF
--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -148,7 +148,9 @@ void PlatformChannel::HandleMethodCall(
 }
 
 void PlatformChannel::SystemNavigatorPop() {
-  ui_app_exit();
+  if (window_) {
+    ui_app_exit();
+  }
 }
 
 void PlatformChannel::PlaySystemSound(const std::string& sound_type) {


### PR DESCRIPTION
When user input Back key in tizen view, if there are no more back element,
the app is closed. this prevent it.
