### PR TITLE
[Tizen] Temporarily fix unexpected partial repaint

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -330,7 +330,7 @@ InferOpenGLPlatformViewCreationCallback(
       return flutter::GLFBOInfo{
           .fbo_id = static_cast<uint32_t>(id),
           .partial_repaint_enabled = false,
-          .existing_damage = SkIRect::MakeEmpty(),
+          .existing_damage = std::nullopt,
       };
     }
 


### PR DESCRIPTION
Always force full repaint when the `populate_existing_damage` callback is not provided.

Fixes the rendering issue mentioned in https://github.com/flutter-tizen/embedder/pull/21.