### PR TITLE
Stop the engine before destroying the surface

### DIFF
--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -266,6 +266,7 @@ bool FlutterTizenEngine::StopEngine() {
     tizen_vsync_waiter_.reset();
 #endif
     FlutterEngineResult result = embedder_api_.Shutdown(engine_);
+    view_ = nullptr;
     engine_ = nullptr;
     return (result == kSuccess);
   }

--- a/shell/platform/tizen/flutter_tizen_view.cc
+++ b/shell/platform/tizen/flutter_tizen_view.cc
@@ -54,6 +54,7 @@ FlutterTizenView::FlutterTizenView(std::unique_ptr<TizenViewBase> tizen_view)
 }
 
 FlutterTizenView::~FlutterTizenView() {
+  engine_->StopEngine();
   DestroyRenderSurface();
 }
 

--- a/shell/platform/tizen/flutter_tizen_view.cc
+++ b/shell/platform/tizen/flutter_tizen_view.cc
@@ -54,7 +54,9 @@ FlutterTizenView::FlutterTizenView(std::unique_ptr<TizenViewBase> tizen_view)
 }
 
 FlutterTizenView::~FlutterTizenView() {
-  engine_->StopEngine();
+  if (engine_) {
+    engine_->StopEngine();
+  }
   DestroyRenderSurface();
 }
 


### PR DESCRIPTION
* This fixes the crash that occurs when terminating flutter-tizen app

Signed-off-by: Boram Bae <boram21.bae@samsung.com>
