### PR TITLE
Reduce non-fatal error message

### DIFF
--- a/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -216,15 +216,17 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
           auto* configure_event =
               reinterpret_cast<Ecore_Wl2_Event_Window_Configure*>(event);
           if (configure_event->win == self->GetWindowId()) {
-            ecore_wl2_egl_window_resize_with_rotation(
-                self->ecore_wl2_egl_window_, configure_event->x,
-                configure_event->y, configure_event->w, configure_event->h,
-                self->GetRotation());
+            if (configure_event->w != 0 && configure_event->h != 0) {
+              ecore_wl2_egl_window_resize_with_rotation(
+                  self->ecore_wl2_egl_window_, configure_event->x,
+                  configure_event->y, configure_event->w, configure_event->h,
+                  self->GetRotation());
 
-            self->view_delegate_->OnResize(
-                configure_event->x, configure_event->y, configure_event->w,
-                configure_event->h);
-            return ECORE_CALLBACK_DONE;
+              self->view_delegate_->OnResize(
+                  configure_event->x, configure_event->y, configure_event->w,
+                  configure_event->h);
+              return ECORE_CALLBACK_DONE;
+            }
           }
         }
         return ECORE_CALLBACK_PASS_ON;


### PR DESCRIPTION
> [WARN][(tid:6985)(wl_egl_window_tizen_set_buffer_transform)] wl_egl_window(0x80807a10) wl_output_transform(0) already rotated

The warning occurs when the `ecore_wl2_egl_window_resize_with_rotation` function is called.
Reducing warn message by reducing the case where the function is called unnecessarily.


Related to issue #348 