### PR TITLE
Allow multiple plugin registrar destruction callbacks

### DIFF
--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -113,7 +113,7 @@ FlutterDesktopMessengerRef FlutterDesktopPluginRegistrarGetMessenger(
 void FlutterDesktopPluginRegistrarSetDestructionHandler(
     FlutterDesktopPluginRegistrarRef registrar,
     FlutterDesktopOnPluginRegistrarDestroyed callback) {
-  registrar->engine->SetPluginRegistrarDestructionCallback(callback);
+  registrar->engine->AddPluginRegistrarDestructionCallback(callback, registrar);
 }
 
 bool FlutterDesktopMessengerSend(FlutterDesktopMessengerRef messenger,

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -259,8 +259,9 @@ bool FlutterTizenEngine::StopEngine() {
     if (platform_view_channel_) {
       platform_view_channel_->Dispose();
     }
-    if (plugin_registrar_destruction_callback_) {
-      plugin_registrar_destruction_callback_(plugin_registrar_.get());
+    for (const auto& [callback, registrar] :
+         plugin_registrar_destruction_callbacks_) {
+      callback(registrar);
     }
 #ifndef TIZEN_RENDERER_EVAS_GL
     tizen_vsync_waiter_.reset();
@@ -276,9 +277,10 @@ void FlutterTizenEngine::SetView(FlutterTizenView* view) {
   view_ = view;
 }
 
-void FlutterTizenEngine::SetPluginRegistrarDestructionCallback(
-    FlutterDesktopOnPluginRegistrarDestroyed callback) {
-  plugin_registrar_destruction_callback_ = callback;
+void FlutterTizenEngine::AddPluginRegistrarDestructionCallback(
+    FlutterDesktopOnPluginRegistrarDestroyed callback,
+    FlutterDesktopPluginRegistrarRef registrar) {
+  plugin_registrar_destruction_callbacks_[callback] = registrar;
 }
 
 bool FlutterTizenEngine::SendPlatformMessage(

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -117,9 +117,10 @@ class FlutterTizenEngine {
   }
 #endif
 
-  // Sets |callback| to be called when the plugin registrar is destroyed.
-  void SetPluginRegistrarDestructionCallback(
-      FlutterDesktopOnPluginRegistrarDestroyed callback);
+  // Registers |callback| to be called when the plugin registrar is destroyed.
+  void AddPluginRegistrarDestructionCallback(
+      FlutterDesktopOnPluginRegistrarDestroyed callback,
+      FlutterDesktopPluginRegistrarRef registrar);
 
   // Sends the given message to the engine, calling |reply| with |user_data|
   // when a reponse is received from the engine if they are non-null.
@@ -238,10 +239,11 @@ class FlutterTizenEngine {
   // The texture registrar.
   std::unique_ptr<FlutterTizenTextureRegistrar> texture_registrar_;
 
-  // A callback to be called when the engine (and thus the plugin registrar)
-  // is being destroyed.
-  FlutterDesktopOnPluginRegistrarDestroyed
-      plugin_registrar_destruction_callback_{nullptr};
+  // Callbacks to be called when the engine (and thus the plugin registrar) is
+  // being destroyed.
+  std::map<FlutterDesktopOnPluginRegistrarDestroyed,
+           FlutterDesktopPluginRegistrarRef>
+      plugin_registrar_destruction_callbacks_;
 
 #ifndef WEARABLE_PROFILE
   // The accessibility bridge for the Tizen platform.

--- a/shell/platform/tizen/flutter_tizen_engine_unittest.cc
+++ b/shell/platform/tizen/flutter_tizen_engine_unittest.cc
@@ -188,5 +188,31 @@ TEST_F(FlutterTizenEngineTest, SendPlatformMessageWithResponse) {
   EXPECT_TRUE(send_message_called);
 }
 
+TEST_F(FlutterTizenEngineTest, AddPluginRegistrarDestructionCallback) {
+  EngineModifier modifier(engine_);
+
+  engine_->RunEngine();
+
+  // Verify that destruction handlers don't overwrite each other.
+  int result1 = 0;
+  int result2 = 0;
+  engine_->AddPluginRegistrarDestructionCallback(
+      [](FlutterDesktopPluginRegistrarRef ref) {
+        auto result = reinterpret_cast<int*>(ref);
+        *result = 1;
+      },
+      reinterpret_cast<FlutterDesktopPluginRegistrarRef>(&result1));
+  engine_->AddPluginRegistrarDestructionCallback(
+      [](FlutterDesktopPluginRegistrarRef ref) {
+        auto result = reinterpret_cast<int*>(ref);
+        *result = 2;
+      },
+      reinterpret_cast<FlutterDesktopPluginRegistrarRef>(&result2));
+
+  engine_->StopEngine();
+  EXPECT_EQ(result1, 1);
+  EXPECT_EQ(result2, 2);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/tizen/flutter_tizen_engine_unittest.cc
+++ b/shell/platform/tizen/flutter_tizen_engine_unittest.cc
@@ -190,6 +190,22 @@ TEST_F(FlutterTizenEngineTest, SendPlatformMessageWithResponse) {
 
 TEST_F(FlutterTizenEngineTest, AddPluginRegistrarDestructionCallback) {
   EngineModifier modifier(engine_);
+  modifier.embedder_api().Run = MOCK_ENGINE_PROC(
+      Run, ([](size_t version, const FlutterRendererConfig* config,
+               const FlutterProjectArgs* args, void* user_data,
+               FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+        *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
+        return kSuccess;
+      }));
+
+  // Stub out UpdateLocales and SendPlatformMessage as we don't have a fully
+  // initialized engine instance.
+  modifier.embedder_api().UpdateLocales = MOCK_ENGINE_PROC(
+      UpdateLocales, ([](auto engine, const FlutterLocale** locales,
+                         size_t locales_count) { return kSuccess; }));
+  modifier.embedder_api().SendPlatformMessage =
+      MOCK_ENGINE_PROC(SendPlatformMessage,
+                       ([](auto engine, auto message) { return kSuccess; }));
 
   engine_->RunEngine();
 
@@ -208,6 +224,10 @@ TEST_F(FlutterTizenEngineTest, AddPluginRegistrarDestructionCallback) {
         *result = 2;
       },
       reinterpret_cast<FlutterDesktopPluginRegistrarRef>(&result2));
+
+  // Ensure that deallocation doesn't call the actual Shutdown with the bogus
+  // engine pointer that the overridden Run returned.
+  modifier.embedder_api().Shutdown = [](auto engine) { return kSuccess; };
 
   engine_->StopEngine();
   EXPECT_EQ(result1, 1);


### PR DESCRIPTION
Applies https://github.com/flutter/engine/pull/30760 to the Tizen embedder.

This is an actual fix for https://github.com/flutter-tizen/flutter-tizen/issues/90, which has been worked around by https://github.com/flutter-tizen/flutter-tizen/pull/98. We can now support the old-fashioned "sharedLib" style plugins (each plugin is built into an individual shared object) based on this change.