### PR TITLE
Explicitly specify symbols to be exported

### DIFF
--- a/shell/platform/embedder/flutter_engine_exports.lst
+++ b/shell/platform/embedder/flutter_engine_exports.lst
@@ -2,13 +2,13 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# Linker script that hides symbols with the prefix "FT_" so that global freetype
-# symbols referenced by Skia are not overriden by an external shared library at
-# runtime.
-
+# Never export symbols internally used by the engine (such as FT_*).
 {
   global:
-    *;
+    kFlutter*;
+    kDart*;
+    FlutterEngine*;
+    FlutterPlatformMessage*;
   local:
-    FT_*;
+    *;
 };


### PR DESCRIPTION
Resolves https://github.com/flutter-tizen/plugins/issues/419. The symbol `TT_RunIns` must not be exposed.

I checked the full list of symbols exposed by `libflutter_engine.so` and it seemed safe to make all the symbols local to the binary except for `*Flutter*` and `kDart*`.