### PR TITLE
Refactor TizenVsyncWaiter

### DIFF
--- a/shell/platform/tizen/external_texture.h
+++ b/shell/platform/tizen/external_texture.h
@@ -26,7 +26,7 @@ struct ExternalTextureGLState {
   ExternalTextureExtensionType gl_extension;
 };
 
-static std::atomic_long next_texture_id = {1};
+static std::atomic<int64_t> next_texture_id = {1};
 
 // An adaptation class of flutter engine and external texture interface.
 class ExternalTexture {
@@ -37,10 +37,11 @@ class ExternalTexture {
         texture_id_(next_texture_id++) {
     state_->gl_extension = gl_extension;
   }
+
   virtual ~ExternalTexture() = default;
 
   // Returns the unique id for the ExternalTextureGL instance.
-  int64_t TextureId() { return (int64_t)texture_id_; }
+  int64_t TextureId() { return texture_id_; }
 
   virtual bool PopulateTexture(size_t width,
                                size_t height,
@@ -48,7 +49,7 @@ class ExternalTexture {
 
  protected:
   std::unique_ptr<ExternalTextureGLState> state_;
-  const long texture_id_{0};
+  const int64_t texture_id_ = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/tizen_view_elementary.cc
+++ b/shell/platform/tizen/tizen_view_elementary.cc
@@ -10,11 +10,13 @@
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/tizen_view_event_handler_delegate.h"
 
+namespace flutter {
+
 namespace {
 
-static const int kScrollDirectionVertical = 0;
-static const int kScrollDirectionHorizontal = 1;
-static const int kScrollOffsetMultiplier = 20;
+constexpr int kScrollDirectionVertical = 0;
+constexpr int kScrollDirectionHorizontal = 1;
+constexpr int kScrollOffsetMultiplier = 20;
 
 uint32_t EvasModifierToEcoreEventModifiers(const Evas_Modifier* evas_modifier) {
   uint32_t modifiers = 0;
@@ -39,8 +41,6 @@ void EvasObjectResizeWithMinMaxHint(Evas_Object* object,
 }
 
 }  // namespace
-
-namespace flutter {
 
 TizenViewElementary::TizenViewElementary(int32_t width,
                                          int32_t height,

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -85,19 +85,15 @@ void TizenVsyncWaiter::RequestVblankLoop(void* data, Ecore_Thread* thread) {
 
   while (!ecore_thread_check(thread)) {
     void* ref;
-    Message* message;
-    message = static_cast<Message*>(
+    Message* message = static_cast<Message*>(
         eina_thread_queue_wait(vblank_thread_queue, &ref));
-    if (message) {
-      eina_thread_queue_wait_done(vblank_thread_queue, ref);
-    } else {
-      FT_LOG(Error) << "Received a null message.";
-      continue;
-    }
     if (message->event == kMessageQuit) {
+      eina_thread_queue_wait_done(vblank_thread_queue, ref);
       break;
     }
-    tdm_client->WaitVblank(message->baton);
+    intptr_t baton = message->baton;
+    eina_thread_queue_wait_done(vblank_thread_queue, ref);
+    tdm_client->WaitVblank(baton);
   }
 
   if (vblank_thread_queue) {

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -66,7 +66,7 @@ void TizenVsyncWaiter::SendMessage(int event, intptr_t baton) {
 }
 
 void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
-  TizenVsyncWaiter* self = reinterpret_cast<TizenVsyncWaiter*>(data);
+  auto* self = reinterpret_cast<TizenVsyncWaiter*>(data);
 
   std::weak_ptr<TdmClient> tdm_client = self->tdm_client_;
   if (!tdm_client.lock()->IsValid()) {
@@ -165,7 +165,7 @@ void TdmClient::VblankCallback(tdm_client_vblank* vblank,
                                unsigned int tv_sec,
                                unsigned int tv_usec,
                                void* user_data) {
-  TdmClient* self = reinterpret_cast<TdmClient*>(user_data);
+  auto* self = reinterpret_cast<TdmClient*>(user_data);
   FT_ASSERT(self != nullptr);
 
   std::lock_guard<std::mutex> lock(self->engine_mutex_);

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -102,14 +102,39 @@ void TizenVsyncWaiter::RequestVblankLoop(void* data, Ecore_Thread* thread) {
 }
 
 TdmClient::TdmClient(FlutterTizenEngine* engine) {
-  if (!CreateTdm()) {
-    FT_LOG(Error) << "CreateTdm() failed.";
+  tdm_error ret;
+  client_ = tdm_client_create(&ret);
+  if (ret != TDM_ERROR_NONE && client_ != NULL) {
+    FT_LOG(Error) << "Failed to create a TDM client.";
+    return;
   }
+
+  output_ = tdm_client_get_output(client_, const_cast<char*>("default"), &ret);
+  if (ret != TDM_ERROR_NONE && output_ != NULL) {
+    FT_LOG(Error) << "Could not obtain the default client output.";
+    return;
+  }
+
+  vblank_ = tdm_client_output_create_vblank(output_, &ret);
+  if (ret != TDM_ERROR_NONE && vblank_ != NULL) {
+    FT_LOG(Error) << "Failed to create a vblank object.";
+    return;
+  }
+  tdm_client_vblank_set_enable_fake(vblank_, 1);
+
   engine_ = engine;
 }
 
 TdmClient::~TdmClient() {
-  DestroyTdm();
+  if (vblank_) {
+    tdm_client_vblank_destroy(vblank_);
+    vblank_ = nullptr;
+  }
+  output_ = nullptr;
+  if (client_) {
+    tdm_client_destroy(client_);
+    client_ = nullptr;
+  }
 }
 
 void TdmClient::OnEngineStop() {
@@ -125,42 +150,6 @@ void TdmClient::WaitVblank(intptr_t baton) {
     return;
   }
   tdm_client_handle_events(client_);
-}
-
-bool TdmClient::CreateTdm() {
-  tdm_error ret;
-  client_ = tdm_client_create(&ret);
-  if (ret != TDM_ERROR_NONE && client_ != NULL) {
-    FT_LOG(Error) << "Failed to create a TDM client.";
-    return false;
-  }
-
-  output_ = tdm_client_get_output(client_, const_cast<char*>("default"), &ret);
-  if (ret != TDM_ERROR_NONE && output_ != NULL) {
-    FT_LOG(Error) << "Could not obtain the default client output.";
-    return false;
-  }
-
-  vblank_ = tdm_client_output_create_vblank(output_, &ret);
-  if (ret != TDM_ERROR_NONE && vblank_ != NULL) {
-    FT_LOG(Error) << "Failed to create a vblank object.";
-    return false;
-  }
-
-  tdm_client_vblank_set_enable_fake(vblank_, 1);
-  return true;
-}
-
-void TdmClient::DestroyTdm() {
-  if (vblank_) {
-    tdm_client_vblank_destroy(vblank_);
-    vblank_ = nullptr;
-  }
-  output_ = nullptr;
-  if (client_) {
-    tdm_client_destroy(client_);
-    client_ = nullptr;
-  }
 }
 
 bool TdmClient::IsValid() {

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -25,7 +25,7 @@ struct Message {
 }  // namespace
 
 TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine) {
-  tdm_client_ = std::make_unique<TdmClient>(engine);
+  tdm_client_ = std::make_shared<TdmClient>(engine);
 
   vblank_thread_ = ecore_thread_feedback_run(RunVblankLoop, nullptr, nullptr,
                                              nullptr, this, EINA_TRUE);
@@ -68,8 +68,8 @@ void TizenVsyncWaiter::SendMessage(int event, intptr_t baton) {
 void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
   TizenVsyncWaiter* self = reinterpret_cast<TizenVsyncWaiter*>(data);
 
-  TdmClient* tdm_client = self->tdm_client_.get();
-  if (!tdm_client->IsValid()) {
+  std::weak_ptr<TdmClient> tdm_client = self->tdm_client_;
+  if (!tdm_client.lock()->IsValid()) {
     FT_LOG(Error) << "Invalid tdm_client.";
     ecore_thread_cancel(thread);
     return;
@@ -93,7 +93,11 @@ void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
     }
     intptr_t baton = message->baton;
     eina_thread_queue_wait_done(vblank_thread_queue, ref);
-    tdm_client->AwaitVblank(baton);
+
+    if (tdm_client.expired()) {
+      break;
+    }
+    tdm_client.lock()->AwaitVblank(baton);
   }
 
   if (vblank_thread_queue) {
@@ -163,6 +167,7 @@ void TdmClient::VblankCallback(tdm_client_vblank* vblank,
                                void* user_data) {
   TdmClient* self = reinterpret_cast<TdmClient*>(user_data);
   FT_ASSERT(self != nullptr);
+
   std::lock_guard<std::mutex> lock(self->engine_mutex_);
   if (self->engine_) {
     uint64_t frame_start_time_nanos = tv_sec * 1e9 + tv_usec * 1e3;

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -16,11 +16,11 @@ namespace {
 constexpr int kMessageQuit = -1;
 constexpr int kMessageRequestVblank = 0;
 
-typedef struct {
+struct Message {
   Eina_Thread_Queue_Msg head;
   int event;
   intptr_t baton;
-} Msg;
+};
 
 }  // namespace
 
@@ -32,10 +32,10 @@ TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine) {
 }
 
 TizenVsyncWaiter::~TizenVsyncWaiter() {
-  if (tdm_client_) {
-    tdm_client_->OnEngineStop();
-  }
-  Send(kMessageQuit, 0);
+  tdm_client_->OnEngineStop();
+
+  SendMessage(kMessageQuit, 0);
+
   if (vblank_thread_) {
     ecore_thread_cancel(vblank_thread_);
     vblank_thread_ = nullptr;
@@ -43,10 +43,10 @@ TizenVsyncWaiter::~TizenVsyncWaiter() {
 }
 
 void TizenVsyncWaiter::AsyncWaitForVsync(intptr_t baton) {
-  Send(kMessageRequestVblank, baton);
+  SendMessage(kMessageRequestVblank, baton);
 }
 
-void TizenVsyncWaiter::Send(int event, intptr_t baton) {
+void TizenVsyncWaiter::SendMessage(int event, intptr_t baton) {
   if (!vblank_thread_ || ecore_thread_check(vblank_thread_)) {
     FT_LOG(Error) << "Invalid vblank thread.";
     return;
@@ -57,12 +57,11 @@ void TizenVsyncWaiter::Send(int event, intptr_t baton) {
     return;
   }
 
-  Msg* msg;
   void* ref;
-  msg = static_cast<Msg*>(
-      eina_thread_queue_send(vblank_thread_queue_, sizeof(Msg), &ref));
-  msg->event = event;
-  msg->baton = baton;
+  Message* message = static_cast<Message*>(
+      eina_thread_queue_send(vblank_thread_queue_, sizeof(Message), &ref));
+  message->event = event;
+  message->baton = baton;
   eina_thread_queue_send_done(vblank_thread_queue_, ref);
 }
 
@@ -86,18 +85,19 @@ void TizenVsyncWaiter::RequestVblankLoop(void* data, Ecore_Thread* thread) {
 
   while (!ecore_thread_check(thread)) {
     void* ref;
-    Msg* msg;
-    msg = static_cast<Msg*>(eina_thread_queue_wait(vblank_thread_queue, &ref));
-    if (msg) {
+    Message* message;
+    message = static_cast<Message*>(
+        eina_thread_queue_wait(vblank_thread_queue, &ref));
+    if (message) {
       eina_thread_queue_wait_done(vblank_thread_queue, ref);
     } else {
       FT_LOG(Error) << "Received a null message.";
       continue;
     }
-    if (msg->event == kMessageQuit) {
+    if (message->event == kMessageQuit) {
       break;
     }
-    tdm_client->WaitVblank(msg->baton);
+    tdm_client->WaitVblank(message->baton);
   }
 
   if (vblank_thread_queue) {

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -20,8 +20,9 @@ typedef struct {
   intptr_t baton;
 } Msg;
 
-TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine)
-    : engine_(engine) {
+TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine) {
+  tdm_client_ = std::make_unique<TdmClient>(engine);
+
   vblank_thread_ = ecore_thread_feedback_run(RequestVblankLoop, nullptr,
                                              nullptr, nullptr, this, EINA_TRUE);
 }
@@ -63,7 +64,6 @@ void TizenVsyncWaiter::Send(int event, intptr_t baton) {
 
 void TizenVsyncWaiter::RequestVblankLoop(void* data, Ecore_Thread* thread) {
   TizenVsyncWaiter* self = reinterpret_cast<TizenVsyncWaiter*>(data);
-  self->SetTdmClient(std::make_unique<TdmClient>(self->engine_));
 
   TdmClient* tdm_client = self->tdm_client_.get();
   if (!tdm_client->IsValid()) {

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -9,16 +9,20 @@
 #include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/logger.h"
 
-static const int kMessageQuit = -1;
-static const int kMessageRequestVblank = 0;
-
 namespace flutter {
+
+namespace {
+
+constexpr int kMessageQuit = -1;
+constexpr int kMessageRequestVblank = 0;
 
 typedef struct {
   Eina_Thread_Queue_Msg head;
   int event;
   intptr_t baton;
 } Msg;
+
+}  // namespace
 
 TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine) {
   tdm_client_ = std::make_unique<TdmClient>(engine);

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -27,8 +27,8 @@ struct Message {
 TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine) {
   tdm_client_ = std::make_unique<TdmClient>(engine);
 
-  vblank_thread_ = ecore_thread_feedback_run(RequestVblankLoop, nullptr,
-                                             nullptr, nullptr, this, EINA_TRUE);
+  vblank_thread_ = ecore_thread_feedback_run(RunVblankLoop, nullptr, nullptr,
+                                             nullptr, this, EINA_TRUE);
 }
 
 TizenVsyncWaiter::~TizenVsyncWaiter() {
@@ -65,7 +65,7 @@ void TizenVsyncWaiter::SendMessage(int event, intptr_t baton) {
   eina_thread_queue_send_done(vblank_thread_queue_, ref);
 }
 
-void TizenVsyncWaiter::RequestVblankLoop(void* data, Ecore_Thread* thread) {
+void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
   TizenVsyncWaiter* self = reinterpret_cast<TizenVsyncWaiter*>(data);
 
   TdmClient* tdm_client = self->tdm_client_.get();
@@ -93,7 +93,7 @@ void TizenVsyncWaiter::RequestVblankLoop(void* data, Ecore_Thread* thread) {
     }
     intptr_t baton = message->baton;
     eina_thread_queue_wait_done(vblank_thread_queue, ref);
-    tdm_client->WaitVblank(baton);
+    tdm_client->AwaitVblank(baton);
   }
 
   if (vblank_thread_queue) {
@@ -142,7 +142,7 @@ void TdmClient::OnEngineStop() {
   engine_ = nullptr;
 }
 
-void TdmClient::WaitVblank(intptr_t baton) {
+void TdmClient::AwaitVblank(intptr_t baton) {
   baton_ = baton;
   tdm_error error = tdm_client_vblank_wait(vblank_, 1, VblankCallback, this);
   if (error != TDM_ERROR_NONE) {

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -104,19 +104,19 @@ void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
 TdmClient::TdmClient(FlutterTizenEngine* engine) {
   tdm_error ret;
   client_ = tdm_client_create(&ret);
-  if (ret != TDM_ERROR_NONE && client_ != NULL) {
+  if (ret != TDM_ERROR_NONE) {
     FT_LOG(Error) << "Failed to create a TDM client.";
     return;
   }
 
   output_ = tdm_client_get_output(client_, const_cast<char*>("default"), &ret);
-  if (ret != TDM_ERROR_NONE && output_ != NULL) {
+  if (ret != TDM_ERROR_NONE) {
     FT_LOG(Error) << "Could not obtain the default client output.";
     return;
   }
 
   vblank_ = tdm_client_output_create_vblank(output_, &ret);
-  if (ret != TDM_ERROR_NONE && vblank_ != NULL) {
+  if (ret != TDM_ERROR_NONE) {
     FT_LOG(Error) << "Failed to create a vblank object.";
     return;
   }
@@ -144,9 +144,9 @@ void TdmClient::OnEngineStop() {
 
 void TdmClient::AwaitVblank(intptr_t baton) {
   baton_ = baton;
-  tdm_error error = tdm_client_vblank_wait(vblank_, 1, VblankCallback, this);
-  if (error != TDM_ERROR_NONE) {
-    FT_LOG(Error) << "tdm_client_vblank_wait() failed.";
+  tdm_error ret = tdm_client_vblank_wait(vblank_, 1, VblankCallback, this);
+  if (ret != TDM_ERROR_NONE) {
+    FT_LOG(Error) << "tdm_client_vblank_wait failed with error: " << ret;
     return;
   }
   tdm_client_handle_events(client_);
@@ -162,14 +162,14 @@ void TdmClient::VblankCallback(tdm_client_vblank* vblank,
                                unsigned int tv_sec,
                                unsigned int tv_usec,
                                void* user_data) {
-  TdmClient* client = reinterpret_cast<TdmClient*>(user_data);
-  FT_ASSERT(client != nullptr);
-  std::lock_guard<std::mutex> lock(client->engine_mutex_);
-  if (client->engine_) {
+  TdmClient* self = reinterpret_cast<TdmClient*>(user_data);
+  FT_ASSERT(self != nullptr);
+  std::lock_guard<std::mutex> lock(self->engine_mutex_);
+  if (self->engine_) {
     uint64_t frame_start_time_nanos = tv_sec * 1e9 + tv_usec * 1e3;
     uint64_t frame_target_time_nanos = 16.6 * 1e6 + frame_start_time_nanos;
-    client->engine_->OnVsync(client->baton_, frame_start_time_nanos,
-                             frame_target_time_nanos);
+    self->engine_->OnVsync(self->baton_, frame_start_time_nanos,
+                           frame_target_time_nanos);
   }
 }
 

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -32,7 +32,7 @@ TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine) {
 }
 
 TizenVsyncWaiter::~TizenVsyncWaiter() {
-  tdm_client_->OnEngineStop();
+  tdm_client_.reset();
 
   SendMessage(kMessageQuit, 0);
 
@@ -126,6 +126,10 @@ TdmClient::TdmClient(FlutterTizenEngine* engine) {
 }
 
 TdmClient::~TdmClient() {
+  {
+    std::lock_guard<std::mutex> lock(engine_mutex_);
+    engine_ = nullptr;
+  }
   if (vblank_) {
     tdm_client_vblank_destroy(vblank_);
     vblank_ = nullptr;
@@ -135,11 +139,6 @@ TdmClient::~TdmClient() {
     tdm_client_destroy(client_);
     client_ = nullptr;
   }
-}
-
-void TdmClient::OnEngineStop() {
-  std::lock_guard<std::mutex> lock(engine_mutex_);
-  engine_ = nullptr;
 }
 
 void TdmClient::AwaitVblank(intptr_t baton) {

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -37,10 +37,6 @@ TizenVsyncWaiter::~TizenVsyncWaiter() {
   }
 }
 
-void TizenVsyncWaiter::SetTdmClient(TdmClient* tdm_client) {
-  tdm_client_ = tdm_client;
-}
-
 void TizenVsyncWaiter::AsyncWaitForVsync(intptr_t baton) {
   Send(kMessageRequestVblank, baton);
 }
@@ -66,23 +62,24 @@ void TizenVsyncWaiter::Send(int event, intptr_t baton) {
 }
 
 void TizenVsyncWaiter::RequestVblankLoop(void* data, Ecore_Thread* thread) {
-  TizenVsyncWaiter* tizen_vsync_waiter =
-      reinterpret_cast<TizenVsyncWaiter*>(data);
-  TdmClient tdm_client(tizen_vsync_waiter->engine_);
-  tizen_vsync_waiter->SetTdmClient(&tdm_client);
-  if (!tdm_client.IsValid()) {
+  TizenVsyncWaiter* self = reinterpret_cast<TizenVsyncWaiter*>(data);
+  self->SetTdmClient(std::make_unique<TdmClient>(self->engine_));
+
+  TdmClient* tdm_client = self->tdm_client_.get();
+  if (!tdm_client->IsValid()) {
     FT_LOG(Error) << "Invalid tdm_client.";
     ecore_thread_cancel(thread);
     return;
   }
+
   Eina_Thread_Queue* vblank_thread_queue = eina_thread_queue_new();
   if (!vblank_thread_queue) {
     FT_LOG(Error) << "Invalid vblank thread queue.";
     ecore_thread_cancel(thread);
     return;
   }
+  self->vblank_thread_queue_ = vblank_thread_queue;
 
-  tizen_vsync_waiter->vblank_thread_queue_ = vblank_thread_queue;
   while (!ecore_thread_check(thread)) {
     void* ref;
     Msg* msg;
@@ -96,8 +93,9 @@ void TizenVsyncWaiter::RequestVblankLoop(void* data, Ecore_Thread* thread) {
     if (msg->event == kMessageQuit) {
       break;
     }
-    tdm_client.WaitVblank(msg->baton);
+    tdm_client->WaitVblank(msg->baton);
   }
+
   if (vblank_thread_queue) {
     eina_thread_queue_free(vblank_thread_queue);
   }

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -21,8 +21,6 @@ class TdmClient {
   TdmClient(FlutterTizenEngine* engine);
   virtual ~TdmClient();
 
-  bool CreateTdm();
-  void DestroyTdm();
   bool IsValid();
   void WaitVblank(intptr_t baton);
   void OnEngineStop();

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -7,6 +7,7 @@
 
 #include <Ecore.h>
 #include <tdm_client.h>
+
 #include <memory>
 #include <mutex>
 

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -52,18 +52,14 @@ class TizenVsyncWaiter {
 
   void AsyncWaitForVsync(intptr_t baton);
 
-  void SetTdmClient(std::unique_ptr<TdmClient> tdm_client) {
-    tdm_client_ = std::move(tdm_client);
-  }
-
  private:
   void Send(int event, intptr_t baton);
+
   static void RequestVblankLoop(void* data, Ecore_Thread* thread);
 
+  std::unique_ptr<TdmClient> tdm_client_;
   Ecore_Thread* vblank_thread_ = nullptr;
   Eina_Thread_Queue* vblank_thread_queue_ = nullptr;
-  FlutterTizenEngine* engine_ = nullptr;
-  std::unique_ptr<TdmClient> tdm_client_;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -7,6 +7,7 @@
 
 #include <Ecore.h>
 #include <tdm_client.h>
+#include <memory>
 #include <mutex>
 
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -19,11 +20,14 @@ class TdmClient {
  public:
   TdmClient(FlutterTizenEngine* engine);
   virtual ~TdmClient();
+
   bool CreateTdm();
   void DestroyTdm();
   bool IsValid();
   void WaitVblank(intptr_t baton);
   void OnEngineStop();
+
+ private:
   static void VblankCallback(tdm_client_vblank* vblank,
                              tdm_error error,
                              unsigned int sequence,
@@ -31,12 +35,13 @@ class TdmClient {
                              unsigned int tv_usec,
                              void* user_data);
 
- private:
+  FlutterTizenEngine* engine_ = nullptr;
   std::mutex engine_mutex_;
+
   tdm_client* client_ = nullptr;
   tdm_client_output* output_ = nullptr;
   tdm_client_vblank* vblank_ = nullptr;
-  FlutterTizenEngine* engine_ = nullptr;
+
   intptr_t baton_ = 0;
 };
 
@@ -44,8 +49,12 @@ class TizenVsyncWaiter {
  public:
   TizenVsyncWaiter(FlutterTizenEngine* engine);
   virtual ~TizenVsyncWaiter();
+
   void AsyncWaitForVsync(intptr_t baton);
-  void SetTdmClient(TdmClient* tdm_client);
+
+  void SetTdmClient(std::unique_ptr<TdmClient> tdm_client) {
+    tdm_client_ = std::move(tdm_client);
+  }
 
  private:
   void Send(int event, intptr_t baton);
@@ -54,7 +63,7 @@ class TizenVsyncWaiter {
   Ecore_Thread* vblank_thread_ = nullptr;
   Eina_Thread_Queue* vblank_thread_queue_ = nullptr;
   FlutterTizenEngine* engine_ = nullptr;
-  TdmClient* tdm_client_ = nullptr;
+  std::unique_ptr<TdmClient> tdm_client_;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -24,7 +24,6 @@ class TdmClient {
 
   bool IsValid();
   void AwaitVblank(intptr_t baton);
-  void OnEngineStop();
 
  private:
   static void VblankCallback(tdm_client_vblank* vblank,
@@ -56,7 +55,7 @@ class TizenVsyncWaiter {
 
   static void RunVblankLoop(void* data, Ecore_Thread* thread);
 
-  std::unique_ptr<TdmClient> tdm_client_;
+  std::shared_ptr<TdmClient> tdm_client_;
   Ecore_Thread* vblank_thread_ = nullptr;
   Eina_Thread_Queue* vblank_thread_queue_ = nullptr;
 };

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -33,11 +33,11 @@ class TdmClient {
 
  private:
   std::mutex engine_mutex_;
-  tdm_client* client_{nullptr};
-  tdm_client_output* output_{nullptr};
-  tdm_client_vblank* vblank_{nullptr};
-  FlutterTizenEngine* engine_{nullptr};
-  intptr_t baton_{0};
+  tdm_client* client_ = nullptr;
+  tdm_client_output* output_ = nullptr;
+  tdm_client_vblank* vblank_ = nullptr;
+  FlutterTizenEngine* engine_ = nullptr;
+  intptr_t baton_ = 0;
 };
 
 class TizenVsyncWaiter {
@@ -50,10 +50,11 @@ class TizenVsyncWaiter {
  private:
   void Send(int event, intptr_t baton);
   static void RequestVblankLoop(void* data, Ecore_Thread* thread);
-  Ecore_Thread* vblank_thread_{nullptr};
-  Eina_Thread_Queue* vblank_thread_queue_{nullptr};
-  FlutterTizenEngine* engine_{nullptr};
-  TdmClient* tdm_client_{nullptr};
+
+  Ecore_Thread* vblank_thread_ = nullptr;
+  Eina_Thread_Queue* vblank_thread_queue_ = nullptr;
+  FlutterTizenEngine* engine_ = nullptr;
+  TdmClient* tdm_client_ = nullptr;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -53,7 +53,7 @@ class TizenVsyncWaiter {
   void AsyncWaitForVsync(intptr_t baton);
 
  private:
-  void Send(int event, intptr_t baton);
+  void SendMessage(int event, intptr_t baton);
 
   static void RequestVblankLoop(void* data, Ecore_Thread* thread);
 

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -22,7 +22,7 @@ class TdmClient {
   virtual ~TdmClient();
 
   bool IsValid();
-  void WaitVblank(intptr_t baton);
+  void AwaitVblank(intptr_t baton);
   void OnEngineStop();
 
  private:
@@ -53,7 +53,7 @@ class TizenVsyncWaiter {
  private:
   void SendMessage(int event, intptr_t baton);
 
-  static void RequestVblankLoop(void* data, Ecore_Thread* thread);
+  static void RunVblankLoop(void* data, Ecore_Thread* thread);
 
   std::unique_ptr<TdmClient> tdm_client_;
   Ecore_Thread* vblank_thread_ = nullptr;

--- a/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -11,15 +11,15 @@
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/tizen_view_event_handler_delegate.h"
 
+namespace flutter {
+
 namespace {
 
-static const int kScrollDirectionVertical = 0;
-static const int kScrollDirectionHorizontal = 1;
-static const int kScrollOffsetMultiplier = 20;
+constexpr int kScrollDirectionVertical = 0;
+constexpr int kScrollDirectionHorizontal = 1;
+constexpr int kScrollOffsetMultiplier = 20;
 
 }  // namespace
-
-namespace flutter {
 
 TizenWindowEcoreWl2::TizenWindowEcoreWl2(TizenGeometry geometry,
                                          bool transparent,

--- a/shell/platform/tizen/tizen_window_elementary.cc
+++ b/shell/platform/tizen/tizen_window_elementary.cc
@@ -10,11 +10,13 @@
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/tizen_view_event_handler_delegate.h"
 
+namespace flutter {
+
 namespace {
 
-static const int kScrollDirectionVertical = 0;
-static const int kScrollDirectionHorizontal = 1;
-static const int kScrollOffsetMultiplier = 20;
+constexpr int kScrollDirectionVertical = 0;
+constexpr int kScrollDirectionHorizontal = 1;
+constexpr int kScrollOffsetMultiplier = 20;
 
 uint32_t EvasModifierToEcoreEventModifiers(const Evas_Modifier* evas_modifier) {
   uint32_t modifiers = 0;
@@ -31,8 +33,6 @@ uint32_t EvasModifierToEcoreEventModifiers(const Evas_Modifier* evas_modifier) {
 }
 
 }  // namespace
-
-namespace flutter {
 
 TizenWindowElementary::TizenWindowElementary(TizenGeometry geometry,
                                              bool transparent,


### PR DESCRIPTION
TizenVsyncWaiter:
- Remove `SetTdmClient` and make `tdm_client_` a shared_ptr. (The current code may cause a segmentation fault.)
- Rename methods, types, and variables. For example:
  - `Send` → `SendMessage`
  - `RequestVblankLoop` → `RunVblankLoop`
  - `Msg` → `Message`
- Always call `eina_thread_queue_wait_done` after finishing retrieving data from `message`.

TdmClient:
- Remove `CreateTdm` and `DestroyTdm` and move the logic to the constructor and destructor.
- Remove `OnEngineStop` and move the logic to the destructor.

Miscellaneous:
- Change the type of `texture_id_` to `int64_t` in `external_texture.h`.
- Replace `const` with `constexpr` in `tizen_view_elementary.cc` and `tizen_window_*.cc`.