### PR TITLE
Change of focus mechanism in TizenViewElementary

### DIFF
--- a/shell/platform/tizen/tizen_view_elementary.h
+++ b/shell/platform/tizen/tizen_view_elementary.h
@@ -55,7 +55,7 @@ class TizenViewElementary : public TizenView {
   std::unordered_map<Evas_Callback_Type, Evas_Object_Event_Cb>
       evas_object_callbacks_;
   std::vector<Ecore_Event_Handler*> ecore_event_key_handlers_;
-  Evas_Smart_Cb focused_callback_ = nullptr;
+  Evas_Smart_Cb unfocused_callback_ = nullptr;
 
   bool scroll_hold_ = false;
 };


### PR DESCRIPTION
This PR changes the way it works when moving the Focus of `TizenView` using `Arrow Key`.
Previously, it was automatically focus using `Arrow Key`, but after this PR, `Enter Key` (`Return Key`) must be entered to focus.

The purpose of this PR is to allow users to select the desired view comfortably by using `Arrow Key` when several `TizenViewElementary` exists.

PR related to what is mentioned in issue #341.