### PR TITLE
Support TizenRendererEvasGL rotate

### DIFF
--- a/shell/platform/tizen/flutter_tizen_view.cc
+++ b/shell/platform/tizen/flutter_tizen_view.cc
@@ -167,31 +167,33 @@ void FlutterTizenView::OnResize(int32_t left,
 }
 
 void FlutterTizenView::OnRotate(int32_t degree) {
-  rotation_degree_ = degree;
-  // Compute renderer transformation based on the angle of rotation.
-  double rad = (360 - rotation_degree_) * M_PI / 180;
   TizenGeometry geometry = tizen_view_->GetGeometry();
   int32_t width = geometry.width;
   int32_t height = geometry.height;
 
-  double trans_x = 0.0, trans_y = 0.0;
-  if (rotation_degree_ == 90) {
-    trans_y = height;
-  } else if (rotation_degree_ == 180) {
-    trans_x = width;
-    trans_y = height;
-  } else if (rotation_degree_ == 270) {
-    trans_x = width;
-  }
+  if (engine_->renderer()->type() == FlutterDesktopRendererType::kEGL) {
+    rotation_degree_ = degree;
+    // Compute renderer transformation based on the angle of rotation.
+    double rad = (360 - rotation_degree_) * M_PI / 180;
+    double trans_x = 0.0, trans_y = 0.0;
+    if (rotation_degree_ == 90) {
+      trans_y = height;
+    } else if (rotation_degree_ == 180) {
+      trans_x = width;
+      trans_y = height;
+    } else if (rotation_degree_ == 270) {
+      trans_x = width;
+    }
 
-  flutter_transformation_ = {
-      cos(rad), -sin(rad), trans_x,  // x
-      sin(rad), cos(rad),  trans_y,  // y
-      0.0,      0.0,       1.0       // perspective
-  };
+    flutter_transformation_ = {
+        cos(rad), -sin(rad), trans_x,  // x
+        sin(rad), cos(rad),  trans_y,  // y
+        0.0,      0.0,       1.0       // perspective
+    };
 
-  if (rotation_degree_ == 90 || rotation_degree_ == 270) {
-    std::swap(width, height);
+    if (rotation_degree_ == 90 || rotation_degree_ == 270) {
+      std::swap(width, height);
+    }
   }
 
   engine_->renderer()->ResizeSurface(width, height);

--- a/shell/platform/tizen/tizen_window_elementary.cc
+++ b/shell/platform/tizen/tizen_window_elementary.cc
@@ -140,8 +140,6 @@ void TizenWindowElementary::RegisterEventHandlers() {
     auto* self = reinterpret_cast<TizenWindowElementary*>(data);
     if (self->view_delegate_) {
       if (self->elm_win_ == object) {
-        // FIXME
-        FT_UNIMPLEMENTED();
         self->view_delegate_->OnRotate(self->GetRotation());
         elm_win_wm_rotation_manual_rotation_done(self->elm_win_);
       }


### PR DESCRIPTION
TizenRendererEvasGL does not rotate the flutter.
elm_win using evas gl renderer gives width and height with rotation applied.
The flutter just needs to resize to fit the changed width and height.

related issue : https://github.com/flutter-tizen/engine/issues/277