### PR TITLE
Fix FlutterEngineOnVsync being called after engine shutdown

### DIFF
--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -4,108 +4,13 @@
 
 #include "tizen_vsync_waiter.h"
 
-#include <eina_thread_queue.h>
-
 #include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/logger.h"
 
 namespace flutter {
 
-namespace {
-
-constexpr int kMessageQuit = -1;
-constexpr int kMessageRequestVblank = 0;
-
-struct Message {
-  Eina_Thread_Queue_Msg head;
-  int event;
-  intptr_t baton;
-};
-
-}  // namespace
-
-TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine) {
-  tdm_client_ = std::make_shared<TdmClient>(engine);
-
-  vblank_thread_ = ecore_thread_feedback_run(RunVblankLoop, nullptr, nullptr,
-                                             nullptr, this, EINA_TRUE);
-}
-
-TizenVsyncWaiter::~TizenVsyncWaiter() {
-  tdm_client_.reset();
-
-  SendMessage(kMessageQuit, 0);
-
-  if (vblank_thread_) {
-    ecore_thread_cancel(vblank_thread_);
-    vblank_thread_ = nullptr;
-  }
-}
-
-void TizenVsyncWaiter::AsyncWaitForVsync(intptr_t baton) {
-  SendMessage(kMessageRequestVblank, baton);
-}
-
-void TizenVsyncWaiter::SendMessage(int event, intptr_t baton) {
-  if (!vblank_thread_ || ecore_thread_check(vblank_thread_)) {
-    FT_LOG(Error) << "Invalid vblank thread.";
-    return;
-  }
-
-  if (!vblank_thread_queue_) {
-    FT_LOG(Error) << "Invalid vblank thread queue.";
-    return;
-  }
-
-  void* ref;
-  Message* message = static_cast<Message*>(
-      eina_thread_queue_send(vblank_thread_queue_, sizeof(Message), &ref));
-  message->event = event;
-  message->baton = baton;
-  eina_thread_queue_send_done(vblank_thread_queue_, ref);
-}
-
-void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
-  auto* self = reinterpret_cast<TizenVsyncWaiter*>(data);
-
-  std::weak_ptr<TdmClient> tdm_client = self->tdm_client_;
-  if (!tdm_client.lock()->IsValid()) {
-    FT_LOG(Error) << "Invalid tdm_client.";
-    ecore_thread_cancel(thread);
-    return;
-  }
-
-  Eina_Thread_Queue* vblank_thread_queue = eina_thread_queue_new();
-  if (!vblank_thread_queue) {
-    FT_LOG(Error) << "Invalid vblank thread queue.";
-    ecore_thread_cancel(thread);
-    return;
-  }
-  self->vblank_thread_queue_ = vblank_thread_queue;
-
-  while (!ecore_thread_check(thread)) {
-    void* ref;
-    Message* message = static_cast<Message*>(
-        eina_thread_queue_wait(vblank_thread_queue, &ref));
-    if (message->event == kMessageQuit) {
-      eina_thread_queue_wait_done(vblank_thread_queue, ref);
-      break;
-    }
-    intptr_t baton = message->baton;
-    eina_thread_queue_wait_done(vblank_thread_queue, ref);
-
-    if (tdm_client.expired()) {
-      break;
-    }
-    tdm_client.lock()->AwaitVblank(baton);
-  }
-
-  if (vblank_thread_queue) {
-    eina_thread_queue_free(vblank_thread_queue);
-  }
-}
-
-TdmClient::TdmClient(FlutterTizenEngine* engine) {
+TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine)
+    : engine_(engine) {
   tdm_error ret;
   client_ = tdm_client_create(&ret);
   if (ret != TDM_ERROR_NONE) {
@@ -125,27 +30,28 @@ TdmClient::TdmClient(FlutterTizenEngine* engine) {
     return;
   }
   tdm_client_vblank_set_enable_fake(vblank_, 1);
-
-  engine_ = engine;
 }
 
-TdmClient::~TdmClient() {
+TizenVsyncWaiter::~TizenVsyncWaiter() {
   {
     std::lock_guard<std::mutex> lock(engine_mutex_);
     engine_ = nullptr;
   }
+
   if (vblank_) {
     tdm_client_vblank_destroy(vblank_);
     vblank_ = nullptr;
   }
+
   output_ = nullptr;
+
   if (client_) {
     tdm_client_destroy(client_);
     client_ = nullptr;
   }
 }
 
-void TdmClient::AwaitVblank(intptr_t baton) {
+void TizenVsyncWaiter::AsyncWaitForVsync(intptr_t baton) {
   baton_ = baton;
   tdm_error ret = tdm_client_vblank_wait(vblank_, 1, VblankCallback, this);
   if (ret != TDM_ERROR_NONE) {
@@ -155,17 +61,13 @@ void TdmClient::AwaitVblank(intptr_t baton) {
   tdm_client_handle_events(client_);
 }
 
-bool TdmClient::IsValid() {
-  return vblank_ && client_;
-}
-
-void TdmClient::VblankCallback(tdm_client_vblank* vblank,
-                               tdm_error error,
-                               unsigned int sequence,
-                               unsigned int tv_sec,
-                               unsigned int tv_usec,
-                               void* user_data) {
-  auto* self = reinterpret_cast<TdmClient*>(user_data);
+void TizenVsyncWaiter::VblankCallback(tdm_client_vblank* vblank,
+                                      tdm_error error,
+                                      unsigned int sequence,
+                                      unsigned int tv_sec,
+                                      unsigned int tv_usec,
+                                      void* user_data) {
+  auto* self = reinterpret_cast<TizenVsyncWaiter*>(user_data);
   FT_ASSERT(self != nullptr);
 
   std::lock_guard<std::mutex> lock(self->engine_mutex_);

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -24,17 +24,18 @@ struct Message {
 
 }  // namespace
 
-TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine)
-    : engine_(engine) {
+TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine) {
+  tdm_client_ = std::make_shared<TdmClient>(engine);
+
   vblank_thread_ = ecore_thread_feedback_run(RunVblankLoop, nullptr, nullptr,
                                              nullptr, this, EINA_TRUE);
 }
 
 TizenVsyncWaiter::~TizenVsyncWaiter() {
-  if (tdm_client_) {
-    tdm_client_->OnEngineStop();
-  }
+  tdm_client_->OnEngineStop();
+
   SendMessage(kMessageQuit, 0);
+
   if (vblank_thread_) {
     ecore_thread_cancel(vblank_thread_);
     vblank_thread_ = nullptr;
@@ -67,9 +68,8 @@ void TizenVsyncWaiter::SendMessage(int event, intptr_t baton) {
 void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
   auto* self = reinterpret_cast<TizenVsyncWaiter*>(data);
 
-  TdmClient tdm_client(self->engine_);
-  self->SetTdmClient(&tdm_client);
-  if (!tdm_client.IsValid()) {
+  std::weak_ptr<TdmClient> tdm_client = self->tdm_client_;
+  if (!tdm_client.lock()->IsValid()) {
     FT_LOG(Error) << "Invalid tdm_client.";
     ecore_thread_cancel(thread);
     return;
@@ -94,7 +94,10 @@ void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
     intptr_t baton = message->baton;
     eina_thread_queue_wait_done(vblank_thread_queue, ref);
 
-    tdm_client.AwaitVblank(baton);
+    if (tdm_client.expired()) {
+      break;
+    }
+    tdm_client.lock()->AwaitVblank(baton);
   }
 
   if (vblank_thread_queue) {

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -4,13 +4,108 @@
 
 #include "tizen_vsync_waiter.h"
 
+#include <eina_thread_queue.h>
+
 #include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/logger.h"
 
 namespace flutter {
 
-TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine)
-    : engine_(engine) {
+namespace {
+
+constexpr int kMessageQuit = -1;
+constexpr int kMessageRequestVblank = 0;
+
+struct Message {
+  Eina_Thread_Queue_Msg head;
+  int event;
+  intptr_t baton;
+};
+
+}  // namespace
+
+TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine) {
+  tdm_client_ = std::make_shared<TdmClient>(engine);
+
+  vblank_thread_ = ecore_thread_feedback_run(RunVblankLoop, nullptr, nullptr,
+                                             nullptr, this, EINA_TRUE);
+}
+
+TizenVsyncWaiter::~TizenVsyncWaiter() {
+  tdm_client_.reset();
+
+  SendMessage(kMessageQuit, 0);
+
+  if (vblank_thread_) {
+    ecore_thread_cancel(vblank_thread_);
+    vblank_thread_ = nullptr;
+  }
+}
+
+void TizenVsyncWaiter::AsyncWaitForVsync(intptr_t baton) {
+  SendMessage(kMessageRequestVblank, baton);
+}
+
+void TizenVsyncWaiter::SendMessage(int event, intptr_t baton) {
+  if (!vblank_thread_ || ecore_thread_check(vblank_thread_)) {
+    FT_LOG(Error) << "Invalid vblank thread.";
+    return;
+  }
+
+  if (!vblank_thread_queue_) {
+    FT_LOG(Error) << "Invalid vblank thread queue.";
+    return;
+  }
+
+  void* ref;
+  Message* message = static_cast<Message*>(
+      eina_thread_queue_send(vblank_thread_queue_, sizeof(Message), &ref));
+  message->event = event;
+  message->baton = baton;
+  eina_thread_queue_send_done(vblank_thread_queue_, ref);
+}
+
+void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
+  auto* self = reinterpret_cast<TizenVsyncWaiter*>(data);
+
+  std::weak_ptr<TdmClient> tdm_client = self->tdm_client_;
+  if (!tdm_client.lock()->IsValid()) {
+    FT_LOG(Error) << "Invalid tdm_client.";
+    ecore_thread_cancel(thread);
+    return;
+  }
+
+  Eina_Thread_Queue* vblank_thread_queue = eina_thread_queue_new();
+  if (!vblank_thread_queue) {
+    FT_LOG(Error) << "Invalid vblank thread queue.";
+    ecore_thread_cancel(thread);
+    return;
+  }
+  self->vblank_thread_queue_ = vblank_thread_queue;
+
+  while (!ecore_thread_check(thread)) {
+    void* ref;
+    Message* message = static_cast<Message*>(
+        eina_thread_queue_wait(vblank_thread_queue, &ref));
+    if (message->event == kMessageQuit) {
+      eina_thread_queue_wait_done(vblank_thread_queue, ref);
+      break;
+    }
+    intptr_t baton = message->baton;
+    eina_thread_queue_wait_done(vblank_thread_queue, ref);
+
+    if (tdm_client.expired()) {
+      break;
+    }
+    tdm_client.lock()->AwaitVblank(baton);
+  }
+
+  if (vblank_thread_queue) {
+    eina_thread_queue_free(vblank_thread_queue);
+  }
+}
+
+TdmClient::TdmClient(FlutterTizenEngine* engine) {
   tdm_error ret;
   client_ = tdm_client_create(&ret);
   if (ret != TDM_ERROR_NONE) {
@@ -30,28 +125,27 @@ TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine)
     return;
   }
   tdm_client_vblank_set_enable_fake(vblank_, 1);
+
+  engine_ = engine;
 }
 
-TizenVsyncWaiter::~TizenVsyncWaiter() {
+TdmClient::~TdmClient() {
   {
     std::lock_guard<std::mutex> lock(engine_mutex_);
     engine_ = nullptr;
   }
-
   if (vblank_) {
     tdm_client_vblank_destroy(vblank_);
     vblank_ = nullptr;
   }
-
   output_ = nullptr;
-
   if (client_) {
     tdm_client_destroy(client_);
     client_ = nullptr;
   }
 }
 
-void TizenVsyncWaiter::AsyncWaitForVsync(intptr_t baton) {
+void TdmClient::AwaitVblank(intptr_t baton) {
   baton_ = baton;
   tdm_error ret = tdm_client_vblank_wait(vblank_, 1, VblankCallback, this);
   if (ret != TDM_ERROR_NONE) {
@@ -61,13 +155,17 @@ void TizenVsyncWaiter::AsyncWaitForVsync(intptr_t baton) {
   tdm_client_handle_events(client_);
 }
 
-void TizenVsyncWaiter::VblankCallback(tdm_client_vblank* vblank,
-                                      tdm_error error,
-                                      unsigned int sequence,
-                                      unsigned int tv_sec,
-                                      unsigned int tv_usec,
-                                      void* user_data) {
-  auto* self = reinterpret_cast<TizenVsyncWaiter*>(user_data);
+bool TdmClient::IsValid() {
+  return vblank_ && client_;
+}
+
+void TdmClient::VblankCallback(tdm_client_vblank* vblank,
+                               tdm_error error,
+                               unsigned int sequence,
+                               unsigned int tv_sec,
+                               unsigned int tv_usec,
+                               void* user_data) {
+  auto* self = reinterpret_cast<TdmClient*>(user_data);
   FT_ASSERT(self != nullptr);
 
   std::lock_guard<std::mutex> lock(self->engine_mutex_);

--- a/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -24,18 +24,17 @@ struct Message {
 
 }  // namespace
 
-TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine) {
-  tdm_client_ = std::make_shared<TdmClient>(engine);
-
+TizenVsyncWaiter::TizenVsyncWaiter(FlutterTizenEngine* engine)
+    : engine_(engine) {
   vblank_thread_ = ecore_thread_feedback_run(RunVblankLoop, nullptr, nullptr,
                                              nullptr, this, EINA_TRUE);
 }
 
 TizenVsyncWaiter::~TizenVsyncWaiter() {
-  tdm_client_.reset();
-
+  if (tdm_client_) {
+    tdm_client_->OnEngineStop();
+  }
   SendMessage(kMessageQuit, 0);
-
   if (vblank_thread_) {
     ecore_thread_cancel(vblank_thread_);
     vblank_thread_ = nullptr;
@@ -68,8 +67,9 @@ void TizenVsyncWaiter::SendMessage(int event, intptr_t baton) {
 void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
   auto* self = reinterpret_cast<TizenVsyncWaiter*>(data);
 
-  std::weak_ptr<TdmClient> tdm_client = self->tdm_client_;
-  if (!tdm_client.lock()->IsValid()) {
+  TdmClient tdm_client(self->engine_);
+  self->SetTdmClient(&tdm_client);
+  if (!tdm_client.IsValid()) {
     FT_LOG(Error) << "Invalid tdm_client.";
     ecore_thread_cancel(thread);
     return;
@@ -94,10 +94,7 @@ void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
     intptr_t baton = message->baton;
     eina_thread_queue_wait_done(vblank_thread_queue, ref);
 
-    if (tdm_client.expired()) {
-      break;
-    }
-    tdm_client.lock()->AwaitVblank(baton);
+    tdm_client.AwaitVblank(baton);
   }
 
   if (vblank_thread_queue) {
@@ -130,10 +127,6 @@ TdmClient::TdmClient(FlutterTizenEngine* engine) {
 }
 
 TdmClient::~TdmClient() {
-  {
-    std::lock_guard<std::mutex> lock(engine_mutex_);
-    engine_ = nullptr;
-  }
   if (vblank_) {
     tdm_client_vblank_destroy(vblank_);
     vblank_ = nullptr;
@@ -145,6 +138,15 @@ TdmClient::~TdmClient() {
   }
 }
 
+bool TdmClient::IsValid() {
+  return vblank_ && client_;
+}
+
+void TdmClient::OnEngineStop() {
+  std::lock_guard<std::mutex> lock(engine_mutex_);
+  engine_ = nullptr;
+}
+
 void TdmClient::AwaitVblank(intptr_t baton) {
   baton_ = baton;
   tdm_error ret = tdm_client_vblank_wait(vblank_, 1, VblankCallback, this);
@@ -153,10 +155,6 @@ void TdmClient::AwaitVblank(intptr_t baton) {
     return;
   }
   tdm_client_handle_events(client_);
-}
-
-bool TdmClient::IsValid() {
-  return vblank_ && client_;
 }
 
 void TdmClient::VblankCallback(tdm_client_vblank* vblank,

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -5,25 +5,21 @@
 #ifndef EMBEDDER_TIZEN_VSYNC_WAITER_H_
 #define EMBEDDER_TIZEN_VSYNC_WAITER_H_
 
-#include <Ecore.h>
 #include <tdm_client.h>
 
 #include <memory>
 #include <mutex>
 
-#include "flutter/shell/platform/embedder/embedder.h"
-
 namespace flutter {
 
 class FlutterTizenEngine;
 
-class TdmClient {
+class TizenVsyncWaiter {
  public:
-  TdmClient(FlutterTizenEngine* engine);
-  virtual ~TdmClient();
+  TizenVsyncWaiter(FlutterTizenEngine* engine);
+  virtual ~TizenVsyncWaiter();
 
-  bool IsValid();
-  void AwaitVblank(intptr_t baton);
+  void AsyncWaitForVsync(intptr_t baton);
 
  private:
   static void VblankCallback(tdm_client_vblank* vblank,
@@ -41,23 +37,6 @@ class TdmClient {
   tdm_client_vblank* vblank_ = nullptr;
 
   intptr_t baton_ = 0;
-};
-
-class TizenVsyncWaiter {
- public:
-  TizenVsyncWaiter(FlutterTizenEngine* engine);
-  virtual ~TizenVsyncWaiter();
-
-  void AsyncWaitForVsync(intptr_t baton);
-
- private:
-  void SendMessage(int event, intptr_t baton);
-
-  static void RunVblankLoop(void* data, Ecore_Thread* thread);
-
-  std::shared_ptr<TdmClient> tdm_client_;
-  Ecore_Thread* vblank_thread_ = nullptr;
-  Eina_Thread_Queue* vblank_thread_queue_ = nullptr;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -5,21 +5,25 @@
 #ifndef EMBEDDER_TIZEN_VSYNC_WAITER_H_
 #define EMBEDDER_TIZEN_VSYNC_WAITER_H_
 
+#include <Ecore.h>
 #include <tdm_client.h>
 
 #include <memory>
 #include <mutex>
 
+#include "flutter/shell/platform/embedder/embedder.h"
+
 namespace flutter {
 
 class FlutterTizenEngine;
 
-class TizenVsyncWaiter {
+class TdmClient {
  public:
-  TizenVsyncWaiter(FlutterTizenEngine* engine);
-  virtual ~TizenVsyncWaiter();
+  TdmClient(FlutterTizenEngine* engine);
+  virtual ~TdmClient();
 
-  void AsyncWaitForVsync(intptr_t baton);
+  bool IsValid();
+  void AwaitVblank(intptr_t baton);
 
  private:
   static void VblankCallback(tdm_client_vblank* vblank,
@@ -37,6 +41,23 @@ class TizenVsyncWaiter {
   tdm_client_vblank* vblank_ = nullptr;
 
   intptr_t baton_ = 0;
+};
+
+class TizenVsyncWaiter {
+ public:
+  TizenVsyncWaiter(FlutterTizenEngine* engine);
+  virtual ~TizenVsyncWaiter();
+
+  void AsyncWaitForVsync(intptr_t baton);
+
+ private:
+  void SendMessage(int event, intptr_t baton);
+
+  static void RunVblankLoop(void* data, Ecore_Thread* thread);
+
+  std::shared_ptr<TdmClient> tdm_client_;
+  Ecore_Thread* vblank_thread_ = nullptr;
+  Eina_Thread_Queue* vblank_thread_queue_ = nullptr;
 };
 
 }  // namespace flutter

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -8,7 +8,6 @@
 #include <Ecore.h>
 #include <tdm_client.h>
 
-#include <memory>
 #include <mutex>
 
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -23,6 +22,7 @@ class TdmClient {
   virtual ~TdmClient();
 
   bool IsValid();
+  void OnEngineStop();
   void AwaitVblank(intptr_t baton);
 
  private:
@@ -53,9 +53,12 @@ class TizenVsyncWaiter {
  private:
   void SendMessage(int event, intptr_t baton);
 
+  void SetTdmClient(TdmClient* tdm_client) { tdm_client_ = tdm_client; }
+
   static void RunVblankLoop(void* data, Ecore_Thread* thread);
 
-  std::shared_ptr<TdmClient> tdm_client_;
+  FlutterTizenEngine* engine_ = nullptr;
+  TdmClient* tdm_client_ = nullptr;
   Ecore_Thread* vblank_thread_ = nullptr;
   Eina_Thread_Queue* vblank_thread_queue_ = nullptr;
 };

--- a/shell/platform/tizen/tizen_vsync_waiter.h
+++ b/shell/platform/tizen/tizen_vsync_waiter.h
@@ -8,6 +8,7 @@
 #include <Ecore.h>
 #include <tdm_client.h>
 
+#include <memory>
 #include <mutex>
 
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -53,12 +54,9 @@ class TizenVsyncWaiter {
  private:
   void SendMessage(int event, intptr_t baton);
 
-  void SetTdmClient(TdmClient* tdm_client) { tdm_client_ = tdm_client; }
-
   static void RunVblankLoop(void* data, Ecore_Thread* thread);
 
-  FlutterTizenEngine* engine_ = nullptr;
-  TdmClient* tdm_client_ = nullptr;
+  std::shared_ptr<TdmClient> tdm_client_;
   Ecore_Thread* vblank_thread_ = nullptr;
   Eina_Thread_Queue* vblank_thread_queue_ = nullptr;
 };


### PR DESCRIPTION
Potentially fixes https://github.com/flutter-tizen/flutter-tizen/issues/232.

This change is just a partial revert of https://github.com/flutter-tizen/engine/pull/317. In the PR, I changed `tdm_client_` from a plain pointer to a `shared_ptr` which is shared between the platform thread and the vblank thread, but it turned out that it results in a synchronization issue in https://github.com/flutter-tizen/flutter-tizen/issues/232 for some unknown reason. The main reason I changed it into a `shared_ptr` was that it seemed not safe to call `OnEngineStop` on a plain pointer because the object pointed by the pointer was being destroyed on thread exit. However, in reality, `OnEngineStop` is guaranteed to be called before a `kMessageQuit` message is sent and thus no segmentation fault should occur.

I also considered removing the vblank thread itself but thought it would not be very efficient since `tdm_client_handle_events` is a blocking call and blocks the UI thread.