### PR TITLE
Ignore SystemChrome.setSystemUIOverlayStyle

### DIFF
--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -35,6 +35,8 @@ constexpr char kSetEnabledSystemUiOverlaysMethod[] =
     "SystemChrome.setEnabledSystemUIOverlays";
 constexpr char kSetPreferredOrientationsMethod[] =
     "SystemChrome.setPreferredOrientations";
+constexpr char kSetSystemUIOverlayStyleMethod[] =
+    "SystemChrome.setSystemUIOverlayStyle";
 
 constexpr char kTextKey[] = "text";
 constexpr char kValueKey[] = "value";
@@ -145,6 +147,9 @@ void PlatformChannel::HandleMethodCall(
       orientations.push_back(iter->GetString());
     }
     SetPreferredOrientations(orientations);
+    result->Success();
+  } else if (method == kSetSystemUIOverlayStyleMethod) {
+    // Not supported on Tizen. Ignore.
     result->Success();
   } else {
     FT_LOG(Info) << "Unimplemented method: " << method;

--- a/shell/platform/tizen/channels/platform_channel.cc
+++ b/shell/platform/tizen/channels/platform_channel.cc
@@ -129,9 +129,6 @@ void PlatformChannel::HandleMethodCall(
   } else if (method == kRestoreSystemUiOverlaysMethod) {
     RestoreSystemUiOverlays();
     result->Success();
-  } else if (method == kSetApplicationSwitcherDescriptionMethod) {
-    // Not supported on Tizen. Ignore.
-    result->Success();
   } else if (method == kSetEnabledSystemUiOverlaysMethod) {
     const rapidjson::Document& list = arguments[0];
     std::vector<std::string> overlays;
@@ -148,7 +145,8 @@ void PlatformChannel::HandleMethodCall(
     }
     SetPreferredOrientations(orientations);
     result->Success();
-  } else if (method == kSetSystemUIOverlayStyleMethod) {
+  } else if (method == kSetApplicationSwitcherDescriptionMethod ||
+             method == kSetSystemUIOverlayStyleMethod) {
     // Not supported on Tizen. Ignore.
     result->Success();
   } else {


### PR DESCRIPTION
The [`SystemChrome.setSystemUIOverlayStyle`](https://api.flutter.dev/flutter/services/SystemChrome/setSystemUIOverlayStyle.html
) method is called when an app restarts, but similarly to https://github.com/flutter-tizen/engine/pull/308, the relevant features are not supported by the Tizen platform and thus calling the method will have no effect.

> If a particular style is not supported on the platform, selecting it will have no effect.