### PR TITLE
Migrate to the new GpuSurfaceTexture API

### DIFF
--- a/shell/platform/tizen/external_texture_surface_egl.h
+++ b/shell/platform/tizen/external_texture_surface_egl.h
@@ -15,7 +15,7 @@ class ExternalTextureSurfaceEGL : public ExternalTexture {
  public:
   ExternalTextureSurfaceEGL(
       ExternalTextureExtensionType gl_extension,
-      FlutterDesktopGpuBufferTextureCallback texture_callback,
+      FlutterDesktopGpuSurfaceTextureCallback texture_callback,
       void* user_data);
 
   virtual ~ExternalTextureSurfaceEGL();
@@ -32,7 +32,7 @@ class ExternalTextureSurfaceEGL : public ExternalTexture {
                        FlutterOpenGLTexture* opengl_texture) override;
 
  private:
-  FlutterDesktopGpuBufferTextureCallback texture_callback_ = nullptr;
+  FlutterDesktopGpuSurfaceTextureCallback texture_callback_ = nullptr;
   void* user_data_ = nullptr;
 };
 

--- a/shell/platform/tizen/external_texture_surface_evas_gl.h
+++ b/shell/platform/tizen/external_texture_surface_evas_gl.h
@@ -15,7 +15,7 @@ class ExternalTextureSurfaceEvasGL : public ExternalTexture {
  public:
   ExternalTextureSurfaceEvasGL(
       ExternalTextureExtensionType gl_extension,
-      FlutterDesktopGpuBufferTextureCallback texture_callback,
+      FlutterDesktopGpuSurfaceTextureCallback texture_callback,
       void* user_data);
 
   virtual ~ExternalTextureSurfaceEvasGL();
@@ -32,7 +32,7 @@ class ExternalTextureSurfaceEvasGL : public ExternalTexture {
                        FlutterOpenGLTexture* opengl_texture) override;
 
  private:
-  FlutterDesktopGpuBufferTextureCallback texture_callback_ = nullptr;
+  FlutterDesktopGpuSurfaceTextureCallback texture_callback_ = nullptr;
   void* user_data_ = nullptr;
 };
 

--- a/shell/platform/tizen/flutter_tizen_texture_registrar.cc
+++ b/shell/platform/tizen/flutter_tizen_texture_registrar.cc
@@ -25,8 +25,8 @@ FlutterTizenTextureRegistrar::FlutterTizenTextureRegistrar(
 int64_t FlutterTizenTextureRegistrar::RegisterTexture(
     const FlutterDesktopTextureInfo* texture_info) {
   if (texture_info->type != kFlutterDesktopPixelBufferTexture &&
-      texture_info->type != kFlutterDesktopGpuBufferTexture) {
-    FT_LOG(Error) << "Attempted to register texture of unsupport type.";
+      texture_info->type != kFlutterDesktopGpuSurfaceTexture) {
+    FT_LOG(Error) << "Attempted to register texture of unsupported type.";
     return -1;
   }
 
@@ -37,9 +37,9 @@ int64_t FlutterTizenTextureRegistrar::RegisterTexture(
     }
   }
 
-  if (texture_info->type == kFlutterDesktopGpuBufferTexture) {
-    if (!texture_info->gpu_buffer_config.callback) {
-      FT_LOG(Error) << "Invalid GPU buffer texture callback.";
+  if (texture_info->type == kFlutterDesktopGpuSurfaceTexture) {
+    if (!texture_info->gpu_surface_config.callback) {
+      FT_LOG(Error) << "Invalid GPU surface texture callback.";
       return -1;
     }
   }
@@ -116,7 +116,7 @@ FlutterTizenTextureRegistrar::CreateExternalTexture(
 #else
       return nullptr;
 #endif
-    case kFlutterDesktopGpuBufferTexture:
+    case kFlutterDesktopGpuSurfaceTexture:
       ExternalTextureExtensionType gl_extension =
           ExternalTextureExtensionType::kNone;
       if (engine_->renderer() && engine_->renderer()->IsSupportedExtension(
@@ -129,13 +129,13 @@ FlutterTizenTextureRegistrar::CreateExternalTexture(
       }
       if (renderer_type == FlutterDesktopRendererType::kEvasGL) {
         return std::make_unique<ExternalTextureSurfaceEvasGL>(
-            gl_extension, texture_info->gpu_buffer_config.callback,
-            texture_info->gpu_buffer_config.user_data);
+            gl_extension, texture_info->gpu_surface_config.callback,
+            texture_info->gpu_surface_config.user_data);
       }
 #ifndef WEARABLE_PROFILE
       return std::make_unique<ExternalTextureSurfaceEGL>(
-          gl_extension, texture_info->gpu_buffer_config.callback,
-          texture_info->gpu_buffer_config.user_data);
+          gl_extension, texture_info->gpu_surface_config.callback,
+          texture_info->gpu_surface_config.user_data);
 #else
       return nullptr;
 #endif

--- a/shell/platform/tizen/flutter_tizen_texture_registrar_unittests.cc
+++ b/shell/platform/tizen/flutter_tizen_texture_registrar_unittests.cc
@@ -54,10 +54,12 @@ TEST_F(FlutterTizenTextureRegistrarTest, RegisterUnregisterTexture) {
   FlutterTizenTextureRegistrar registrar(engine_);
 
   FlutterDesktopTextureInfo texture_info = {};
-  texture_info.type = kFlutterDesktopGpuBufferTexture;
-  texture_info.gpu_buffer_config.callback =
+  texture_info.type = kFlutterDesktopGpuSurfaceTexture;
+  texture_info.gpu_surface_config.callback =
       [](size_t width, size_t height,
-         void* user_data) -> const FlutterDesktopGpuBuffer* { return nullptr; };
+         void* user_data) -> const FlutterDesktopGpuSurfaceDescriptor* {
+    return nullptr;
+  };
 
   int64_t registered_texture_id = 0;
   bool register_called = false;


### PR DESCRIPTION
Migrate from the outdated [`FlutterDesktopGpuBuffer`](https://github.com/flutter-tizen/engine/blob/flutter-3.0.5-tizen/shell/platform/common/public/flutter_texture_registrar.h)-based APIs to the official [`FlutterDesktopGpuSurfaceDescriptor`](https://github.com/flutter-tizen/engine/blob/flutter-3.3.0-tizen/shell/platform/common/public/flutter_texture_registrar.h)-based APIs.

Contributes to https://github.com/flutter-tizen/engine/issues/285.

Plugins that use the relevant texture API must be updated as well.