### PR TITLE
[Tizen] ci: Add missing action

### DIFF
--- a/.github/workflows/check-symbols.yml
+++ b/.github/workflows/check-symbols.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
         with:
           repository: flutter-tizen/tizen_allowlist
           token: ${{ secrets.TIZENAPI_TOKEN }}


### PR DESCRIPTION
Add missing github actions while preparing for 3.19.3 support.
When future updates, this patch can be combined with
the `[Tizen] Update action version and disable gtk config in test` commit.

https://github.com/flutter-tizen/embedder/pull/57#issuecomment-2008569212