### PR TITLE
Restore support for pixel buffer textures

### DIFF
--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -115,6 +115,7 @@ template("embedder") {
       "channels/settings_channel.cc",
       "channels/text_input_channel.cc",
       "channels/window_channel.cc",
+      "external_texture_pixel_evas_gl.cc",
       "external_texture_surface_evas_gl.cc",
       "flutter_project_bundle.cc",
       "flutter_tizen.cc",
@@ -186,6 +187,7 @@ template("embedder") {
 
     if (target_name != "flutter_tizen_wearable") {
       sources += [
+        "external_texture_pixel_egl.cc",
         "external_texture_surface_egl.cc",
         "tizen_renderer_egl.cc",
         "tizen_vsync_waiter.cc",

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -160,10 +160,7 @@ template("embedder") {
       "evas",
       "feedback",
       "tbm",
-      "tdm-client",
       "wayland-client",
-      "EGL",
-      "GLESv2",
     ]
 
     if (target_name == "flutter_tizen_common") {
@@ -197,7 +194,10 @@ template("embedder") {
 
       libs += [
         "ecore_wl2",
+        "tdm-client",
         "tizen-extension-client",
+        "EGL",
+        "GLESv2",
       ]
     }
 

--- a/shell/platform/tizen/external_texture_pixel_egl.cc
+++ b/shell/platform/tizen/external_texture_pixel_egl.cc
@@ -1,0 +1,70 @@
+// Copyright 2020 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "external_texture_pixel_egl.h"
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <GLES3/gl32.h>
+
+namespace flutter {
+
+bool ExternalTexturePixelEGL::PopulateTexture(
+    size_t width,
+    size_t height,
+    FlutterOpenGLTexture* opengl_texture) {
+  if (!CopyPixelBuffer(width, height)) {
+    return false;
+  }
+
+  // Populate the texture object used by the engine.
+  opengl_texture->target = GL_TEXTURE_2D;
+  opengl_texture->name = state_->gl_texture;
+  opengl_texture->format = GL_RGBA8;
+  opengl_texture->destruction_callback = nullptr;
+  opengl_texture->user_data = nullptr;
+  opengl_texture->width = width;
+  opengl_texture->height = height;
+  return true;
+}
+
+ExternalTexturePixelEGL::ExternalTexturePixelEGL(
+    FlutterDesktopPixelBufferTextureCallback texture_callback,
+    void* user_data)
+    : ExternalTexture(),
+      texture_callback_(texture_callback),
+      user_data_(user_data) {}
+
+bool ExternalTexturePixelEGL::CopyPixelBuffer(size_t& width, size_t& height) {
+  if (!texture_callback_) {
+    return false;
+  }
+
+  const FlutterDesktopPixelBuffer* pixel_buffer =
+      texture_callback_(width, height, user_data_);
+
+  if (!pixel_buffer || !pixel_buffer->buffer) {
+    return false;
+  }
+
+  width = pixel_buffer->width;
+  height = pixel_buffer->height;
+
+  if (state_->gl_texture == 0) {
+    glGenTextures(1, static_cast<GLuint*>(&state_->gl_texture));
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(state_->gl_texture));
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  } else {
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(state_->gl_texture));
+  }
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, pixel_buffer->width,
+               pixel_buffer->height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+               pixel_buffer->buffer);
+  return true;
+}
+
+}  // namespace flutter

--- a/shell/platform/tizen/external_texture_pixel_egl.h
+++ b/shell/platform/tizen/external_texture_pixel_egl.h
@@ -1,0 +1,35 @@
+// Copyright 2020 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef EMBEDDER_EXTERNAL_TEXTURE_PIXEL_EGL_H
+#define EMBEDDER_EXTERNAL_TEXTURE_PIXEL_EGL_H
+
+#include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
+#include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/tizen/external_texture.h"
+
+namespace flutter {
+
+class ExternalTexturePixelEGL : public ExternalTexture {
+ public:
+  ExternalTexturePixelEGL(
+      FlutterDesktopPixelBufferTextureCallback texture_callback,
+      void* user_data);
+
+  ~ExternalTexturePixelEGL() = default;
+
+  bool PopulateTexture(size_t width,
+                       size_t height,
+                       FlutterOpenGLTexture* opengl_texture) override;
+
+  bool CopyPixelBuffer(size_t& width, size_t& height);
+
+ private:
+  FlutterDesktopPixelBufferTextureCallback texture_callback_ = nullptr;
+  void* user_data_ = nullptr;
+};
+
+}  // namespace flutter
+
+#endif  // EMBEDDER_EXTERNAL_TEXTURE_PIXEL_EGL_H

--- a/shell/platform/tizen/external_texture_pixel_evas_gl.cc
+++ b/shell/platform/tizen/external_texture_pixel_evas_gl.cc
@@ -1,0 +1,71 @@
+// Copyright 2020 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "external_texture_pixel_evas_gl.h"
+
+#include "tizen_evas_gl_helper.h"
+extern Evas_GL* g_evas_gl;
+EVAS_GL_GLOBAL_GLES2_DECLARE();
+
+namespace flutter {
+
+bool ExternalTexturePixelEvasGL::PopulateTexture(
+    size_t width,
+    size_t height,
+    FlutterOpenGLTexture* opengl_texture) {
+  if (!CopyPixelBuffer(width, height)) {
+    return false;
+  }
+
+  // Populate the texture object used by the engine.
+  opengl_texture->target = GL_TEXTURE_2D;
+  opengl_texture->name = state_->gl_texture;
+  opengl_texture->format = GL_RGBA8;
+  opengl_texture->destruction_callback = nullptr;
+  opengl_texture->user_data = nullptr;
+  opengl_texture->width = width;
+  opengl_texture->height = height;
+  return true;
+}
+
+ExternalTexturePixelEvasGL::ExternalTexturePixelEvasGL(
+    FlutterDesktopPixelBufferTextureCallback texture_callback,
+    void* user_data)
+    : ExternalTexture(),
+      texture_callback_(texture_callback),
+      user_data_(user_data) {}
+
+bool ExternalTexturePixelEvasGL::CopyPixelBuffer(size_t& width,
+                                                 size_t& height) {
+  if (!texture_callback_) {
+    return false;
+  }
+
+  const FlutterDesktopPixelBuffer* pixel_buffer =
+      texture_callback_(width, height, user_data_);
+
+  if (!pixel_buffer || !pixel_buffer->buffer) {
+    return false;
+  }
+
+  width = pixel_buffer->width;
+  height = pixel_buffer->height;
+
+  if (state_->gl_texture == 0) {
+    glGenTextures(1, static_cast<GLuint*>(&state_->gl_texture));
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(state_->gl_texture));
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  } else {
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(state_->gl_texture));
+  }
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, pixel_buffer->width,
+               pixel_buffer->height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+               pixel_buffer->buffer);
+  return true;
+}
+
+}  // namespace flutter

--- a/shell/platform/tizen/external_texture_pixel_evas_gl.h
+++ b/shell/platform/tizen/external_texture_pixel_evas_gl.h
@@ -1,0 +1,35 @@
+// Copyright 2020 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef EMBEDDER_EXTERNAL_TEXTURE_PIXEL_EVAS_GL_H
+#define EMBEDDER_EXTERNAL_TEXTURE_PIXEL_EVAS_GL_H
+
+#include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
+#include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/tizen/external_texture.h"
+
+namespace flutter {
+
+class ExternalTexturePixelEvasGL : public ExternalTexture {
+ public:
+  ExternalTexturePixelEvasGL(
+      FlutterDesktopPixelBufferTextureCallback texture_callback,
+      void* user_data);
+
+  ~ExternalTexturePixelEvasGL() = default;
+
+  bool PopulateTexture(size_t width,
+                       size_t height,
+                       FlutterOpenGLTexture* opengl_texture) override;
+
+  bool CopyPixelBuffer(size_t& width, size_t& height);
+
+ private:
+  FlutterDesktopPixelBufferTextureCallback texture_callback_ = nullptr;
+  void* user_data_ = nullptr;
+};
+
+}  // namespace flutter
+
+#endif  // EMBEDDER_EXTERNAL_TEXTURE_PIXEL_EVAS_GL_H


### PR DESCRIPTION
Resolves https://github.com/flutter-tizen/engine/issues/321. This change is a partial revert of https://github.com/flutter-tizen/engine/pull/312/commits/d06b6fa2db953e62fcd8b2f01b3fb27414db8082.

Also resolves https://github.com/flutter-tizen/engine/pull/312#discussion_r927364791.

We can't avoid a certain amount of code duplication because `external_texture_pixel_egl.cc` and `external_texture_pixel_evas_gl.cc` should both be compiled into a single binary. Please let me know if there's any better design.

Previous discussion: https://github.com/flutter-tizen/engine/pull/312#discussion_r920651201