### PR TITLE
Revert "Make the context current before accessing GL in MakeSkiaGpuImage"

### DIFF
--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -325,13 +325,5 @@ if (enable_unittests) {
       sources += [ "shell_io_manager_unittests.cc" ]
       deps += [ "//third_party/swiftshader" ]
     }
-
-    if (shell_enable_gl) {
-      deps += [
-        "//third_party/angle:libEGL_static",
-        "//third_party/angle:libGLESv2_static",
-        "//third_party/swiftshader",
-      ]
-    }
   }
 }

--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -354,9 +354,6 @@ void scene_with_red_box() {
   PlatformDispatcher.instance.scheduleFrame();
 }
 
-@pragma('vm:external-name', 'NativeOnBeforeToImageSync')
-external void onBeforeToImageSync();
-
 
 @pragma('vm:entry-point')
 Future<void> toImageSync() async {
@@ -365,7 +362,6 @@ Future<void> toImageSync() async {
   canvas.drawPaint(Paint()..color = const Color(0xFFAAAAAA));
   final Picture picture = recorder.endRecording();
 
-  onBeforeToImageSync();
   final Image image = picture.toImageSync(20, 25);
   void expect(Object? a, Object? b) {
     if (a != b) {

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -294,12 +294,17 @@ std::unique_ptr<Rasterizer::GpuImageResult> Rasterizer::MakeSkiaGpuImage(
   TRACE_EVENT0("flutter", "Rasterizer::MakeGpuImage");
   FML_DCHECK(display_list);
 
+// TODO(dnfield): the Linux embedding is in a rough state right now and
+// I can't seem to get the GPU path working on it.
+// https://github.com/flutter/flutter/issues/108835
+#if FML_OS_LINUX
+  return MakeBitmapImage(display_list, image_info);
+#endif
+
   std::unique_ptr<SnapshotDelegate::GpuImageResult> result;
   delegate_.GetIsGpuDisabledSyncSwitch()->Execute(
       fml::SyncSwitch::Handlers()
           .SetIfTrue([&result, &image_info, &display_list] {
-            // TODO(dnfield): This isn't safe if display_list contains any GPU
-            // resources like an SkImage_gpu.
             result = MakeBitmapImage(display_list, image_info);
           })
           .SetIfFalse([&result, &image_info, &display_list,
@@ -307,14 +312,6 @@ std::unique_ptr<Rasterizer::GpuImageResult> Rasterizer::MakeSkiaGpuImage(
                        gpu_image_behavior = gpu_image_behavior_] {
             if (!surface ||
                 gpu_image_behavior == MakeGpuImageBehavior::kBitmap) {
-              // TODO(dnfield): This isn't safe if display_list contains any GPU
-              // resources like an SkImage_gpu.
-              result = MakeBitmapImage(display_list, image_info);
-              return;
-            }
-
-            auto context_switch = surface->MakeRenderContextCurrent();
-            if (!context_switch->GetResult()) {
               result = MakeBitmapImage(display_list, image_info);
               return;
             }

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -11,10 +11,6 @@
 #include <utility>
 #include <vector>
 
-#if SHELL_ENABLE_GL
-#include <EGL/egl.h>
-#endif  // SHELL_ENABLE_GL
-
 #include "assets/directory_asset_bundle.h"
 #include "common/graphics/persistent_cache.h"
 #include "flutter/flow/layers/backdrop_filter_layer.h"
@@ -3959,11 +3955,6 @@ TEST_F(ShellTest, PictureToImageSync) {
                   ShellTestPlatformView::BackendType::kGLBackend  //
       );
 
-  AddNativeCallback("NativeOnBeforeToImageSync",
-                    CREATE_NATIVE_ENTRY([&](auto args) {
-                      // nop
-                    }));
-
   fml::CountDownLatch latch(2);
   AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&](auto args) {
                       // Teardown and set up rasterizer again.
@@ -4032,58 +4023,6 @@ TEST_F(ShellTest, PictureToImageSyncImpellerNoSurface) {
   PlatformViewNotifyDestroyed(shell.get());
   DestroyShell(std::move(shell));
 }
-
-#if SHELL_ENABLE_GL
-// This test uses the GL backend and refers to symbols in egl.h
-TEST_F(ShellTest, PictureToImageSyncWithTrampledContext) {
-  // make it easier to trample the GL context by running on a single task
-  // runner.
-  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
-                         ThreadHost::Type::Platform);
-  auto task_runner = thread_host.platform_thread->GetTaskRunner();
-  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
-                           task_runner);
-
-  auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell =
-      CreateShell(settings,                                       //
-                  task_runners,                                   //
-                  false,                                          //
-                  nullptr,                                        //
-                  false,                                          //
-                  ShellTestPlatformView::BackendType::kGLBackend  //
-      );
-
-  AddNativeCallback(
-      "NativeOnBeforeToImageSync", CREATE_NATIVE_ENTRY([&](auto args) {
-        // Trample the GL context. If the rasterizer fails
-        // to make the right one current again, test will
-        // fail.
-        ::eglMakeCurrent(::eglGetCurrentDisplay(), NULL, NULL, NULL);
-      }));
-
-  fml::CountDownLatch latch(2);
-  AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&](auto args) {
-                      // Teardown and set up rasterizer again.
-                      PlatformViewNotifyDestroyed(shell.get());
-                      PlatformViewNotifyCreated(shell.get());
-                      latch.CountDown();
-                    }));
-
-  ASSERT_NE(shell, nullptr);
-  ASSERT_TRUE(shell->IsSetup());
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  PlatformViewNotifyCreated(shell.get());
-  configuration.SetEntrypoint("toImageSync");
-  RunEngine(shell.get(), std::move(configuration));
-  PumpOneFrame(shell.get());
-
-  latch.Wait();
-
-  PlatformViewNotifyDestroyed(shell.get());
-  DestroyShell(std::move(shell), task_runners);
-}
-#endif  // SHELL_ENABLE_GL
 
 TEST_F(ShellTest, PluginUtilitiesCallbackHandleErrorHandling) {
   auto settings = CreateSettingsForFixture();


### PR DESCRIPTION
This reverts https://github.com/flutter/engine/pull/40208, which causes `PictureRasterizationException` (and screen flickering) on emulators when calling `Naviagator.push`.

```text
══╡ EXCEPTION CAUGHT BY RENDERING LIBRARY ╞═════════════════════════════════════════════════════════
The following PictureRasterizationException was thrown during paint():
Failed to rasterize a picture: unable to create texture render target at specified size 720x1280.
The callstack when the image was created was:
#0      new Image._.<anonymous closure> (dart:ui/painting.dart:1711:32)
#1      new Image._ (dart:ui/painting.dart:1713:6)
#2      Scene.toImageSync (dart:ui/compositing.dart:34:18)
#3      OffsetLayer.toImageSync (package:flutter/src/rendering/layer.dart:1487:20)
#4      _RenderSnapshotWidget._paintAndDetachToImage
(package:flutter/src/widgets/snapshot_widget.dart:315:40)
#5      _RenderSnapshotWidget.paint (package:flutter/src/widgets/snapshot_widget.dart:345:22)
#6      RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3059:7)
#7      PaintingContext.paintChild (package:flutter/src/rendering/object.dart:253:13)
#8      RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:146:15)
#9      _ZoomEnterTransitionPainter.paint
(package:flutter/src/material/page_transitions_theme.dart:923:23)
#10     _RenderSnapshotWidget.paint (package:flutter/src/widgets/snapshot_widget.dart:335:15)
#11     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3059:7)
#12     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:253:13)
#13     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:146:15)
#14     _ZoomExitTransitionPainter.paint
(package:flutter/src/material/page_transitions_theme.dart:995:23)
#15     _RenderSnapshotWidget.paint (package:flutter/src/widgets/snapshot_widget.dart:335:15)
#16     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3059:7)
#17     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:253:13)
#18     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:146:15)
#19     _ZoomEnterTransitionPainter.paint
(package:flutter/src/material/page_transitions_theme.dart:923:23)
#20     _RenderSnapshotWidget.paint (package:flutter/src/widgets/snapshot_widget.dart:335:15)
#21     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3059:7)
#22     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:253:13)
#23     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:146:15)
#24     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3059:7)
#25     PaintingContext._repaintCompositedChild (package:flutter/src/rendering/object.dart:169:11)
#26     PaintingContext.repaintCompositedChild (package:flutter/src/rendering/object.dart:112:5)
#27     PipelineOwner.flushPaint (package:flutter/src/rendering/object.dart:1147:31)
#28     RendererBinding.drawFrame (package:flutter/src/rendering/binding.dart:494:19)
#29     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:905:13)
#30     RendererBinding._handlePersistentFrameCallback
(package:flutter/src/rendering/binding.dart:358:5)
#31     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1284:15)
#32     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1214:9)
#33     SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1072:5)
#34     _invoke (dart:ui/hooks.dart:142:13)
#35     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:359:5)
#36     _drawFrame (dart:ui/hooks.dart:112:31)

The relevant error-causing widget was:
  MaterialApp
  MaterialApp:file:///home/swift/Git/plugins/packages/video_player/example/lib/main.dart:14:5

When the exception was thrown, this was the stack:
#0      Canvas.drawImageRect (dart:ui/painting.dart:5414:7)
#1      _drawImageScaledAndCentered (package:flutter/src/material/page_transitions_theme.dart:819:18)
#2      _ZoomExitTransitionPainter.paintSnapshot (package:flutter/src/material/page_transitions_theme.dart:987:5)
#3      _RenderSnapshotWidget.paint (package:flutter/src/widgets/snapshot_widget.dart:351:15)
#4      RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3059:7)
#5      PaintingContext.paintChild (package:flutter/src/rendering/object.dart:253:13)
#6      RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:146:15)
#7      _ZoomEnterTransitionPainter.paint (package:flutter/src/material/page_transitions_theme.dart:923:23)
#8      _RenderSnapshotWidget.paint (package:flutter/src/widgets/snapshot_widget.dart:335:15)
#9      RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3059:7)
#10     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:253:13)
#11     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:146:15)
#12     _ZoomExitTransitionPainter.paint (package:flutter/src/material/page_transitions_theme.dart:995:23)
#13     _RenderSnapshotWidget.paint (package:flutter/src/widgets/snapshot_widget.dart:335:15)
#14     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3059:7)
#15     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:253:13)
#16     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:146:15)
#17     _ZoomEnterTransitionPainter.paint (package:flutter/src/material/page_transitions_theme.dart:923:23)
#18     _RenderSnapshotWidget.paint (package:flutter/src/widgets/snapshot_widget.dart:335:15)
#19     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3059:7)
#20     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:253:13)
#21     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:146:15)
#22     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3059:7)
#23     PaintingContext._repaintCompositedChild (package:flutter/src/rendering/object.dart:169:11)
#24     PaintingContext.repaintCompositedChild (package:flutter/src/rendering/object.dart:112:5)
#25     PipelineOwner.flushPaint (package:flutter/src/rendering/object.dart:1147:31)
#26     RendererBinding.drawFrame (package:flutter/src/rendering/binding.dart:494:19)
#27     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:905:13)
#28     RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:358:5)
#29     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1284:15)
#30     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1214:9)
#31     SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1072:5)
#32     _invoke (dart:ui/hooks.dart:142:13)
#33     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:359:5)
#34     _drawFrame (dart:ui/hooks.dart:112:31)

The following RenderObject was being processed when the exception was fired: _RenderSnapshotWidget#4aaf5:
  needs compositing
  creator: SnapshotWidget ← _ZoomExitTransition ← SnapshotWidget ← _ZoomEnterTransition ←
    DualTransitionBuilder ← SnapshotWidget ← _ZoomExitTransition ← SnapshotWidget ←
    _ZoomEnterTransition ← DualTransitionBuilder ← _ZoomPageTransition ← AnimatedBuilder ← ⋯
  parentData: <none> (can use size)
  constraints: BoxConstraints(w=315.9, h=561.7)
  size: Size(315.9, 561.7)
This RenderObject had the following descendants (showing up to depth 5):
    child: RenderIgnorePointer#a4dea
      child: RenderRepaintBoundary#a60a9
        child: RenderSemanticsAnnotations#8bb72
          child: RenderPhysicalModel#451e6
            child: _RenderInkFeatures#837b3
════════════════════════════════════════════════════════════════════════════════════════════════════
```

Easily reproducible with the `sqflite_tizen` and `video_player_tizen` examples on [Flutter 3.10](https://github.com/flutter-tizen/flutter-tizen/pull/497).

@flutter-tizen/maintainers Could someone take a closer look at this issue? Right now I don't fully understand what the purpose of the original commit is.