### PR TITLE
Implement FlutterTizenEngine spawn

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1114,6 +1114,441 @@ FlutterEngineResult FlutterEngineRun(size_t version,
   return FlutterEngineRunInitialized(*engine_out);
 }
 
+FlutterEngineResult FlutterEngineSpawn(size_t version,
+                                       const FlutterRendererConfig* config,
+                                       const FlutterProjectArgs* args,
+                                       void* user_data,
+                                       FLUTTER_API_SYMBOL(FlutterEngine)
+                                           engine_spawner,
+                                       FLUTTER_API_SYMBOL(FlutterEngine) *
+                                           engine_out) {
+  // user_data : spawnd FlutterTizenEngine
+  // engine_out : will be spawned engine
+  // Step 0. Figure out arguments for shell spawn.
+  if (version != FLUTTER_ENGINE_VERSION) {
+    return LOG_EMBEDDER_ERROR(
+        kInvalidLibraryVersion,
+        "Flutter embedder version mismatch. There has been a breaking change. "
+        "Please consult the changelog and update the embedder.");
+  }
+
+  if (engine_out == nullptr) {
+    return LOG_EMBEDDER_ERROR(kInvalidArguments,
+                              "The engine out parameter was missing.");
+  }
+
+  if (args == nullptr) {
+    return LOG_EMBEDDER_ERROR(kInvalidArguments,
+                              "The Flutter project arguments were missing.");
+  }
+
+  if (SAFE_ACCESS(args, assets_path, nullptr) == nullptr) {
+    return LOG_EMBEDDER_ERROR(
+        kInvalidArguments,
+        "The assets path in the Flutter project arguments was missing.");
+  }
+
+  if (SAFE_ACCESS(args, main_path__unused__, nullptr) != nullptr) {
+    FML_LOG(WARNING)
+        << "FlutterProjectArgs.main_path is deprecated and should be set null.";
+  }
+
+  if (SAFE_ACCESS(args, packages_path__unused__, nullptr) != nullptr) {
+    FML_LOG(WARNING) << "FlutterProjectArgs.packages_path is deprecated and "
+                        "should be set null.";
+  }
+
+  if (!IsRendererValid(config)) {
+    return LOG_EMBEDDER_ERROR(kInvalidArguments,
+                              "The renderer configuration was invalid.");
+  }
+
+  std::string icu_data_path;
+  if (SAFE_ACCESS(args, icu_data_path, nullptr) != nullptr) {
+    icu_data_path = SAFE_ACCESS(args, icu_data_path, nullptr);
+  }
+
+  if (SAFE_ACCESS(args, persistent_cache_path, nullptr) != nullptr) {
+    std::string persistent_cache_path =
+        SAFE_ACCESS(args, persistent_cache_path, nullptr);
+    flutter::PersistentCache::SetCacheDirectoryPath(persistent_cache_path);
+  }
+
+  if (SAFE_ACCESS(args, is_persistent_cache_read_only, false)) {
+    flutter::PersistentCache::gIsReadOnly = true;
+  }
+
+  fml::CommandLine command_line;
+  if (SAFE_ACCESS(args, command_line_argc, 0) != 0 &&
+      SAFE_ACCESS(args, command_line_argv, nullptr) != nullptr) {
+    command_line = fml::CommandLineFromArgcArgv(
+        SAFE_ACCESS(args, command_line_argc, 0),
+        SAFE_ACCESS(args, command_line_argv, nullptr));
+  }
+
+  flutter::Settings settings = flutter::SettingsFromCommandLine(command_line);
+
+  if (SAFE_ACCESS(args, aot_data, nullptr)) {
+    if (SAFE_ACCESS(args, vm_snapshot_data, nullptr) ||
+        SAFE_ACCESS(args, vm_snapshot_instructions, nullptr) ||
+        SAFE_ACCESS(args, isolate_snapshot_data, nullptr) ||
+        SAFE_ACCESS(args, isolate_snapshot_instructions, nullptr)) {
+      return LOG_EMBEDDER_ERROR(
+          kInvalidArguments,
+          "Multiple AOT sources specified. Embedders should provide either "
+          "*_snapshot_* buffers or aot_data, not both.");
+    }
+  }
+
+  PopulateSnapshotMappingCallbacks(args, settings);
+
+  settings.icu_data_path = icu_data_path;
+  settings.assets_path = args->assets_path;
+  settings.leak_vm = !SAFE_ACCESS(args, shutdown_dart_vm_when_done, false);
+  settings.old_gen_heap_size = SAFE_ACCESS(args, dart_old_gen_heap_size, -1);
+
+  if (!flutter::DartVM::IsRunningPrecompiledCode()) {
+    // Verify the assets path contains Dart 2 kernel assets.
+    const std::string kApplicationKernelSnapshotFileName = "kernel_blob.bin";
+    std::string application_kernel_path = fml::paths::JoinPaths(
+        {settings.assets_path, kApplicationKernelSnapshotFileName});
+    if (!fml::IsFile(application_kernel_path)) {
+      return LOG_EMBEDDER_ERROR(
+          kInvalidArguments,
+          "Not running in AOT mode but could not resolve the kernel binary.");
+    }
+    settings.application_kernel_asset = kApplicationKernelSnapshotFileName;
+  }
+
+  settings.task_observer_add = [](intptr_t key, fml::closure callback) {
+    fml::MessageLoop::GetCurrent().AddTaskObserver(key, std::move(callback));
+  };
+  settings.task_observer_remove = [](intptr_t key) {
+    fml::MessageLoop::GetCurrent().RemoveTaskObserver(key);
+  };
+  if (SAFE_ACCESS(args, root_isolate_create_callback, nullptr) != nullptr) {
+    VoidCallback callback =
+        SAFE_ACCESS(args, root_isolate_create_callback, nullptr);
+    settings.root_isolate_create_callback =
+        [callback, user_data](const auto& isolate) { callback(user_data); };
+  }
+  if (SAFE_ACCESS(args, log_message_callback, nullptr) != nullptr) {
+    FlutterLogMessageCallback callback =
+        SAFE_ACCESS(args, log_message_callback, nullptr);
+    settings.log_message_callback = [callback, user_data](
+                                        const std::string& tag,
+                                        const std::string& message) {
+      callback(tag.c_str(), message.c_str(), user_data);
+    };
+  }
+  if (SAFE_ACCESS(args, log_tag, nullptr) != nullptr) {
+    settings.log_tag = SAFE_ACCESS(args, log_tag, nullptr);
+  }
+
+  flutter::PlatformViewEmbedder::UpdateSemanticsNodesCallback
+      update_semantics_nodes_callback = nullptr;
+  if (SAFE_ACCESS(args, update_semantics_node_callback, nullptr) != nullptr) {
+    update_semantics_nodes_callback =
+        [ptr = args->update_semantics_node_callback,
+         user_data](flutter::SemanticsNodeUpdates update) {
+          for (const auto& value : update) {
+            const auto& node = value.second;
+            SkMatrix transform = node.transform.asM33();
+            FlutterTransformation flutter_transform{
+                transform.get(SkMatrix::kMScaleX),
+                transform.get(SkMatrix::kMSkewX),
+                transform.get(SkMatrix::kMTransX),
+                transform.get(SkMatrix::kMSkewY),
+                transform.get(SkMatrix::kMScaleY),
+                transform.get(SkMatrix::kMTransY),
+                transform.get(SkMatrix::kMPersp0),
+                transform.get(SkMatrix::kMPersp1),
+                transform.get(SkMatrix::kMPersp2)};
+            const FlutterSemanticsNode embedder_node{
+                sizeof(FlutterSemanticsNode),
+                node.id,
+                static_cast<FlutterSemanticsFlag>(node.flags),
+                static_cast<FlutterSemanticsAction>(node.actions),
+                node.textSelectionBase,
+                node.textSelectionExtent,
+                node.scrollChildren,
+                node.scrollIndex,
+                node.scrollPosition,
+                node.scrollExtentMax,
+                node.scrollExtentMin,
+                node.elevation,
+                node.thickness,
+                node.label.c_str(),
+                node.hint.c_str(),
+                node.value.c_str(),
+                node.increasedValue.c_str(),
+                node.decreasedValue.c_str(),
+                static_cast<FlutterTextDirection>(node.textDirection),
+                FlutterRect{node.rect.fLeft, node.rect.fTop, node.rect.fRight,
+                            node.rect.fBottom},
+                flutter_transform,
+                node.childrenInTraversalOrder.size(),
+                node.childrenInTraversalOrder.data(),
+                node.childrenInHitTestOrder.data(),
+                node.customAccessibilityActions.size(),
+                node.customAccessibilityActions.data(),
+                node.platformViewId,
+            };
+            ptr(&embedder_node, user_data);
+          }
+          const FlutterSemanticsNode batch_end_sentinel = {
+              sizeof(FlutterSemanticsNode),
+              kFlutterSemanticsNodeIdBatchEnd,
+          };
+          ptr(&batch_end_sentinel, user_data);
+        };
+  }
+
+  flutter::PlatformViewEmbedder::UpdateSemanticsCustomActionsCallback
+      update_semantics_custom_actions_callback = nullptr;
+  if (SAFE_ACCESS(args, update_semantics_custom_action_callback, nullptr) !=
+      nullptr) {
+    update_semantics_custom_actions_callback =
+        [ptr = args->update_semantics_custom_action_callback,
+         user_data](flutter::CustomAccessibilityActionUpdates actions) {
+          for (const auto& value : actions) {
+            const auto& action = value.second;
+            const FlutterSemanticsCustomAction embedder_action = {
+                sizeof(FlutterSemanticsCustomAction),
+                action.id,
+                static_cast<FlutterSemanticsAction>(action.overrideId),
+                action.label.c_str(),
+                action.hint.c_str(),
+            };
+            ptr(&embedder_action, user_data);
+          }
+          const FlutterSemanticsCustomAction batch_end_sentinel = {
+              sizeof(FlutterSemanticsCustomAction),
+              kFlutterSemanticsCustomActionIdBatchEnd,
+          };
+          ptr(&batch_end_sentinel, user_data);
+        };
+  }
+
+  flutter::PlatformViewEmbedder::PlatformMessageResponseCallback
+      platform_message_response_callback = nullptr;
+  if (SAFE_ACCESS(args, platform_message_callback, nullptr) != nullptr) {
+    platform_message_response_callback =
+        [ptr = args->platform_message_callback,
+         user_data](std::unique_ptr<flutter::PlatformMessage> message) {
+          auto handle = new FlutterPlatformMessageResponseHandle();
+          const FlutterPlatformMessage incoming_message = {
+              sizeof(FlutterPlatformMessage),  // struct_size
+              message->channel().c_str(),      // channel
+              message->data().GetMapping(),    // message
+              message->data().GetSize(),       // message_size
+              handle,                          // response_handle
+          };
+          handle->message = std::move(message);
+          return ptr(&incoming_message, user_data);
+        };
+  }
+
+  flutter::VsyncWaiterEmbedder::VsyncCallback vsync_callback = nullptr;
+  if (SAFE_ACCESS(args, vsync_callback, nullptr) != nullptr) {
+    vsync_callback = [ptr = args->vsync_callback, user_data](intptr_t baton) {
+      return ptr(user_data, baton);
+    };
+  }
+
+  flutter::PlatformViewEmbedder::ComputePlatformResolvedLocaleCallback
+      compute_platform_resolved_locale_callback = nullptr;
+  if (SAFE_ACCESS(args, compute_platform_resolved_locale_callback, nullptr) !=
+      nullptr) {
+    compute_platform_resolved_locale_callback =
+        [ptr = args->compute_platform_resolved_locale_callback](
+            const std::vector<std::string>& supported_locales_data) {
+          const size_t number_of_strings_per_locale = 3;
+          size_t locale_count =
+              supported_locales_data.size() / number_of_strings_per_locale;
+          std::vector<FlutterLocale> supported_locales;
+          std::vector<const FlutterLocale*> supported_locales_ptr;
+          for (size_t i = 0; i < locale_count; ++i) {
+            supported_locales.push_back(
+                {.struct_size = sizeof(FlutterLocale),
+                 .language_code =
+                     supported_locales_data[i * number_of_strings_per_locale +
+                                            0]
+                         .c_str(),
+                 .country_code =
+                     supported_locales_data[i * number_of_strings_per_locale +
+                                            1]
+                         .c_str(),
+                 .script_code =
+                     supported_locales_data[i * number_of_strings_per_locale +
+                                            2]
+                         .c_str(),
+                 .variant_code = nullptr});
+            supported_locales_ptr.push_back(&supported_locales[i]);
+          }
+
+          const FlutterLocale* result =
+              ptr(supported_locales_ptr.data(), locale_count);
+
+          std::unique_ptr<std::vector<std::string>> out =
+              std::make_unique<std::vector<std::string>>();
+          if (result) {
+            std::string language_code(SAFE_ACCESS(result, language_code, ""));
+            if (language_code != "") {
+              out->push_back(language_code);
+              out->emplace_back(SAFE_ACCESS(result, country_code, ""));
+              out->emplace_back(SAFE_ACCESS(result, script_code, ""));
+            }
+          }
+          return out;
+        };
+  }
+
+  flutter::PlatformViewEmbedder::OnPreEngineRestartCallback
+      on_pre_engine_restart_callback = nullptr;
+  if (SAFE_ACCESS(args, on_pre_engine_restart_callback, nullptr) != nullptr) {
+    on_pre_engine_restart_callback = [ptr =
+                                          args->on_pre_engine_restart_callback,
+                                      user_data]() { return ptr(user_data); };
+  }
+
+  auto external_view_embedder_result =
+      InferExternalViewEmbedderFromArgs(SAFE_ACCESS(args, compositor, nullptr));
+  if (external_view_embedder_result.second) {
+    return LOG_EMBEDDER_ERROR(kInvalidArguments,
+                              "Compositor arguments were invalid.");
+  }
+
+  flutter::PlatformViewEmbedder::PlatformDispatchTable platform_dispatch_table =
+      {
+          update_semantics_nodes_callback,            //
+          update_semantics_custom_actions_callback,   //
+          platform_message_response_callback,         //
+          vsync_callback,                             //
+          compute_platform_resolved_locale_callback,  //
+          on_pre_engine_restart_callback,             //
+      };
+
+  auto on_create_platform_view = InferPlatformViewCreationCallback(
+      config, user_data, platform_dispatch_table,
+      std::move(external_view_embedder_result.first));
+
+  if (!on_create_platform_view) {
+    return LOG_EMBEDDER_ERROR(
+        kInternalInconsistency,
+        "Could not infer platform view creation callback.");
+  }
+
+  flutter::Shell::CreateCallback<flutter::Rasterizer> on_create_rasterizer =
+      [](flutter::Shell& shell) {
+        return std::make_unique<flutter::Rasterizer>(shell);
+      };
+
+  using ExternalTextureResolver = flutter::EmbedderExternalTextureResolver;
+  std::unique_ptr<ExternalTextureResolver> external_texture_resolver;
+  external_texture_resolver = std::make_unique<ExternalTextureResolver>();
+
+#ifdef SHELL_ENABLE_GL
+  flutter::EmbedderExternalTextureGL::ExternalTextureCallback
+      external_texture_callback;
+  if (config->type == kOpenGL) {
+    const FlutterOpenGLRendererConfig* open_gl_config = &config->open_gl;
+    if (SAFE_ACCESS(open_gl_config, gl_external_texture_frame_callback,
+                    nullptr) != nullptr) {
+      external_texture_callback =
+          [ptr = open_gl_config->gl_external_texture_frame_callback, user_data](
+              int64_t texture_identifier, size_t width,
+              size_t height) -> std::unique_ptr<FlutterOpenGLTexture> {
+        std::unique_ptr<FlutterOpenGLTexture> texture =
+            std::make_unique<FlutterOpenGLTexture>();
+        if (!ptr(user_data, texture_identifier, width, height, texture.get())) {
+          return nullptr;
+        }
+        return texture;
+      };
+      external_texture_resolver =
+          std::make_unique<ExternalTextureResolver>(external_texture_callback);
+    }
+  }
+#endif
+#ifdef SHELL_ENABLE_METAL
+  flutter::EmbedderExternalTextureMetal::ExternalTextureCallback
+      external_texture_metal_callback;
+  if (config->type == kMetal) {
+    const FlutterMetalRendererConfig* metal_config = &config->metal;
+    if (SAFE_ACCESS(metal_config, external_texture_frame_callback, nullptr)) {
+      external_texture_metal_callback =
+          [ptr = metal_config->external_texture_frame_callback, user_data](
+              int64_t texture_identifier, size_t width,
+              size_t height) -> std::unique_ptr<FlutterMetalExternalTexture> {
+        std::unique_ptr<FlutterMetalExternalTexture> texture =
+            std::make_unique<FlutterMetalExternalTexture>();
+        texture->struct_size = sizeof(FlutterMetalExternalTexture);
+        if (!ptr(user_data, texture_identifier, width, height, texture.get())) {
+          return nullptr;
+        }
+        return texture;
+      };
+      external_texture_resolver = std::make_unique<ExternalTextureResolver>(
+          external_texture_metal_callback);
+    }
+  }
+#endif
+
+  auto run_configuration =
+      flutter::RunConfiguration::InferFromSettings(settings);
+
+  if (SAFE_ACCESS(args, custom_dart_entrypoint, nullptr) != nullptr) {
+    auto dart_entrypoint = std::string{args->custom_dart_entrypoint};
+    if (dart_entrypoint.size() != 0) {
+      run_configuration.SetEntrypoint(std::move(dart_entrypoint));
+    }
+  }
+
+  if (SAFE_ACCESS(args, dart_entrypoint_argc, 0) > 0) {
+    if (SAFE_ACCESS(args, dart_entrypoint_argv, nullptr) == nullptr) {
+      return LOG_EMBEDDER_ERROR(kInvalidArguments,
+                                "Could not determine Dart entrypoint arguments "
+                                "as dart_entrypoint_argc "
+                                "was set, but dart_entrypoint_argv was null.");
+    }
+    std::vector<std::string> arguments(args->dart_entrypoint_argc);
+    for (int i = 0; i < args->dart_entrypoint_argc; ++i) {
+      arguments[i] = std::string{args->dart_entrypoint_argv[i]};
+    }
+    run_configuration.SetEntrypointArgs(std::move(arguments));
+  }
+
+  if (!run_configuration.IsValid()) {
+    return LOG_EMBEDDER_ERROR(
+        kInvalidArguments,
+        "Could not infer the Flutter project to run from given arguments.");
+  }
+
+  // Create the engine but don't launch the shell or run the root isolate.
+  // Spawn the engine by using spawner
+
+  auto embedder_engine_spawner =
+      reinterpret_cast<flutter::EmbedderEngine*>(engine_spawner);
+
+  auto embedder_engine = embedder_engine_spawner->SpawnEmbedderEngine(
+      std::move(settings),           //
+      std::move(run_configuration),  //
+      on_create_platform_view,       //
+      on_create_rasterizer,          //
+      std::move(external_texture_resolver));
+
+  if (!embedder_engine->NotifyCreated()) {
+    return LOG_EMBEDDER_ERROR(kInternalInconsistency,
+                              "Could not create platform view components.");
+  }
+
+  *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(
+      embedder_engine.release());
+
+  return kSuccess;
+}
+
 FlutterEngineResult FlutterEngineInitialize(size_t version,
                                             const FlutterRendererConfig* config,
                                             const FlutterProjectArgs* args,
@@ -2642,6 +3077,7 @@ FlutterEngineResult FlutterEngineGetProcAddresses(
   SET_PROC(CreateAOTData, FlutterEngineCreateAOTData);
   SET_PROC(CollectAOTData, FlutterEngineCollectAOTData);
   SET_PROC(Run, FlutterEngineRun);
+  SET_PROC(Spawn, FlutterEngineSpawn);
   SET_PROC(Shutdown, FlutterEngineShutdown);
   SET_PROC(Initialize, FlutterEngineInitialize);
   SET_PROC(Deinitialize, FlutterEngineDeinitialize);

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1200,8 +1200,6 @@ FlutterEngineResult FlutterEngineSpawn(size_t version,
     }
   }
 
-  PopulateSnapshotMappingCallbacks(args, settings);
-
   settings.icu_data_path = icu_data_path;
   settings.assets_path = args->assets_path;
   settings.leak_vm = !SAFE_ACCESS(args, shutdown_dart_vm_when_done, false);

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1824,6 +1824,15 @@ FlutterEngineResult FlutterEngineRun(size_t version,
                                      FLUTTER_API_SYMBOL(FlutterEngine) *
                                          engine_out);
 
+FLUTTER_EXPORT
+FlutterEngineResult FlutterEngineSpawn(size_t version,
+                                       const FlutterRendererConfig* config,
+                                       const FlutterProjectArgs* args,
+                                       void* user_data,
+                                       FLUTTER_API_SYMBOL(FlutterEngine)
+                                           spawner,
+                                       FLUTTER_API_SYMBOL(FlutterEngine) *
+                                           engine_out);
 //------------------------------------------------------------------------------
 /// @brief      Shuts down a Flutter engine instance. The engine handle is no
 ///             longer valid for any calls in the embedder API after this point.
@@ -2441,6 +2450,13 @@ typedef FlutterEngineResult (*FlutterEngineRunFnPtr)(
     const FlutterProjectArgs* args,
     void* user_data,
     FLUTTER_API_SYMBOL(FlutterEngine) * engine_out);
+typedef FlutterEngineResult (*FlutterEngineSpawnFnPtr)(
+    size_t version,
+    const FlutterRendererConfig* config,
+    const FlutterProjectArgs* args,
+    void* user_data,
+    FLUTTER_API_SYMBOL(FlutterEngine) engine_spawner,
+    FLUTTER_API_SYMBOL(FlutterEngine) * engine_out);
 typedef FlutterEngineResult (*FlutterEngineShutdownFnPtr)(
     FLUTTER_API_SYMBOL(FlutterEngine) engine);
 typedef FlutterEngineResult (*FlutterEngineInitializeFnPtr)(
@@ -2554,6 +2570,7 @@ typedef struct {
   FlutterEngineCreateAOTDataFnPtr CreateAOTData;
   FlutterEngineCollectAOTDataFnPtr CollectAOTData;
   FlutterEngineRunFnPtr Run;
+  FlutterEngineSpawnFnPtr Spawn;
   FlutterEngineShutdownFnPtr Shutdown;
   FlutterEngineInitializeFnPtr Initialize;
   FlutterEngineDeinitializeFnPtr Deinitialize;

--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -22,14 +22,14 @@ struct ShellArgs {
 };
 
 EmbedderEngine::EmbedderEngine(
-    std::unique_ptr<EmbedderThreadHost> thread_host,
+    std::shared_ptr<EmbedderThreadHost> thread_host,
     flutter::TaskRunners task_runners,
     flutter::Settings settings,
     RunConfiguration run_configuration,
     Shell::CreateCallback<PlatformView> on_create_platform_view,
     Shell::CreateCallback<Rasterizer> on_create_rasterizer,
     std::unique_ptr<EmbedderExternalTextureResolver> external_texture_resolver)
-    : thread_host_(std::move(thread_host)),
+    : thread_host_(thread_host),
       task_runners_(task_runners),
       run_configuration_(std::move(run_configuration)),
       shell_args_(std::make_unique<ShellArgs>(std::move(settings),
@@ -289,6 +289,31 @@ bool EmbedderEngine::ScheduleFrame() {
 Shell& EmbedderEngine::GetShell() {
   FML_DCHECK(shell_);
   return *shell_.get();
+}
+
+std::unique_ptr<EmbedderEngine> EmbedderEngine::SpawnEmbedderEngine(
+    flutter::Settings settings,
+    RunConfiguration run_configuration,
+    Shell::CreateCallback<PlatformView> on_create_platform_view,
+    Shell::CreateCallback<Rasterizer> on_create_rasterizer,
+    std::unique_ptr<EmbedderExternalTextureResolver>
+        external_texture_resolver) {
+  auto engine = std::make_unique<EmbedderEngine>(
+      thread_host_, thread_host_->GetTaskRunners(),
+      std::move(settings),           //
+      std::move(run_configuration),  //
+      on_create_platform_view,       //
+      on_create_rasterizer,          //
+      std::move(external_texture_resolver));
+
+  auto shell =
+      shell_->Spawn(std::move(engine->run_configuration_), std::string(),
+                    on_create_platform_view, on_create_rasterizer);
+
+  engine->shell_ = std::move(shell);
+  engine->shell_args_.reset();
+
+  return engine;
 }
 
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_engine.h
+++ b/shell/platform/embedder/embedder_engine.h
@@ -22,7 +22,7 @@ struct ShellArgs;
 // instance of the Flutter engine.
 class EmbedderEngine {
  public:
-  EmbedderEngine(std::unique_ptr<EmbedderThreadHost> thread_host,
+  EmbedderEngine(std::shared_ptr<EmbedderThreadHost> thread_host,
                  TaskRunners task_runners,
                  Settings settings,
                  RunConfiguration run_configuration,
@@ -85,8 +85,16 @@ class EmbedderEngine {
 
   Shell& GetShell();
 
+  std::unique_ptr<EmbedderEngine> SpawnEmbedderEngine(
+      flutter::Settings settings,
+      RunConfiguration run_configuration,
+      Shell::CreateCallback<PlatformView> on_create_platform_view,
+      Shell::CreateCallback<Rasterizer> on_create_rasterizer,
+      std::unique_ptr<EmbedderExternalTextureResolver>
+          external_texture_resolver);
+
  private:
-  const std::unique_ptr<EmbedderThreadHost> thread_host_;
+  const std::shared_ptr<EmbedderThreadHost> thread_host_;
   TaskRunners task_runners_;
   RunConfiguration run_configuration_;
   std::unique_ptr<ShellArgs> shell_args_;

--- a/shell/platform/tizen/BUILD.gn
+++ b/shell/platform/tizen/BUILD.gn
@@ -129,6 +129,7 @@ template("embedder") {
       "flutter_tizen.cc",
       "flutter_tizen_elementary.cc",
       "flutter_tizen_engine.cc",
+      "flutter_tizen_engine_group.cc",
       "flutter_tizen_texture_registrar.cc",
       "flutter_tizen_view.cc",
       "logger.cc",

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -69,9 +69,11 @@ FlutterDesktopEngineRef FlutterDesktopEngineCreate(
   if (project.GetArgumentValue("--tizen-logging-port", &logging_port)) {
     flutter::Logger::SetLoggingPort(std::stoi(logging_port));
   }
-  flutter::Logger::Start();
-
   auto& engine_group = flutter::FlutterTizenEngineGroup::GetInstance();
+
+  if (engine_group.GetEngineCount() <= 0) {
+    flutter::Logger::Start();
+  }
   auto engine = engine_group.MakeEngineWithProject(project);
   return HandleForEngine(engine);
 }
@@ -81,7 +83,10 @@ bool FlutterDesktopEngineRun(const FlutterDesktopEngineRef engine) {
 }
 
 void FlutterDesktopEngineShutdown(FlutterDesktopEngineRef engine_ref) {
-  flutter::Logger::Stop();
+  auto& engine_group = flutter::FlutterTizenEngineGroup::GetInstance();
+  if (engine_group.GetEngineCount() <= 1) {
+    flutter::Logger::Stop();
+  }
 
   flutter::FlutterTizenEngine* engine = EngineFromHandle(engine_ref);
   engine->StopEngine();

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -10,6 +10,7 @@
 #include "flutter/shell/platform/common/incoming_message_dispatcher.h"
 #include "flutter/shell/platform/tizen/flutter_project_bundle.h"
 #include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
+#include "flutter/shell/platform/tizen/flutter_tizen_engine_group.h"
 #include "flutter/shell/platform/tizen/flutter_tizen_view.h"
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/public/flutter_platform_view.h"
@@ -70,12 +71,13 @@ FlutterDesktopEngineRef FlutterDesktopEngineCreate(
   }
   flutter::Logger::Start();
 
-  auto engine = std::make_unique<flutter::FlutterTizenEngine>(project);
-  return HandleForEngine(engine.release());
+  auto& engine_group = flutter::FlutterTizenEngineGroup::GetInstance();
+  auto engine = engine_group.MakeEngineWithProject(project);
+  return HandleForEngine(engine);
 }
 
 bool FlutterDesktopEngineRun(const FlutterDesktopEngineRef engine) {
-  return EngineFromHandle(engine)->RunEngine();
+  return EngineFromHandle(engine)->RunOrSpawnEngine();
 }
 
 void FlutterDesktopEngineShutdown(FlutterDesktopEngineRef engine_ref) {
@@ -222,7 +224,7 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromNewWindow(
       std::unique_ptr<flutter::FlutterTizenEngine>(EngineFromHandle(engine)));
   view->CreateRenderSurface(window_properties.renderer_type);
   if (!view->engine()->IsRunning()) {
-    if (!view->engine()->RunEngine()) {
+    if (!view->engine()->RunOrSpawnEngine()) {
       return nullptr;
     }
   }

--- a/shell/platform/tizen/flutter_tizen.cc
+++ b/shell/platform/tizen/flutter_tizen.cc
@@ -89,8 +89,7 @@ void FlutterDesktopEngineShutdown(FlutterDesktopEngineRef engine_ref) {
   }
 
   flutter::FlutterTizenEngine* engine = EngineFromHandle(engine_ref);
-  engine->StopEngine();
-  delete engine;
+  engine_group.RemoveEngine(engine);
 }
 
 FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetView(
@@ -224,9 +223,7 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromNewWindow(
 
   auto view = std::make_unique<flutter::FlutterTizenView>(std::move(window));
 
-  // Take ownership of the engine, starting it if necessary.
-  view->SetEngine(
-      std::unique_ptr<flutter::FlutterTizenEngine>(EngineFromHandle(engine)));
+  view->SetEngine(EngineFromHandle(engine));
   view->CreateRenderSurface(window_properties.renderer_type);
   if (!view->engine()->IsRunning()) {
     if (!view->engine()->RunOrSpawnEngine()) {

--- a/shell/platform/tizen/flutter_tizen_elementary.cc
+++ b/shell/platform/tizen/flutter_tizen_elementary.cc
@@ -8,6 +8,8 @@
 #include "flutter/shell/platform/tizen/flutter_tizen_view.h"
 #include "flutter/shell/platform/tizen/tizen_view_elementary.h"
 
+#include "flutter/shell/platform/tizen/logger.h"
+
 namespace {
 
 // Returns the engine corresponding to the given opaque API handle.
@@ -38,7 +40,7 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromElmParent(
       std::unique_ptr<flutter::FlutterTizenEngine>(EngineFromHandle(engine)));
   view->CreateRenderSurface(FlutterDesktopRendererType::kEvasGL);
   if (!view->engine()->IsRunning()) {
-    if (!view->engine()->RunEngine()) {
+    if (!view->engine()->RunOrSpawnEngine()) {
       return nullptr;
     }
   }

--- a/shell/platform/tizen/flutter_tizen_elementary.cc
+++ b/shell/platform/tizen/flutter_tizen_elementary.cc
@@ -35,9 +35,8 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromElmParent(
   auto view =
       std::make_unique<flutter::FlutterTizenView>(std::move(tizen_view));
 
-  // Take ownership of the engine, starting it if necessary.
-  view->SetEngine(
-      std::unique_ptr<flutter::FlutterTizenEngine>(EngineFromHandle(engine)));
+  // Starting it if necessary.
+  view->SetEngine(EngineFromHandle(engine));
   view->CreateRenderSurface(FlutterDesktopRendererType::kEvasGL);
   if (!view->engine()->IsRunning()) {
     if (!view->engine()->RunOrSpawnEngine()) {

--- a/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/shell/platform/tizen/flutter_tizen_engine.cc
@@ -14,6 +14,7 @@
 #include "flutter/shell/platform/tizen/flutter_platform_node_delegate_tizen.h"
 #include "flutter/shell/platform/tizen/tizen_renderer_egl.h"
 #endif
+#include "flutter/shell/platform/tizen/flutter_tizen_engine_group.h"
 #include "flutter/shell/platform/tizen/flutter_tizen_view.h"
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/system_utils.h"
@@ -98,6 +99,16 @@ void FlutterTizenEngine::CreateRenderer(
     renderer_ = std::make_unique<TizenRendererEgl>();
   }
 #endif
+}
+
+bool FlutterTizenEngine::RunOrSpawnEngine() {
+  auto& engine_group = FlutterTizenEngineGroup::GetInstance();
+  if (engine_group.GetEngineCount() <= 1) {
+    return RunEngine();
+  } else {
+    auto* spawner = engine_group.GetEngineSpawner();
+    return SpawnEngine(spawner);
+  }
 }
 
 bool FlutterTizenEngine::RunEngine() {
@@ -222,6 +233,131 @@ bool FlutterTizenEngine::RunEngine() {
 
   FlutterEngineResult result = embedder_api_.Run(
       FLUTTER_ENGINE_VERSION, &renderer_config, &args, this, &engine_);
+  if (result != kSuccess || engine_ == nullptr) {
+    FT_LOG(Error) << "Failed to start the Flutter engine with error: "
+                  << result;
+    return false;
+  }
+
+  internal_plugin_registrar_ =
+      std::make_unique<PluginRegistrar>(plugin_registrar_.get());
+  accessibility_channel_ = std::make_unique<AccessibilityChannel>(
+      internal_plugin_registrar_->messenger());
+  app_control_channel_ = std::make_unique<AppControlChannel>(
+      internal_plugin_registrar_->messenger());
+  lifecycle_channel_ = std::make_unique<LifecycleChannel>(
+      internal_plugin_registrar_->messenger());
+  settings_channel_ = std::make_unique<SettingsChannel>(
+      internal_plugin_registrar_->messenger());
+
+  if (IsHeaded()) {
+    texture_registrar_ = std::make_unique<FlutterTizenTextureRegistrar>(this);
+    key_event_channel_ = std::make_unique<KeyEventChannel>(
+        internal_plugin_registrar_->messenger(),
+        [this](const FlutterKeyEvent& event, FlutterKeyEventCallback callback,
+               void* user_data) { SendKeyEvent(event, callback, user_data); });
+    navigation_channel_ = std::make_unique<NavigationChannel>(
+        internal_plugin_registrar_->messenger());
+    platform_view_channel_ = std::make_unique<PlatformViewChannel>(
+        internal_plugin_registrar_->messenger());
+  }
+
+  accessibility_settings_ = std::make_unique<AccessibilitySettings>(this);
+
+  SetupLocales();
+
+  return true;
+}
+
+bool FlutterTizenEngine::SpawnEngine(FlutterTizenEngine* spawner) {
+  if (engine_ != nullptr) {
+    FT_LOG(Error) << "The engine has already started.";
+    return false;
+  }
+  if (IsHeaded() && !renderer_->IsValid()) {
+    FT_LOG(Error) << "The display was not valid.";
+    return false;
+  }
+
+  if (!project_->HasValidPaths()) {
+    FT_LOG(Error) << "Missing or unresolvable path to assets.";
+    return false;
+  }
+  std::string assets_path_string = project_->assets_path().u8string();
+  std::string icu_path_string = project_->icu_path().u8string();
+  if (embedder_api_.RunsAOTCompiledDartCode()) {
+    aot_data_ = project_->LoadAotData(embedder_api_);
+    if (!aot_data_) {
+      FT_LOG(Error) << "Unable to start engine without AOT data.";
+      return false;
+    }
+  }
+
+  // FlutterProjectArgs is expecting a full argv, so when processing it for
+  // flags the first item is treated as the executable and ignored. Add a dummy
+  // value so that all provided arguments are used.
+  std::vector<std::string> engine_args = project_->engine_arguments();
+  std::vector<const char*> engine_argv = {"placeholder"};
+  std::transform(
+      engine_args.begin(), engine_args.end(), std::back_inserter(engine_argv),
+      [](const std::string& arg) -> const char* { return arg.c_str(); });
+
+  const std::vector<std::string>& entrypoint_args =
+      project_->dart_entrypoint_arguments();
+  std::vector<const char*> entrypoint_argv;
+  std::transform(
+      entrypoint_args.begin(), entrypoint_args.end(),
+      std::back_inserter(entrypoint_argv),
+      [](const std::string& arg) -> const char* { return arg.c_str(); });
+
+  FlutterProjectArgs args = {};
+  args.struct_size = sizeof(FlutterProjectArgs);
+  args.assets_path = assets_path_string.c_str();
+  args.icu_data_path = icu_path_string.c_str();
+  args.command_line_argc = static_cast<int>(engine_argv.size());
+  args.command_line_argv =
+      engine_argv.size() > 0 ? engine_argv.data() : nullptr;
+  args.dart_entrypoint_argc = static_cast<int>(entrypoint_argv.size());
+  args.dart_entrypoint_argv =
+      entrypoint_argv.size() > 0 ? entrypoint_argv.data() : nullptr;
+  args.platform_message_callback =
+      [](const FlutterPlatformMessage* engine_message, void* user_data) {
+        if (engine_message->struct_size != sizeof(FlutterPlatformMessage)) {
+          FT_LOG(Error) << "Invalid message size received. Expected: "
+                        << sizeof(FlutterPlatformMessage) << ", but received "
+                        << engine_message->struct_size;
+          return;
+        }
+        auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+        FlutterDesktopMessage message =
+            engine->ConvertToDesktopMessage(*engine_message);
+        engine->message_dispatcher_->HandleMessage(message);
+      };
+  if (aot_data_) {
+    args.aot_data = aot_data_.get();
+  }
+  if (!project_->custom_dart_entrypoint().empty()) {
+    args.custom_dart_entrypoint = project_->custom_dart_entrypoint().c_str();
+  }
+#ifndef WEARABLE_PROFILE
+  args.update_semantics_node_callback = OnUpdateSemanticsNode;
+  args.update_semantics_custom_action_callback = OnUpdateSemanticsCustomActions;
+
+  if (IsHeaded() && renderer_->type() == FlutterDesktopRendererType::kEGL) {
+    vsync_waiter_ = std::make_unique<TizenVsyncWaiter>(this);
+    args.vsync_callback = [](void* user_data, intptr_t baton) -> void {
+      auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+      engine->vsync_waiter_->AsyncWaitForVsync(baton);
+    };
+  }
+#endif
+
+  FlutterRendererConfig renderer_config = GetRendererConfig();
+
+  FlutterEngineResult result =
+      embedder_api_.Spawn(FLUTTER_ENGINE_VERSION, &renderer_config, &args, this,
+                          spawner->engine_, &engine_);
+
   if (result != kSuccess || engine_ == nullptr) {
     FT_LOG(Error) << "Failed to start the Flutter engine with error: "
                   << result;
@@ -568,5 +704,81 @@ void FlutterTizenEngine::OnUpdateSemanticsCustomActions(
   }
 }
 #endif
+
+// FlutterProjectArgs FlutterTizenEngine::GetProjectArgsForSpawn() {
+//   std::string assets_path_string = project_->assets_path().u8string();
+//   std::string icu_path_string = project_->icu_path().u8string();
+//   if (embedder_api_.RunsAOTCompiledDartCode()) {
+//     aot_data_ = project_->LoadAotData(embedder_api_);
+//     if (!aot_data_) {
+//       FT_LOG(Error) << "Unable to start engine without AOT data.";
+//     }
+//   }
+
+//   // FlutterProjectArgs is expecting a full argv, so when processing it for
+//   // flags the first item is treated as the executable and ignored. Add a
+//   dummy
+//   // value so that all provided arguments are used.
+//   std::vector<std::string> engine_args = project_->engine_arguments();
+//   std::vector<const char*> engine_argv = {"placeholder"};
+//   std::transform(
+//       engine_args.begin(), engine_args.end(),
+//       std::back_inserter(engine_argv),
+//       [](const std::string& arg) -> const char* { return arg.c_str(); });
+
+//   const std::vector<std::string>& entrypoint_args =
+//       project_->dart_entrypoint_arguments();
+//   std::vector<const char*> entrypoint_argv;
+//   std::transform(
+//       entrypoint_args.begin(), entrypoint_args.end(),
+//       std::back_inserter(entrypoint_argv),
+//       [](const std::string& arg) -> const char* { return arg.c_str(); });
+
+//   FlutterProjectArgs args = {};
+//   args.struct_size = sizeof(FlutterProjectArgs);
+//   args.assets_path = assets_path_string.c_str();
+//   args.icu_data_path = icu_path_string.c_str();
+//   args.command_line_argc = static_cast<int>(engine_argv.size());
+//   args.command_line_argv =
+//       engine_argv.size() > 0 ? engine_argv.data() : nullptr;
+//   args.dart_entrypoint_argc = static_cast<int>(entrypoint_argv.size());
+//   args.dart_entrypoint_argv =
+//       entrypoint_argv.size() > 0 ? entrypoint_argv.data() : nullptr;
+//   args.platform_message_callback =
+//       [](const FlutterPlatformMessage* engine_message, void* user_data) {
+//         if (engine_message->struct_size != sizeof(FlutterPlatformMessage)) {
+//           FT_LOG(Error) << "Invalid message size received. Expected: "
+//                         << sizeof(FlutterPlatformMessage) << ", but received
+//                         "
+//                         << engine_message->struct_size;
+//           return;
+//         }
+//         auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+//         FlutterDesktopMessage message =
+//             engine->ConvertToDesktopMessage(*engine_message);
+//         engine->message_dispatcher_->HandleMessage(message);
+//       };
+//   if (aot_data_) {
+//     args.aot_data = aot_data_.get();
+//   }
+//   if (!project_->custom_dart_entrypoint().empty()) {
+//     args.custom_dart_entrypoint = project_->custom_dart_entrypoint().c_str();
+//   }
+// #ifndef WEARABLE_PROFILE
+//   args.update_semantics_node_callback = OnUpdateSemanticsNode;
+//   args.update_semantics_custom_action_callback =
+//   OnUpdateSemanticsCustomActions;
+
+//   if (IsHeaded() && renderer_->type() == FlutterDesktopRendererType::kEGL) {
+//     vsync_waiter_ = std::make_unique<TizenVsyncWaiter>(this);
+//     args.vsync_callback = [](void* user_data, intptr_t baton) -> void {
+//       auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+//       engine->vsync_waiter_->AsyncWaitForVsync(baton);
+//     };
+//   }
+// #endif
+
+//   return args;
+// }
 
 }  // namespace flutter

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -81,9 +81,15 @@ class FlutterTizenEngine {
   // Sets the view that is displaying this engine's content.
   void SetView(FlutterTizenView* view);
 
+  void SetEngineName(std::string name);
+
+  void SetRemoveCallback(std::function<void(std::string name)> remove_callback);
+
   // The view displaying this engine's content, if any. This will be null for
   // headless engines.
   FlutterTizenView* view() { return view_; }
+
+  std::string name() { return engine_name_; }
 
   FlutterDesktopMessengerRef messenger() { return messenger_.get(); }
 
@@ -218,6 +224,10 @@ class FlutterTizenEngine {
 
   // The Flutter engine instance.
   FLUTTER_API_SYMBOL(FlutterEngine) engine_ = nullptr;
+
+  std::string engine_name_;
+
+  std::function<void(std::string name)> remove_callback_;
 
   // The proc table of the embedder APIs.
   FlutterEngineProcTable embedder_api_ = {};

--- a/shell/platform/tizen/flutter_tizen_engine.h
+++ b/shell/platform/tizen/flutter_tizen_engine.h
@@ -62,11 +62,15 @@ class FlutterTizenEngine {
   // Creates a GL renderer from the given type.
   void CreateRenderer(FlutterDesktopRendererType renderer_type);
 
+  bool RunOrSpawnEngine();
+
   // Starts running the engine with the given entrypoint. If null, defaults to
   // main().
   //
   // Returns false if the engine couldn't be started.
   bool RunEngine();
+
+  bool SpawnEngine(FlutterTizenEngine* spawner);
 
   // Returns true if the engine is currently running.
   bool IsRunning() { return engine_ != nullptr; }

--- a/shell/platform/tizen/flutter_tizen_engine_group.cc
+++ b/shell/platform/tizen/flutter_tizen_engine_group.cc
@@ -1,0 +1,22 @@
+#include "flutter/shell/platform/tizen/flutter_tizen_engine_group.h"
+
+namespace flutter {
+
+FlutterTizenEngine* FlutterTizenEngineGroup::MakeEngineWithProject(
+    const FlutterProjectBundle& project) {
+  std::shared_ptr<FlutterTizenEngine> engine = nullptr;
+  engine = std::make_shared<flutter::FlutterTizenEngine>(project);
+  engines_.push_back(engine);
+
+  return engine.get();
+}
+
+int FlutterTizenEngineGroup::GetEngineCount() {
+  return engines_.size();
+}
+
+FlutterTizenEngine* FlutterTizenEngineGroup::GetEngineSpawner() {
+  return engines_[0].get();
+}
+
+}  // namespace flutter

--- a/shell/platform/tizen/flutter_tizen_engine_group.cc
+++ b/shell/platform/tizen/flutter_tizen_engine_group.cc
@@ -6,6 +6,17 @@ FlutterTizenEngine* FlutterTizenEngineGroup::MakeEngineWithProject(
     const FlutterProjectBundle& project) {
   std::shared_ptr<FlutterTizenEngine> engine = nullptr;
   engine = std::make_shared<flutter::FlutterTizenEngine>(project);
+  engine->SetEngineName(std::string("FlutterTizenEngine") +
+                        std::to_string(engines_.size()));
+  engine->SetRemoveCallback([&](std::string name) {
+    for (size_t i = 0; i < engines_.size(); ++i) {
+      if (engines_[i]->name() == name) {
+        engines_.erase(engines_.begin() + i);
+        return;
+      }
+    }
+  });
+
   engines_.push_back(engine);
 
   return engine.get();

--- a/shell/platform/tizen/flutter_tizen_engine_group.h
+++ b/shell/platform/tizen/flutter_tizen_engine_group.h
@@ -1,0 +1,30 @@
+#ifndef EMBEDDER_FLUTTER_TIZEN_ENGINE_GROUP_H_
+#define EMBEDDER_FLUTTER_TIZEN_ENGINE_GROUP_H_
+
+#include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
+
+namespace flutter {
+
+class FlutterTizenEngineGroup {
+ public:
+  static FlutterTizenEngineGroup& GetInstance() {
+    static FlutterTizenEngineGroup instance;
+    return instance;
+  }
+
+  FlutterTizenEngineGroup() {}
+
+  FlutterTizenEngine* MakeEngineWithProject(
+      const FlutterProjectBundle& project);
+
+  int GetEngineCount();
+
+  FlutterTizenEngine* GetEngineSpawner();
+
+ private:
+  std::vector<std::shared_ptr<FlutterTizenEngine>> engines_;
+};
+
+}  // namespace flutter
+
+#endif

--- a/shell/platform/tizen/flutter_tizen_engine_group.h
+++ b/shell/platform/tizen/flutter_tizen_engine_group.h
@@ -17,12 +17,14 @@ class FlutterTizenEngineGroup {
   FlutterTizenEngine* MakeEngineWithProject(
       const FlutterProjectBundle& project);
 
-  int GetEngineCount();
-
   FlutterTizenEngine* GetEngineSpawner();
 
+  int GetEngineCount();
+
+  void RemoveEngine(FlutterTizenEngine* engine);
+
  private:
-  std::vector<std::shared_ptr<FlutterTizenEngine>> engines_;
+  std::vector<std::unique_ptr<FlutterTizenEngine>> engines_;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/flutter_tizen_nui.cc
+++ b/shell/platform/tizen/flutter_tizen_nui.cc
@@ -42,9 +42,8 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromImageView(
   auto view =
       std::make_unique<flutter::FlutterTizenView>(std::move(tizen_view));
 
-  // Take ownership of the engine, starting it if necessary.
-  view->SetEngine(
-      std::unique_ptr<flutter::FlutterTizenEngine>(EngineFromHandle(engine)));
+  // Starting it if necessary.
+  view->SetEngine(EngineFromHandle(engine));
   view->CreateRenderSurface(FlutterDesktopRendererType::kEGL);
   if (!view->engine()->IsRunning()) {
     if (!view->engine()->RunEngine()) {

--- a/shell/platform/tizen/flutter_tizen_view.h
+++ b/shell/platform/tizen/flutter_tizen_view.h
@@ -28,9 +28,9 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
 
   // Configures the window instance with an instance of a running Flutter
   // engine.
-  void SetEngine(std::unique_ptr<FlutterTizenEngine> engine);
+  void SetEngine(FlutterTizenEngine* engine);
 
-  FlutterTizenEngine* engine() { return engine_.get(); }
+  FlutterTizenEngine* engine() { return engine_; }
 
   TizenViewBase* tizen_view() { return tizen_view_.get(); }
 
@@ -131,7 +131,7 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
                                int device_id);
 
   // The engine associated with this view.
-  std::unique_ptr<FlutterTizenEngine> engine_;
+  FlutterTizenEngine* engine_;
 
   // The platform view associated with this Flutter view.
   std::unique_ptr<TizenViewBase> tizen_view_;


### PR DESCRIPTION
This is a implementation for multi-engine scenarios. This implementation allows to reduce the memory we need to use multiple engines.

- Implement `FlutterTizenEngineGroup`
- Change the type of `EmbedderEngine's thread_host_` from `std::unique_ptr<EmbedderThreadHost>` to `std::shared_ptr<EmbedderThreadHost>`
- Add `SpawnEmbedderEngine` api at `embedder_engine`
- Add `FlutterEngineSpawn` api at `embedder`
- Add `SpawnEngine` api at `FlutterTizenEngine`

The table below shows the result of using [gallery](https://github.com/JSUYA/gallery/tree/test_flutterview) with emulator(device Tizen T-samsung-6.5-x86).

|Instances|Standard|Spawn|
|:------:|---|---|
|1|143 MiB|143 MiB|
|2|252 MiB|154 MiB|
|5|625 MiB|181 MiB|

Whenever an instance is added, add about 120 MiB memory in the Standard and add about 10 MiB memory when using Spawn.

contribute to https://github.com/flutter-tizen/flutter-tizen/issues/351

Signed-off-by: swan.seo <swan.seo@samsung.com>