### PR TITLE
Ignore SystemChrome.setApplicationSwitcherDescription

### DIFF
--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -29,6 +29,8 @@ constexpr char kHapticFeedbackVibrateMethod[] = "HapticFeedback.vibrate";
 constexpr char kSystemNavigatorPopMethod[] = "SystemNavigator.pop";
 constexpr char kRestoreSystemUiOverlaysMethod[] =
     "SystemChrome.restoreSystemUIOverlays";
+constexpr char kSetApplicationSwitcherDescriptionMethod[] =
+    "SystemChrome.setApplicationSwitcherDescription";
 constexpr char kSetEnabledSystemUiOverlaysMethod[] =
     "SystemChrome.setEnabledSystemUIOverlays";
 constexpr char kSetPreferredOrientationsMethod[] =
@@ -124,6 +126,8 @@ void PlatformChannel::HandleMethodCall(
     result->Success(document);
   } else if (method == kRestoreSystemUiOverlaysMethod) {
     RestoreSystemUiOverlays();
+    result->Success();
+  } else if (method == kSetApplicationSwitcherDescriptionMethod) {
     result->Success();
   } else if (method == kSetEnabledSystemUiOverlaysMethod) {
     const rapidjson::Document& list = arguments[0];

--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -128,6 +128,7 @@ void PlatformChannel::HandleMethodCall(
     RestoreSystemUiOverlays();
     result->Success();
   } else if (method == kSetApplicationSwitcherDescriptionMethod) {
+    // Not supported on Tizen. Ignore.
     result->Success();
   } else if (method == kSetEnabledSystemUiOverlaysMethod) {
     const rapidjson::Document& list = arguments[0];


### PR DESCRIPTION
Do not print the "unimplemented method" warning when run with the `--verbose-system-logs` option. The method is always called when the [Title](https://api.flutter.dev/flutter/widgets/Title-class.html) widget rebuilds.