### PR TITLE
[Tizen] Changed runner to macos-13 for macOS based on Intel chips

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
           if-no-files-found: error
 
   macos-build:
-    runs-on: macos-latest
+    runs-on: macos-latest-large
 
     strategy:
       matrix:
@@ -186,7 +186,7 @@ jobs:
 
       - name: Build
         run: |
-          # Change host_toolchain to mac/clang_arm64.
+          # Change host_toolchain to mac/clang_x64.
           sed -i "" "s|//build/toolchain/linux:clang_$host_cpu|//build/toolchain/mac:clang_$host_cpu|g" src/build/config/BUILDCONFIG.gn
 
           # Pass dummy values to prevent using the default (Linux) toolchain.
@@ -200,12 +200,12 @@ jobs:
             --runtime-mode=${{ matrix.mode }} \
             --disable-desktop-embeddings \
             --target-dir build
-          ninja -C src/out/build clang_arm64/gen_snapshot
+          ninja -C src/out/build clang_x64/gen_snapshot
 
       - uses: actions/upload-artifact@v4
         with:
           name: tizen-${{ matrix.arch }}-${{ matrix.mode }}_darwin-x64
-          path: src/out/build/clang_arm64/gen_snapshot
+          path: src/out/build/clang_x64/gen_snapshot
           if-no-files-found: error
 
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
           if-no-files-found: error
 
   macos-build:
-    runs-on: macos-latest-large
+    runs-on: macos-13
 
     strategy:
       matrix:


### PR DESCRIPTION
macos-latest has been changed to macOS14 arm64.
~~It should also be changed to macos-latest-large to support operation on intel chips for existing compatibility.~~
https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/running-jobs-on-larger-runners?platform=mac#available-macos-larger-runners

+) The large runner need to cost. we are not ready for this task at the moment, so we use the macos-13 runner version.

This patch reverts [b95ef479](https://github.com/flutter-tizen/engine/commit/b95ef4797ed04386a814d46a3f361386d1fc32a6) that was added in the update for 3.27.1.

