### PR TITLE
TizenRendererEvasGL: Add nullcheck for evas_gl_

### DIFF
--- a/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -82,14 +82,18 @@ bool TizenRendererEvasGL::CreateSurface(void* render_target,
 }
 
 void TizenRendererEvasGL::DestroySurface() {
-  evas_gl_surface_destroy(evas_gl_, gl_surface_);
-  evas_gl_surface_destroy(evas_gl_, gl_resource_surface_);
+  if (evas_gl_) {
+    evas_gl_surface_destroy(evas_gl_, gl_surface_);
+    evas_gl_surface_destroy(evas_gl_, gl_resource_surface_);
 
-  evas_gl_context_destroy(evas_gl_, gl_context_);
-  evas_gl_context_destroy(evas_gl_, gl_resource_context_);
+    evas_gl_context_destroy(evas_gl_, gl_context_);
+    evas_gl_context_destroy(evas_gl_, gl_resource_context_);
 
-  evas_gl_config_free(gl_config_);
-  evas_gl_free(evas_gl_);
+    evas_gl_config_free(gl_config_);
+    evas_gl_free(evas_gl_);
+
+    evas_gl_ = nullptr;
+  }
 }
 
 bool TizenRendererEvasGL::OnMakeCurrent() {


### PR DESCRIPTION
DestorySurface is called more than once depending on the situation.
Add nullcheck to avoid destroying already destroyed evas_gl_ again.

related issue : https://github.com/flutter-tizen/engine/issues/319